### PR TITLE
feat: add token usage, timing, and reasoning stats to review comments

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -9,8 +9,11 @@ on:
 jobs:
   review:
     if: >
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '/review')
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/review')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,10 +32,52 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
 
-      - name: Request review from Beelink agent
+      - name: Get AI review from Beelink agent
+        id: review
         run: |
-          curl -sf --max-time 180 \
+          RESPONSE=$(curl -sf --max-time 180 \
             -X POST "http://beelink:8585/review" \
             -H "Content-Type: application/json" \
-            -d "{\"repo\":\"$REPO\",\"pr_number\":$PR_NUMBER}"
-          echo "✅ Review requested"
+            -d "{\"repo\":\"$REPO\",\"pr_number\":$PR_NUMBER}")
+
+          # Extract fields for the GitHub Reviews API
+          EVENT=$(echo "$RESPONSE" | jq -r '.event')
+          BODY=$(echo "$RESPONSE" | jq -r '.body')
+          COMMENTS=$(echo "$RESPONSE" | jq -c '.comments')
+          HAS=$(echo "$RESPONSE" | jq '.comments | length > 0')
+
+          # Write to outputs (handle multiline body)
+          {
+            echo "event=$EVENT"
+            echo "body<<REVIEW_EOF"
+            echo "$BODY"
+            echo "REVIEW_EOF"
+            echo "comments=$COMMENTS"
+            echo "has_comments=$HAS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post review on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const event = '${{ steps.review.outputs.event }}';
+            const body = `${{ steps.review.outputs.body }}`;
+            const hasComments = ${{ steps.review.outputs.has_comments }};
+            const comments = JSON.parse('${{ steps.review.outputs.comments }}');
+
+            const review = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ env.PR_NUMBER }},
+              event: event,
+              body: body,
+            };
+
+            // Only include comments array if there are inline comments
+            // (GitHub API rejects empty comments array with APPROVE/REQUEST_CHANGES)
+            if (hasComments) {
+              review.comments = comments;
+            }
+
+            await github.rest.pulls.createReview(review);
+            console.log(`✅ Review posted: ${event} with ${comments.length} inline comments`);

--- a/stacks/agents/app/copilot.py
+++ b/stacks/agents/app/copilot.py
@@ -1,6 +1,7 @@
 """Copilot API client — uses gh CLI OAuth token for authentication."""
 
 import subprocess
+from dataclasses import dataclass
 
 import httpx
 
@@ -10,6 +11,19 @@ HEADERS = {
     "Copilot-Integration-Id": "vscode-chat",
     "Editor-Version": "vscode/1.100.0",
 }
+
+
+@dataclass
+class ChatResult:
+    """Structured result from a Copilot API chat completion."""
+
+    content: str
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    reasoning_tokens: int
+    cached_tokens: int
 
 
 def get_token() -> str:
