### PR TITLE
fix: improve review skill to reduce review cycles

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -18,6 +18,13 @@ Review for:
 - **Breaking changes** — API contract changes, config renames, removed features
 - **Operational risk** — resource leaks, missing healthchecks, unbounded growth
 
+## Review Approach
+
+- **Trace the full flow.** Don't just read the diff line-by-line. Follow data through the system — if a function is changed, check every caller. If a status value is added, check every consumer.
+- **Think about implications.** If you recommend "this should raise instead of log", also flag what happens to callers when it raises. Don't create a fix that introduces a new bug.
+- **Batch related findings.** If you find the same class of issue in multiple places, group them and say "this pattern appears in X, Y, and Z — fix all of them." Don't report them one at a time across review rounds.
+- **Front-load everything.** Aim for one review round, not five. Surface all issues — including second-order effects of your own recommendations — in a single pass.
+
 ## Severity Levels
 
 - 🚫 **Blocker** — must fix before merge (bugs, security, breaking changes)

--- a/.github/skills/implement/SKILL.md
+++ b/.github/skills/implement/SKILL.md
@@ -33,6 +33,16 @@ You are implementing a GitHub issue. The issue details are provided in the promp
 - Prefer modifying existing tests over creating new test files
 - If you add a new module, add a corresponding test file
 
+## The Review Cycle
+
+After you finish, an automated review bot will review your changes. It checks for bugs, security issues, breaking changes, and operational risk. Each review round costs time and tokens — **aim for zero blockers on the first review.**
+
+Before finishing your work, self-review against these questions:
+- **Error handling:** Do all external calls (HTTP, subprocess, filesystem) handle failures? If something raises, do callers handle it? Trace each new error path to the top.
+- **Security:** Are credentials kept out of logs, error messages, and command args? Are untrusted inputs validated?
+- **Consistency:** If you added a new status value, enum, or pattern, is it handled everywhere it's consumed (including workflows, polling loops, API responses)?
+- **Cascading effects:** If you changed a function signature or return value, did you update every caller?
+
 ## Responding to Review Feedback
 
 When fixing issues raised by the review bot (or any reviewer):

--- a/stacks/agents/app/github.py
+++ b/stacks/agents/app/github.py
@@ -183,12 +183,13 @@ async def get_unresolved_threads(repo: str, pr_number: int) -> str:
             path = t.get("path", "?")
             line = t.get("line") or "?"
             thread_id = t["id"]
-            # Include all comments in the thread for full context
+            # Only include bot-authored comments to prevent prompt injection
+            # from untrusted PR participants replying in review threads
+            bot_comments = [c for c in comments if c.get("author", {}).get("login") == login]
             thread_lines = [f"- **{path}:{line}** (thread {thread_id})"]
-            for comment in comments:
-                author = comment.get("author", {}).get("login", "unknown")
+            for comment in bot_comments:
                 body = comment.get("body", "").strip()
-                thread_lines.append(f"  **{author}:** {body}")
+                thread_lines.append(f"  {body}")
             lines.append("\n".join(thread_lines))
 
         return "\n".join(lines)

--- a/stacks/agents/app/github.py
+++ b/stacks/agents/app/github.py
@@ -182,9 +182,14 @@ async def get_unresolved_threads(repo: str, pr_number: int) -> str:
 
             path = t.get("path", "?")
             line = t.get("line") or "?"
-            body = first.get("body", "").strip()
             thread_id = t["id"]
-            lines.append(f"- **{path}:{line}** (thread {thread_id}) — {body}")
+            # Include all comments in the thread for full context
+            thread_lines = [f"- **{path}:{line}** (thread {thread_id})"]
+            for comment in comments:
+                author = comment.get("author", {}).get("login", "unknown")
+                body = comment.get("body", "").strip()
+                thread_lines.append(f"  **{author}:** {body}")
+            lines.append("\n".join(thread_lines))
 
         return "\n".join(lines)
 

--- a/stacks/agents/app/implement.py
+++ b/stacks/agents/app/implement.py
@@ -79,12 +79,13 @@ async def implement_issue(
             body=issue.get("body") or "(no description)",
         )
 
+        # Agent gets NO GitHub API access — it only edits local files.
+        # The orchestrator handles all git/GitHub operations with the App token.
         result = await run_copilot(
             worktree_path,
             prompt,
             model=model,
             effort=reasoning_effort,
-            gh_token=token,
         )
 
         sha = await commit_and_push(
@@ -170,12 +171,12 @@ async def fix_pr(
             threads=threads,
         )
 
+        # Agent gets NO GitHub API access — it only edits local files.
         result = await run_copilot(
             worktree_path,
             prompt,
             model=model,
             effort=reasoning_effort,
-            gh_token=token,
         )
 
         sha = await commit_and_push(

--- a/stacks/agents/app/implement.py
+++ b/stacks/agents/app/implement.py
@@ -35,6 +35,12 @@ Use the implement skill for guidelines on how to make changes.
 FIX_PROMPT_TEMPLATE = """\
 Fix the review feedback on PR #{pr_number} in {repo}.
 
+## PR Description
+
+{pr_body}
+
+## Review Findings
+
 The review bot found the following issues that need to be addressed:
 
 {threads}
@@ -168,6 +174,7 @@ async def fix_pr(
         prompt = FIX_PROMPT_TEMPLATE.format(
             repo=repo,
             pr_number=pr_number,
+            pr_body=pr_data.get("body") or "(no description)",
             threads=threads,
         )
 

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -49,7 +49,7 @@ class TestImplementIssue:
 class TestFixPR:
     def test_fixes_review_feedback(self):
         mock_cli_result = CLIResult(output="fixed", total_premium_requests=1)
-        mock_pr_data = {"head": {"ref": "agent/issue-42"}}
+        mock_pr_data = {"head": {"ref": "agent/issue-42"}, "body": "Implements #42."}
 
         async def run():
             with (


### PR DESCRIPTION
## Problem

PR #35 took 6 review cycles to converge. Two root causes:

1. **Bot reviewed line-by-line, not system-level.** Each round found 2-4 issues on specific lines but didn't trace implications. Fixes to those lines created new edge cases caught in the next round.

2. **Fixer (me) did the bare minimum.** Fixed exactly what was pointed at without stepping back to think about downstream effects — the exact anti-pattern we then wrote instructions against.

## Fix

Added 'Review Approach' section to the code-review skill:
- **Trace the full flow** — follow data through the system, check every caller
- **Think about implications** — if recommending 'raise instead of log', flag what happens to callers
- **Batch related findings** — same class of issue in multiple places → one comment, not five rounds
- **Front-load everything** — aim for one review round, not five

The implement skill already got 'Responding to Review Feedback' guidelines in PR #35. This completes the other side of the equation.