### PR TITLE
chore: add PR template + Renovate platformAutomerge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## What changed
+
+<!-- Brief description of the change -->
+
+## Why
+
+<!-- Link to issue, requirement, or context -->
+
+## Checklist
+
+- [ ] `mise run ci` passes locally
+- [ ] Docs updated (if applicable)
+- [ ] Tested on server (if infra change)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "docker:enableMajor"],
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchManagers": ["docker-compose"],

--- a/stacks/observability/provisioning/alerting/rules.yaml
+++ b/stacks/observability/provisioning/alerting/rules.yaml
@@ -79,7 +79,9 @@ groups:
               to: 0
             datasourceUid: "PBFA97CFB590B2093"
             model:
-              expr: 1 - (node_filesystem_avail_bytes{mountpoint="/",job="node"} / node_filesystem_size_bytes{mountpoint="/",job="node"})
+              expr: >-
+                1 - (node_filesystem_avail_bytes{mountpoint="/",job="node"}
+                / node_filesystem_size_bytes{mountpoint="/",job="node"})
               instant: true
               refId: A
           - refId: C


### PR DESCRIPTION
## What changed

- Added lightweight PR template with checklist
- Enabled `platformAutomerge` in Renovate so minor/patch Docker updates auto-merge via GitHub's native automerge (requires CI to pass first)

## Why

Tightening repo with standard solo-dev best practices: required PRs, CI checks, clean squash-merge history.

## Also configured (via API, not in this diff)

- **Branch protection on `main`**: require `check` job to pass, no direct pushes
- **Squash merge only**: clean linear history
- **Auto-delete branches**: after merge
- **Strict status checks**: branch must be up-to-date with main