### PR TITLE
docs: add context comment to MAX_DIFF_BYTES

### DIFF
--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -51,7 +51,7 @@ Use sparingly — only for things that are objectively wrong.
 - If the PR looks good, return verdict `approve` with an empty comments array
 """
 
-MAX_DIFF_BYTES = 80_000
+MAX_DIFF_BYTES = 80_000  # ~80KB cap to stay within model context limits
 
 # Premium request multipliers per model (source: GitHub Copilot docs)
 MODEL_MULTIPLIERS: dict[str, float] = {


### PR DESCRIPTION
Trivial comment. Testing the `opened` trigger for the review bot with strict json_schema structured output.