### PR TITLE
fix: bare clone ref + issue reaction for implement workflow

### DIFF
--- a/.github/workflows/implement.yaml
+++ b/.github/workflows/implement.yaml
@@ -34,6 +34,15 @@ jobs:
           gh api "/repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" \
             --method POST -f content='rocket' --silent
 
+      - name: React to label
+        if: github.event_name == 'issues'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "/repos/$REPO/issues/$ISSUE_NUMBER/reactions" \
+            --method POST -f content='rocket' --silent
+
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4
         with:

--- a/stacks/agents/app/git.py
+++ b/stacks/agents/app/git.py
@@ -36,10 +36,11 @@ async def init_bare_clone(repo_url: str) -> Path:
         # Prune stale worktree refs (e.g. after container restart with persistent volume)
         with contextlib.suppress(RuntimeError):
             await _run(["git", "worktree", "prune"], cwd=BARE_CLONE_PATH)
-        # Bare clones have no default refspec, so fetch explicitly into refs/heads/
-        # to keep local branch refs up to date with the remote.
+        # Bare clones have no default refspec, so fetch main explicitly to keep
+        # the base ref current. Only fetch main — fetching all of refs/heads/*
+        # would prune local-only worktree branches (agent/issue-*, pr-*).
         await _run(
-            ["git", "fetch", "origin", "+refs/heads/*:refs/heads/*", "--prune"],
+            ["git", "fetch", "origin", "+refs/heads/main:refs/heads/main"],
             cwd=BARE_CLONE_PATH,
         )
     else:

--- a/stacks/agents/app/git.py
+++ b/stacks/agents/app/git.py
@@ -95,8 +95,10 @@ async def create_branch_worktree(branch_name: str, repo_url: str) -> Path:
         with contextlib.suppress(RuntimeError):
             await _run(["git", "branch", "-D", branch_name], cwd=BARE_CLONE_PATH)
 
+        # In a bare clone, fetch writes directly to refs/heads/ (no remote-tracking
+        # branches), so the ref is "main" not "origin/main".
         await _run(
-            ["git", "branch", branch_name, "origin/main"],
+            ["git", "branch", branch_name, "main"],
             cwd=BARE_CLONE_PATH,
         )
 

--- a/stacks/agents/app/git.py
+++ b/stacks/agents/app/git.py
@@ -36,7 +36,12 @@ async def init_bare_clone(repo_url: str) -> Path:
         # Prune stale worktree refs (e.g. after container restart with persistent volume)
         with contextlib.suppress(RuntimeError):
             await _run(["git", "worktree", "prune"], cwd=BARE_CLONE_PATH)
-        await _run(["git", "fetch", "--all", "--prune"], cwd=BARE_CLONE_PATH)
+        # Bare clones have no default refspec, so fetch explicitly into refs/heads/
+        # to keep local branch refs up to date with the remote.
+        await _run(
+            ["git", "fetch", "origin", "+refs/heads/*:refs/heads/*", "--prune"],
+            cwd=BARE_CLONE_PATH,
+        )
     else:
         BARE_CLONE_PATH.parent.mkdir(parents=True, exist_ok=True)
         await _run(["git", "clone", "--bare", repo_url, str(BARE_CLONE_PATH)])


### PR DESCRIPTION
## Problem

The implement workflow fails immediately with:
```
fatal: not a valid object name: 'origin/main'
```

`git clone --bare` doesn't create remote-tracking branches — refs live at `refs/heads/main`, not `refs/remotes/origin/main`. This means `create_branch_worktree` (used by implement) always fails.

Also, when the implement workflow triggers via the `agent` label, there's no feedback on the issue — no reaction, no comment. The `/implement` comment path gets a 🚀 reaction, but the label path is silent.

## Fix

1. **`git.py`**: Reference `main` instead of `origin/main` in `create_branch_worktree`
2. **`implement.yaml`**: Add 🚀 reaction on the issue when triggered via label

## Testing

- All 32 tests pass
- Discovered while battle-testing the implement loop on issue #38