### PR TITLE
fix: use Copilot API with GPT-5.4 and high reasoning

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Review with AI
         env:
-          GITHUB_MODELS_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
         run: bash scripts/review-pr.sh
 
       - name: Post review

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -26,7 +26,7 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
-        run: echo "sha=$(gh api repos/$REPO/pulls/$PR_NUMBER --jq '.head.sha')" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
         with:

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2016  # $model, $system etc. are jq variables, not shell
-# Call GitHub Models API to review a PR diff.
+# Call GitHub Copilot API to review a PR diff.
 # Reads: /tmp/pr_title.txt, /tmp/pr_body.txt, /tmp/pr_diff_truncated.txt
 # Outputs: /tmp/review.txt
 #
-# Required env: GITHUB_MODELS_TOKEN
-# Optional env: MODEL (default: openai/gpt-4.1), REASONING_EFFORT (only for gpt-5 models)
+# Required env: COPILOT_TOKEN
+# Optional env: MODEL (default: gpt-5.4), REASONING_EFFORT (default: high)
 set -euo pipefail
 
-MODEL="${MODEL:-openai/gpt-4.1}"
-REASONING_EFFORT="${REASONING_EFFORT:-}"
+MODEL="${MODEL:-gpt-5.4}"
+REASONING_EFFORT="${REASONING_EFFORT:-high}"
 
 SYSTEM_PROMPT=$(cat <<'EOF'
 You are a senior engineer reviewing a pull request. Review the diff for:
@@ -39,41 +39,28 @@ DIFF=$(cat /tmp/pr_diff_truncated.txt)
 USER_CONTENT=$(printf "## PR: %s\n\n%s\n\n## Diff\n\n%s" "$PR_TITLE" "$PR_BODY" "$DIFF")
 
 # Build request JSON safely via jq
-JQ_ARGS=(
-  --arg model "$MODEL"
-  --arg system "$SYSTEM_PROMPT"
-  --arg user "$USER_CONTENT"
-)
-JQ_FILTER='{
-  model: $model,
-  messages: [
-    { role: "system", content: $system },
-    { role: "user", content: $user }
-  ]
-}'
-
-if [ -n "$REASONING_EFFORT" ]; then
-  JQ_ARGS+=(--arg effort "$REASONING_EFFORT")
-  JQ_FILTER='{
+jq -n \
+  --arg model "$MODEL" \
+  --arg effort "$REASONING_EFFORT" \
+  --arg system "$SYSTEM_PROMPT" \
+  --arg user "$USER_CONTENT" \
+  '{
     model: $model,
     reasoning: { effort: $effort },
     messages: [
       { role: "system", content: $system },
       { role: "user", content: $user }
     ]
-  }'
-fi
+  }' > /tmp/request.json
 
-jq -n "${JQ_ARGS[@]}" "$JQ_FILTER" > /tmp/request.json
-
-LABEL="${MODEL}"
-[ -n "$REASONING_EFFORT" ] && LABEL="${MODEL} (reasoning: ${REASONING_EFFORT})"
-echo "Calling ${LABEL}..."
+echo "Calling ${MODEL} (reasoning: ${REASONING_EFFORT})..."
 
 RESPONSE=$(curl -sS --fail-with-body \
-  -X POST "https://models.github.ai/inference/chat/completions" \
-  -H "Authorization: Bearer ${GITHUB_MODELS_TOKEN}" \
+  -X POST "https://api.githubcopilot.com/chat/completions" \
+  -H "Authorization: Bearer ${COPILOT_TOKEN}" \
   -H "Content-Type: application/json" \
+  -H "Copilot-Integration-Id: vscode-chat" \
+  -H "Editor-Version: vscode/1.100.0" \
   -d @/tmp/request.json)
 
 echo "$RESPONSE" | jq -r '.choices[0].message.content' > /tmp/review.txt

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -55,13 +55,21 @@ jq -n \
 
 echo "Calling ${MODEL} (reasoning: ${REASONING_EFFORT})..."
 
-RESPONSE=$(curl -sS --fail-with-body \
+HTTP_CODE=$(curl -sS -w "%{http_code}" -o /tmp/response.json \
   -X POST "https://api.githubcopilot.com/chat/completions" \
   -H "Authorization: Bearer ${COPILOT_TOKEN}" \
   -H "Content-Type: application/json" \
   -H "Copilot-Integration-Id: vscode-chat" \
   -H "Editor-Version: vscode/1.100.0" \
   -d @/tmp/request.json)
+
+if [ "$HTTP_CODE" -ge 400 ]; then
+  echo "::error::API returned HTTP ${HTTP_CODE}"
+  cat /tmp/response.json >&2
+  exit 1
+fi
+
+RESPONSE=$(cat /tmp/response.json)
 
 echo "$RESPONSE" | jq -r '.choices[0].message.content' > /tmp/review.txt
 


### PR DESCRIPTION
## What changed
- Switched from GitHub Models API to Copilot API (`api.githubcopilot.com`)
- Default model: `gpt-5.4` with `high` reasoning
- GitHub Models catalog doesn't have GPT-5.4; Copilot API does via subscription

## Why
GPT-5.4 isn't available in the GitHub Models catalog. The Copilot API has it and works with the existing `COPILOT_GITHUB_TOKEN` secret.