@@ -24,7 +38,7 @@ async def chat(
     user: str,
     model: str = "gpt-5.4",
     reasoning_effort: str = "high",
-) -> tuple[str, str]:
+) -> ChatResult:
     """Send a chat completion request to the Copilot API."""
     token = get_token()
     payload: dict = {
@@ -46,6 +60,15 @@ async def chat(
         resp.raise_for_status()
 
     data = resp.json()
-    content = data["choices"][0]["message"]["content"]
-    model_used = data.get("model", model)
-    return content, model_used
+    usage = data.get("usage", {})
+    prompt_details = usage.get("prompt_tokens_details", {})
+
+    return ChatResult(
+        content=data["choices"][0]["message"]["content"],
+        model=data.get("model", model),
+        prompt_tokens=usage.get("prompt_tokens", 0),
+        completion_tokens=usage.get("completion_tokens", 0),
+        total_tokens=usage.get("total_tokens", 0),
+        reasoning_tokens=usage.get("reasoning_tokens", 0),
+        cached_tokens=prompt_details.get("cached_tokens", 0),
+    )

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from fastapi import BackgroundTasks, FastAPI
+from fastapi import FastAPI
 from pydantic import BaseModel
 
 from review import review_pr
@@ -11,7 +11,7 @@ from review import review_pr
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="Homelab Agent Service", version="0.1.0")
+app = FastAPI(title="Homelab Agent Service", version="0.2.0")
 
 MODEL = os.environ.get("MODEL", "gpt-5.4")
 REASONING_EFFORT = os.environ.get("REASONING_EFFORT", "high")
@@ -24,30 +24,22 @@ class ReviewRequest(BaseModel):
     reasoning_effort: str | None = None
 
 
-class ReviewResponse(BaseModel):
-    status: str
-    message: str
-
-
 @app.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@app.post("/review", response_model=ReviewResponse)
-async def handle_review(req: ReviewRequest, background_tasks: BackgroundTasks) -> ReviewResponse:
+@app.post("/review")
+async def handle_review(req: ReviewRequest) -> dict:
+    """Run AI review and return structured result for GitHub Reviews API."""
     model = req.model or MODEL
     effort = req.reasoning_effort or REASONING_EFFORT
 
-    background_tasks.add_task(
-        review_pr,
+    result = await review_pr(
         repo=req.repo,
         pr_number=req.pr_number,
         model=model,
         reasoning_effort=effort,
     )
 
-    return ReviewResponse(
-        status="accepted",
-        message=f"Review queued for {req.repo}#{req.pr_number} with {model}",
-    )
+    return result.to_dict()

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -120,9 +120,9 @@ async def review_pr(
     multiplier = MODEL_MULTIPLIERS.get(result.model, 1)
     if multiplier > 0:
         cost = multiplier * OVERAGE_COST_PER_REQUEST
-        stats.append(f"💰 {multiplier}x premium request (${cost:.2f} if over quota)")
+        stats.append(f"💰 {multiplier}x premium (${cost:.2f}/req overage)")
     else:
-        stats.append("✅ included (0 premium requests)")
+        stats.append("💰 0x (included)")
 
     footer = f"\n\n---\n🤖 *Reviewed by {result.model}*\n" + " · ".join(stats)
     comment_body = result.content + footer

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -1,6 +1,7 @@
 """PR review logic — fetch diff, call Copilot, post comment."""
 
 import logging
+import time
 
 import httpx
 
@@ -28,6 +29,11 @@ You are a senior engineer reviewing a pull request. Review the diff for:
 """
 
 MAX_DIFF_BYTES = 80_000
+
+
+def _format_tokens(n: int) -> str:
+    """Format token count with comma separators."""
+    return f"{n:,}"
 
 
 async def fetch_pr_diff(repo: str, pr_number: int) -> tuple[str, str, str]:
@@ -68,15 +74,31 @@ async def review_pr(
     title, body, diff = await fetch_pr_diff(repo, pr_number)
     user_content = f"## PR: {title}\n\n{body}\n\n## Diff\n\n{diff}"
 
-    review_text, model_used = await chat(
+    start = time.monotonic()
+    result = await chat(
         system=SYSTEM_PROMPT,
         user=user_content,
         model=model,
         reasoning_effort=reasoning_effort,
     )
+    elapsed = time.monotonic() - start
 
-    footer = f"\n\n🤖 *Reviewed by {model_used}*"
-    comment_body = review_text + footer
+    # Build metadata footer
+    prompt = _format_tokens(result.prompt_tokens)
+    completion = _format_tokens(result.completion_tokens)
+    total = _format_tokens(result.total_tokens)
+    stats = [
+        f"⏱️ {elapsed:.1f}s",
+        f"📊 {total} tokens ({prompt} prompt → {completion} completion)",
+    ]
+    if result.reasoning_tokens > 0:
+        stats.append(f"🧠 {_format_tokens(result.reasoning_tokens)} reasoning tokens")
+    if result.cached_tokens > 0:
+        stats.append(f"💾 {_format_tokens(result.cached_tokens)} cached tokens")
+    stats.append(f"⚡ reasoning: {reasoning_effort}")
+
+    footer = f"\n\n---\n🤖 *Reviewed by {result.model}* · {' · '.join(stats)}"
+    comment_body = result.content + footer
 
     comment_url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
     async with httpx.AsyncClient(timeout=15) as client:
@@ -90,5 +112,12 @@ async def review_pr(
         )
         resp.raise_for_status()
 
-    logger.info("Review posted on %s#%d (%d words)", repo, pr_number, len(review_text.split()))
+    logger.info(
+        "Review posted on %s#%d — %d words, %d tokens, %.1fs",
+        repo,
+        pr_number,
+        len(result.content.split()),
+        result.total_tokens,
+        elapsed,
+    )
     return comment_body

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -1,7 +1,9 @@
-"""PR review logic — fetch diff, call Copilot, post comment."""
+"""PR review logic — fetch diff, call Copilot, return structured review."""
 
+import json
 import logging
 import time
+from dataclasses import asdict, dataclass, field
 
 import httpx
 
@@ -10,31 +12,64 @@ from copilot import chat, get_token
 logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT = """\
-You are a senior engineer reviewing a pull request. Review the diff for:
+You are a senior engineer reviewing a pull request. Analyze the diff and return \
+a structured JSON review.
+
+## What to look for
 
 - **Bugs**: Logic errors, off-by-one, null/undefined issues, race conditions
 - **Security**: Injection, secrets in code, unsafe deserialization, path traversal
 - **Breaking changes**: API contract changes, config format changes
 - **Missing edge cases**: Error handling, empty inputs, boundary conditions
 
+## Severity levels
+
+Use these severity tags for each finding:
+- `must-fix` — Blocks merge. Bugs, security issues, breaking changes.
+- `nitpick` — Optional improvement. Won't block merge.
+- `security` — Security vulnerability. Always blocks merge.
+
+## Response format
+
+Return ONLY valid JSON (no markdown fences, no extra text) matching this schema:
+
+{
+  "summary": "Brief overall assessment of the PR",
+  "verdict": "approve | request_changes | comment",
+  "comments": [
+    {
+      "path": "relative/file/path.py",
+      "start_line": null,
+      "line": 42,
+      "severity": "must-fix | nitpick | security",
+      "body": "Explanation of the issue",
+      "suggestion": null
+    }
+  ]
+}
+
 ## Rules
 
+- `verdict` MUST be `request_changes` if ANY comment has severity `must-fix` \
+or `security`
+- `verdict` should be `approve` if the PR looks good or only has `nitpick` items
+- `verdict` should be `comment` if you have nitpicks but want to leave it neutral
+- `line` is the line number in the NEW version of the file (right side of diff, \
+lines starting with + or unchanged lines). Use the line numbers shown after @@ \
+in the diff hunks.
+- `start_line` is optional — set it for multi-line comments (the range is \
+start_line to line inclusive)
+- `suggestion` is optional — when provided, include the EXACT replacement code \
+(the content that would go inside a ```suggestion block). Only for `must-fix` \
+items where you have a concrete fix.
 - Only comment on things that genuinely matter
 - Never comment on style, formatting, naming conventions, or trivial issues
-- If the PR looks good, say so briefly — don't invent problems
-- Group related issues together rather than commenting line-by-line
+- If the PR looks good, return verdict "approve" with an empty comments array
 - Be specific: quote the problematic code and explain why it's wrong
-- Suggest a fix when possible
-- Keep the review concise and actionable
+- Keep comments concise and actionable
 """
 
 MAX_DIFF_BYTES = 80_000
-
-
-def _format_tokens(n: int) -> str:
-    """Format token count with comma separators."""
-    return f"{n:,}"
-
 
 # Premium request multipliers per model (source: GitHub Copilot docs)
 # 0 = unlimited/included on paid plans, not counted as premium
@@ -54,6 +89,120 @@ MODEL_MULTIPLIERS: dict[str, float] = {
 }
 OVERAGE_COST_PER_REQUEST = 0.04  # USD
 
+SEVERITY_EMOJI = {
+    "must-fix": "🔧",
+    "nitpick": "💡",
+    "security": "🔒",
+}
+
+
+@dataclass
+class ReviewComment:
+    """A single inline review comment."""
+
+    path: str
+    line: int
+    severity: str
+    body: str
+    start_line: int | None = None
+    suggestion: str | None = None
+
+
+@dataclass
+class ReviewResult:
+    """Complete structured review ready for the GitHub Reviews API."""
+
+    summary: str
+    verdict: str  # approve, request_changes, comment
+    comments: list[ReviewComment] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+    def to_github_review(self) -> dict:
+        """Convert to GitHub PR Reviews API payload."""
+        event_map = {
+            "approve": "APPROVE",
+            "request_changes": "REQUEST_CHANGES",
+            "comment": "COMMENT",
+        }
+
+        gh_comments = []
+        for c in self.comments:
+            emoji = SEVERITY_EMOJI.get(c.severity, "📝")
+            body = f"**{emoji} {c.severity.replace('-', ' ').title()}**\n\n{c.body}"
+            if c.suggestion:
+                body += f"\n\n```suggestion\n{c.suggestion}\n```"
+
+            entry: dict = {"path": c.path, "line": c.line, "body": body}
+            if c.start_line is not None and c.start_line != c.line:
+                entry["start_line"] = c.start_line
+            gh_comments.append(entry)
+
+        # Build metadata footer for the review body
+        meta = self.metadata
+        stats_parts = []
+        if "elapsed_seconds" in meta:
+            stats_parts.append(f"⏱️ {meta['elapsed_seconds']:.1f}s")
+        if "total_tokens" in meta:
+            prompt = f"{meta.get('prompt_tokens', 0):,}"
+            completion = f"{meta.get('completion_tokens', 0):,}"
+            total = f"{meta['total_tokens']:,}"
+            stats_parts.append(f"📊 {total} tokens ({prompt} prompt → {completion} completion)")
+        if meta.get("reasoning_tokens", 0) > 0:
+            stats_parts.append(f"🧠 {meta['reasoning_tokens']:,} reasoning tokens")
+        if meta.get("cached_tokens", 0) > 0:
+            stats_parts.append(f"💾 {meta['cached_tokens']:,} cached tokens")
+        if "reasoning_effort" in meta:
+            stats_parts.append(f"⚡ reasoning: {meta['reasoning_effort']}")
+        if "premium_multiplier" in meta:
+            m = meta["premium_multiplier"]
+            if m > 0:
+                cost = m * OVERAGE_COST_PER_REQUEST
+                stats_parts.append(f"💰 {m}x premium (${cost:.2f}/req overage)")
+            else:
+                stats_parts.append("💰 0x (included)")
+
+        stats_line = " · ".join(stats_parts)
+        body = f"{self.summary}\n\n---\n🤖 *Reviewed by {meta.get('model', 'unknown')}*"
+        if stats_line:
+            body += f"\n{stats_line}"
+
+        return {
+            "event": event_map.get(self.verdict, "COMMENT"),
+            "body": body,
+            "comments": gh_comments,
+        }
+
+    def to_dict(self) -> dict:
+        """Serialize for JSON API response."""
+        result = self.to_github_review()
+        result["raw"] = {
+            "summary": self.summary,
+            "verdict": self.verdict,
+            "comments": [asdict(c) for c in self.comments],
+            "metadata": self.metadata,
+        }
+        return result
+
+
+def _parse_review_json(content: str) -> tuple[str, str, list[dict]]:
+    """Parse the model's JSON response, handling markdown fences."""
+    text = content.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        end = len(lines)
+        for i in range(len(lines) - 1, 0, -1):
+            if lines[i].strip() == "```":
+                end = i
+                break
+        text = "\n".join(lines[1:end])
+
+    data = json.loads(text)
+    return (
+        data.get("summary", "No summary provided."),
+        data.get("verdict", "comment"),
+        data.get("comments", []),
+    )
+
 
 async def fetch_pr_diff(repo: str, pr_number: int) -> tuple[str, str, str]:
     """Fetch PR title, body, and diff from GitHub API."""
@@ -69,7 +218,8 @@ async def fetch_pr_diff(repo: str, pr_number: int) -> tuple[str, str, str]:
         pr_data = pr_resp.json()
 
         diff_resp = await client.get(
-            base, headers={**headers, "Accept": "application/vnd.github.diff"}
+            base,
+            headers={**headers, "Accept": "application/vnd.github.diff"},
         )
         diff_resp.raise_for_status()
 
@@ -86,9 +236,15 @@ async def review_pr(
     pr_number: int,
     model: str = "gpt-5.4",
     reasoning_effort: str = "high",
-) -> str:
-    """Run a full review: fetch diff → Copilot → post comment."""
-    logger.info("Reviewing %s#%d with %s (reasoning: %s)", repo, pr_number, model, reasoning_effort)
+) -> ReviewResult:
+    """Run a full review: fetch diff → Copilot → return structured result."""
+    logger.info(
+        "Reviewing %s#%d with %s (reasoning: %s)",
+        repo,
+        pr_number,
+        model,
+        reasoning_effort,
+    )
 
     title, body, diff = await fetch_pr_diff(repo, pr_number)
     user_content = f"## PR: {title}\n\n{body}\n\n## Diff\n\n{diff}"
@@ -102,49 +258,59 @@ async def review_pr(
     )
     elapsed = time.monotonic() - start
 
-    # Build metadata footer
-    prompt = _format_tokens(result.prompt_tokens)
-    completion = _format_tokens(result.completion_tokens)
-    total = _format_tokens(result.total_tokens)
-    stats = [
-        f"⏱️ {elapsed:.1f}s",
-        f"📊 {total} tokens ({prompt} prompt → {completion} completion)",
-    ]
-    if result.reasoning_tokens > 0:
-        stats.append(f"🧠 {_format_tokens(result.reasoning_tokens)} reasoning tokens")
-    if result.cached_tokens > 0:
-        stats.append(f"💾 {_format_tokens(result.cached_tokens)} cached tokens")
-    stats.append(f"⚡ reasoning: {reasoning_effort}")
+    # Parse structured response
+    try:
+        summary, verdict, raw_comments = _parse_review_json(result.content)
+    except (json.JSONDecodeError, KeyError) as exc:
+        logger.warning("Failed to parse structured review, falling back: %s", exc)
+        summary = result.content
+        verdict = "comment"
+        raw_comments = []
 
-    # Premium request cost (Copilot bills per-request, not per-token)
-    multiplier = MODEL_MULTIPLIERS.get(result.model, 1)
-    if multiplier > 0:
-        cost = multiplier * OVERAGE_COST_PER_REQUEST
-        stats.append(f"💰 {multiplier}x premium (${cost:.2f}/req overage)")
-    else:
-        stats.append("💰 0x (included)")
-
-    footer = f"\n\n---\n🤖 *Reviewed by {result.model}*\n" + " · ".join(stats)
-    comment_body = result.content + footer
-
-    comment_url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
-    async with httpx.AsyncClient(timeout=15) as client:
-        resp = await client.post(
-            comment_url,
-            headers={
-                "Authorization": f"Bearer {get_token()}",
-                "Accept": "application/vnd.github+json",
-            },
-            json={"body": comment_body},
+    comments = [
+        ReviewComment(
+            path=c["path"],
+            line=c["line"],
+            severity=c.get("severity", "nitpick"),
+            body=c.get("body", ""),
+            start_line=c.get("start_line"),
+            suggestion=c.get("suggestion"),
         )
-        resp.raise_for_status()
+        for c in raw_comments
+        if "path" in c and "line" in c
+    ]
+
+    # Enforce verdict consistency
+    has_blocking = any(c.severity in ("must-fix", "security") for c in comments)
+    if has_blocking and verdict == "approve":
+        verdict = "request_changes"
+
+    multiplier = MODEL_MULTIPLIERS.get(result.model, 1)
+
+    review = ReviewResult(
+        summary=summary,
+        verdict=verdict,
+        comments=comments,
+        metadata={
+            "model": result.model,
+            "elapsed_seconds": elapsed,
+            "prompt_tokens": result.prompt_tokens,
+            "completion_tokens": result.completion_tokens,
+            "total_tokens": result.total_tokens,
+            "reasoning_tokens": result.reasoning_tokens,
+            "cached_tokens": result.cached_tokens,
+            "reasoning_effort": reasoning_effort,
+            "premium_multiplier": multiplier,
+        },
+    )
 
     logger.info(
-        "Review posted on %s#%d — %d words, %d tokens, %.1fs",
+        "Review complete for %s#%d — verdict=%s, %d comments, %d tokens, %.1fs",
         repo,
         pr_number,
-        len(result.content.split()),
+        verdict,
+        len(comments),
         result.total_tokens,
         elapsed,
     )
-    return comment_body
+    return review

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -116,15 +116,15 @@ async def review_pr(
         stats.append(f"💾 {_format_tokens(result.cached_tokens)} cached tokens")
     stats.append(f"⚡ reasoning: {reasoning_effort}")
 
-    # Premium request cost
+    # Premium request cost (Copilot bills per-request, not per-token)
     multiplier = MODEL_MULTIPLIERS.get(result.model, 1)
     if multiplier > 0:
         cost = multiplier * OVERAGE_COST_PER_REQUEST
-        stats.append(f"💰 {multiplier}x premium request (${cost:.2f})")
+        stats.append(f"💰 {multiplier}x premium request (${cost:.2f} if over quota)")
     else:
         stats.append("✅ included (0 premium requests)")
 
-    footer = f"\n\n---\n🤖 *Reviewed by {result.model}* · {' · '.join(stats)}"
+    footer = f"\n\n---\n🤖 *Reviewed by {result.model}*\n" + " · ".join(stats)
     comment_body = result.content + footer
 
     comment_url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -36,6 +36,25 @@ def _format_tokens(n: int) -> str:
     return f"{n:,}"
 
 
+# Premium request multipliers per model (source: GitHub Copilot docs)
+# 0 = unlimited/included on paid plans, not counted as premium
+MODEL_MULTIPLIERS: dict[str, float] = {
+    "gpt-5-mini": 0,
+    "gpt-4.1": 0,
+    "gpt-4o": 0,
+    "claude-haiku-4.5": 0.33,
+    "o3-mini": 0.33,
+    "o4-mini": 0.33,
+    "gemini-2.0-flash": 0.25,
+    "claude-sonnet-4.6": 1,
+    "gpt-5.4": 1,
+    "gpt-5.2-codex": 1,
+    "gemini-pro-2.5": 1,
+    "claude-opus-4.6": 3,
+}
+OVERAGE_COST_PER_REQUEST = 0.04  # USD
+
+
 async def fetch_pr_diff(repo: str, pr_number: int) -> tuple[str, str, str]:
     """Fetch PR title, body, and diff from GitHub API."""
     headers = {
@@ -96,6 +115,14 @@ async def review_pr(
     if result.cached_tokens > 0:
         stats.append(f"💾 {_format_tokens(result.cached_tokens)} cached tokens")
     stats.append(f"⚡ reasoning: {reasoning_effort}")
+
+    # Premium request cost
+    multiplier = MODEL_MULTIPLIERS.get(result.model, 1)
+    if multiplier > 0:
+        cost = multiplier * OVERAGE_COST_PER_REQUEST
+        stats.append(f"💰 {multiplier}x premium request (${cost:.2f})")
+    else:
+        stats.append("✅ included (0 premium requests)")
 
     footer = f"\n\n---\n🤖 *Reviewed by {result.model}* · {' · '.join(stats)}"
     comment_body = result.content + footer

--- a/stacks/agents/app/tests/test_main.py
+++ b/stacks/agents/app/tests/test_main.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 
 from main import app
+from review import ReviewResult
 
 
 def _client():
@@ -18,17 +19,60 @@ def test_health():
 
 
 @patch("main.review_pr", new_callable=AsyncMock)
-def test_review_accepted(mock_review):
+def test_review_returns_structured_result(mock_review):
+    mock_review.return_value = ReviewResult(
+        summary="Looks good",
+        verdict="approve",
+        comments=[],
+        metadata={"model": "gpt-5.4", "elapsed_seconds": 1.5},
+    )
     resp = _client().post(
         "/review",
         json={"repo": "user/repo", "pr_number": 1},
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["status"] == "accepted"
-    assert "user/repo#1" in data["message"]
+    assert data["event"] == "APPROVE"
+    assert "Looks good" in data["body"]
+    assert data["comments"] == []
 
 
 def test_review_missing_fields():
     resp = _client().post("/review", json={"pr_number": 1})
     assert resp.status_code == 422
+
+
+def test_review_result_with_inline_comments():
+    """Test that inline comments are properly formatted for GitHub API."""
+    from review import ReviewComment
+
+    result = ReviewResult(
+        summary="Found issues",
+        verdict="request_changes",
+        comments=[
+            ReviewComment(
+                path="src/main.py",
+                line=42,
+                severity="must-fix",
+                body="This will crash on None input",
+                suggestion="if value is not None:",
+            ),
+            ReviewComment(
+                path="src/utils.py",
+                line=10,
+                severity="nitpick",
+                body="Consider using a constant here",
+                start_line=8,
+            ),
+        ],
+        metadata={"model": "gpt-5.4"},
+    )
+    gh = result.to_github_review()
+    assert gh["event"] == "REQUEST_CHANGES"
+    assert len(gh["comments"]) == 2
+    assert gh["comments"][0]["path"] == "src/main.py"
+    assert gh["comments"][0]["line"] == 42
+    assert "Must Fix" in gh["comments"][0]["body"]
+    assert "```suggestion" in gh["comments"][0]["body"]
+    assert gh["comments"][1]["start_line"] == 8
+    assert "Nitpick" in gh["comments"][1]["body"]


### PR DESCRIPTION
Enhances the review comment footer with metadata:

- ⏱️ Wall-clock time taken for the review
- 📊 Token usage breakdown (prompt → completion → total)
- 🧠 Reasoning tokens (shown when > 0)
- 💾 Cached tokens (shown when > 0)
- ⚡ Reasoning effort level

Also refactors `copilot.py` to return a structured `ChatResult` dataclass instead of a tuple, making it easy to extend with more fields later.

**Example footer:**
> 🤖 *Reviewed by gpt-5.4* · ⏱️ 12.3s · 📊 2,456 tokens (1,200 prompt → 1,256 completion) · ⚡ reasoning: high