### PR TITLE
refactor: strip GH_TOKEN from CLI, post reviews from orchestrator

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -31,31 +31,35 @@ Review for:
 - 💡 **Suggestion** — non-blocking improvement, author decides
 - ❓ **Question** — seeks clarification, non-blocking
 
-## Posting Reviews
+## Review Output
 
-You have `gh` CLI available and authenticated. Post reviews directly via the GitHub API.
+You do NOT have GitHub API access. Write your review as a JSON file at `.copilot-review.json` in the repository root.
 
-To post a review with inline comments:
+Schema:
 
-```bash
-gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
-  --method POST \
-  -f event="APPROVE" \
-  -f body="Summary text" \
-  -f 'comments=[{"path":"file.py","line":42,"body":"🚫 **Blocker**\n\nExplanation"}]'
+```json
+{
+  "event": "APPROVE",
+  "body": "Summary of the review.",
+  "comments": [
+    {
+      "path": "file.py",
+      "line": 42,
+      "body": "🚫 **Blocker**\n\nExplanation of the issue."
+    }
+  ]
+}
 ```
 
 Rules:
-- Use `event: "REQUEST_CHANGES"` only if you have blocker-severity comments
-- Use `event: "APPROVE"` when the code looks good or only has suggestions
-- End the body with `\n\n---` (no attribution line — stats are appended automatically)
-- If the code looks good, approve with no inline comments
+- `event` must be `"REQUEST_CHANGES"` if you have blocker-severity comments, otherwise `"APPROVE"`
+- `body` is the review summary — end with `\n\n---`
+- `comments` is an array of inline comments (can be empty for a clean approval)
+- Each comment needs `path` (relative file path), `line` (line number in the new file), and `body`
+- For multi-line comments, add `start_line` (first line) alongside `line` (last line)
+- If the code looks good, set `event` to `"APPROVE"` with an empty `comments` array
 
-## Permissions
-
-Your `gh` token has **pull requests: write** and **contents: read**. You cannot:
-- Push commits, create branches, or modify repository contents
-- Resolve or unresolve review threads (requires contents: write)
+The orchestrator will read this file and post the review on your behalf.
 
 ## Previous Review Threads
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,6 +26,8 @@ Discovered during battle-testing. Each is tracked as an issue.
 | Can't rebase or resolve merge conflicts | [#41](https://github.com/ColinCee/homelab/issues/41) | PRs stall when `main` moves during implementation |
 | Failed runs discard all CLI work | [#42](https://github.com/ColinCee/homelab/issues/42) | ~6 min + 1 premium request wasted per failed attempt |
 | Parallel agents can conflict on shared files | [#43](https://github.com/ColinCee/homelab/issues/43) | Low risk today (single agent), blocks scaling |
+| Can't self-review review infrastructure changes | — | PRs that change the review skill or orchestrator break the review loop (CLI reads the PR's skill, but orchestrator runs the old code) |
+| Dokploy config isn't code-editable | — | Agent can edit `compose.yaml` but not Dokploy-level settings (domains, env vars, resource limits) — those live in Dokploy's DB. Would need Terraform/Pulumi for full IaC |
 
 ## Scaling Path
 

--- a/stacks/agents/app/copilot.py
+++ b/stacks/agents/app/copilot.py
@@ -76,7 +76,6 @@ async def run_copilot(
     *,
     model: str = "gpt-5.4",
     effort: str = "high",
-    gh_token: str | None = None,
 ) -> CLIResult:
     """Run Copilot CLI in headless mode and return result with stats."""
     cmd = [
@@ -93,8 +92,9 @@ async def run_copilot(
     ]
 
     env = os.environ.copy()
-    if gh_token:
-        env["GH_TOKEN"] = gh_token
+    # Ensure the CLI never inherits GitHub API access — the orchestrator
+    # handles all GitHub operations with its own scoped token.
+    env.pop("GH_TOKEN", None)
 
     logger.info("Running Copilot CLI in %s (model=%s, effort=%s)", worktree_path, model, effort)
 

--- a/stacks/agents/app/github.py
+++ b/stacks/agents/app/github.py
@@ -227,52 +227,6 @@ async def dismiss_stale_reviews(repo: str, pr_number: int) -> None:
                 logger.warning("Failed to dismiss review %d: %d", review["id"], resp.status_code)
 
 
-async def append_stats_to_review(repo: str, pr_number: int, stats_line: str) -> None:
-    """Find the bot's latest review and append a stats footer."""
-    if not stats_line:
-        return
-
-    token = await get_token()
-    login = bot_login()
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-    }
-    reviews_url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews"
-
-    reviews = await _fetch_all_reviews(repo, pr_number, token)
-    bot_reviews = [r for r in reviews if r.get("user", {}).get("login") == login]
-    if not bot_reviews:
-        logger.warning("No reviews from %s found to append stats to", login)
-        return
-
-    latest = bot_reviews[-1]
-    review_id = latest["id"]
-    current_body = latest.get("body", "")
-    updated_body = f"{current_body}\n{stats_line}"
-
-    update_url = f"{reviews_url}/{review_id}"
-    async with httpx.AsyncClient(timeout=30) as client:
-        resp = await client.put(update_url, headers=headers, json={"body": updated_body})
-        if resp.status_code == 200:
-            logger.info("Appended stats to review %d", review_id)
-        else:
-            logger.warning("Failed to update review with stats: %d", resp.status_code)
-
-
-async def count_bot_reviews(repo: str, pr_number: int) -> int:
-    """Count active (non-dismissed) bot reviews on a PR."""
-    token = await get_token()
-    login = bot_login()
-    reviews = await _fetch_all_reviews(repo, pr_number, token)
-    return sum(
-        1
-        for r in reviews
-        if r.get("user", {}).get("login") == login
-        and r.get("state") in ("CHANGES_REQUESTED", "APPROVED", "COMMENTED")
-    )
-
-
 async def get_issue(repo: str, issue_number: int) -> dict:
     """Fetch issue details (title, body, labels)."""
     token = await get_token()
@@ -345,3 +299,32 @@ async def comment_on_issue(repo: str, issue_number: int, body: str) -> None:
             raise RuntimeError(
                 f"Failed to comment on {repo}#{issue_number}: HTTP {resp.status_code}"
             )
+
+
+async def post_review(
+    repo: str,
+    pr_number: int,
+    *,
+    event: str,
+    body: str,
+    comments: list[dict] | None = None,
+) -> dict:
+    """Post a pull request review with optional inline comments."""
+    token = await get_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+
+    payload: dict = {"event": event, "body": body}
+    if comments:
+        payload["comments"] = comments
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -1,16 +1,17 @@
 """PR review orchestrator — ties together git, copilot, and github modules."""
 
+import json
 import logging
 import time
+from pathlib import Path
 
 from copilot import run_copilot
 from git import cleanup_worktree, create_worktree
 from github import (
-    append_stats_to_review,
-    count_bot_reviews,
+    comment_on_issue,
     dismiss_stale_reviews,
-    get_token,
     get_unresolved_threads,
+    post_review,
 )
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,56 @@ Only re-report issues that are still present as new inline comments.
 {threads}
 """
 
+REVIEW_OUTPUT_FILE = ".copilot-review.json"
+VALID_EVENTS = {"APPROVE", "REQUEST_CHANGES", "COMMENT"}
+
+
+def _parse_review_file(review_file: Path) -> dict:
+    """Parse and validate the review JSON file written by the CLI.
+
+    Returns a validated dict with 'event', 'body', and 'comments' keys.
+    Raises RuntimeError with a descriptive message on any validation failure.
+    """
+    if not review_file.exists():
+        raise RuntimeError(
+            f"Copilot CLI did not produce a review file ({REVIEW_OUTPUT_FILE} not found)"
+        )
+
+    raw = review_file.read_text().strip()
+
+    # CLI occasionally wraps JSON in markdown code fences
+    if raw.startswith("```"):
+        lines = raw.splitlines()
+        lines = [line for line in lines if not line.startswith("```")]
+        raw = "\n".join(lines).strip()
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Review file is not valid JSON: {exc}\nContent (first 500 chars): {raw[:500]}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise RuntimeError(f"Review file must be a JSON object, got {type(data).__name__}")
+
+    event = data.get("event")
+    if event not in VALID_EVENTS:
+        raise RuntimeError(f"Invalid review event '{event}' — must be one of {VALID_EVENTS}")
+
+    comments = data.get("comments", [])
+    if not isinstance(comments, list):
+        raise RuntimeError(f"'comments' must be a list, got {type(comments).__name__}")
+
+    for i, c in enumerate(comments):
+        if not isinstance(c, dict):
+            raise RuntimeError(f"Comment {i} must be an object, got {type(c).__name__}")
+        for required_key in ("path", "line", "body"):
+            if required_key not in c:
+                raise RuntimeError(f"Comment {i} missing required key '{required_key}'")
+
+    return {"event": event, "body": data.get("body", ""), "comments": comments}
+
 
 async def review_pr(
     *,
@@ -40,17 +91,13 @@ async def review_pr(
     model: str = "gpt-5.4",
     reasoning_effort: str = "high",
 ) -> dict:
-    """Full review pipeline: worktree → Copilot CLI → post-review cleanup."""
+    """Full review pipeline: worktree → Copilot CLI → read JSON → post review."""
     logger.info("Starting review for %s#%d (model=%s)", repo, pr_number, model)
     start = time.monotonic()
     repo_url = f"https://github.com/{repo}.git"
 
-    token = await get_token()
-
     try:
         worktree_path = await create_worktree(pr_number, repo_url)
-
-        reviews_before = await count_bot_reviews(repo, pr_number)
 
         threads = await get_unresolved_threads(repo, pr_number)
         previous_section = PREVIOUS_REVIEW_SECTION.format(threads=threads) if threads else ""
@@ -65,23 +112,34 @@ async def review_pr(
             prompt,
             model=model,
             effort=reasoning_effort,
-            gh_token=token,
         )
 
-        elapsed = time.monotonic() - start
-
-        reviews_after = await count_bot_reviews(repo, pr_number)
-        if reviews_after <= reviews_before:
-            raise RuntimeError(
-                f"Copilot CLI exited 0 but no new review was posted "
-                f"(before={reviews_before}, after={reviews_after})"
+        try:
+            review_data = _parse_review_file(worktree_path / REVIEW_OUTPUT_FILE)
+        except RuntimeError as exc:
+            logger.error("Review output validation failed: %s", exc)
+            await comment_on_issue(
+                repo,
+                pr_number,
+                f"⚠️ **Review failed** — CLI produced invalid output.\n\n```\n{exc}\n```",
             )
+            raise
+
+        body = review_data["body"]
+        if result.stats_line:
+            body += f"\n\n📊 {result.stats_line}"
+
+        await post_review(
+            repo,
+            pr_number,
+            event=review_data["event"],
+            body=body,
+            comments=review_data["comments"] or None,
+        )
 
         await dismiss_stale_reviews(repo, pr_number)
 
-        if result.stats_line:
-            await append_stats_to_review(repo, pr_number, result.stats_line)
-
+        elapsed = time.monotonic() - start
         logger.info("Review complete for %s#%d in %.1fs", repo, pr_number, elapsed)
 
         return {

--- a/stacks/agents/app/tests/test_review.py
+++ b/stacks/agents/app/tests/test_review.py
@@ -1,0 +1,105 @@
+"""Tests for review orchestrator — specifically the review file parser."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from review import _parse_review_file
+
+
+@pytest.fixture
+def review_file(tmp_path: Path) -> Path:
+    return tmp_path / ".copilot-review.json"
+
+
+def _write(path: Path, data: dict | str) -> None:
+    content = data if isinstance(data, str) else json.dumps(data)
+    path.write_text(content)
+
+
+class TestParseReviewFile:
+    def test_parses_valid_approve(self, review_file: Path):
+        _write(review_file, {"event": "APPROVE", "body": "LGTM", "comments": []})
+        result = _parse_review_file(review_file)
+        assert result["event"] == "APPROVE"
+        assert result["body"] == "LGTM"
+        assert result["comments"] == []
+
+    def test_parses_request_changes_with_comments(self, review_file: Path):
+        _write(
+            review_file,
+            {
+                "event": "REQUEST_CHANGES",
+                "body": "Issues found",
+                "comments": [{"path": "main.py", "line": 10, "body": "Bug here"}],
+            },
+        )
+        result = _parse_review_file(review_file)
+        assert result["event"] == "REQUEST_CHANGES"
+        assert len(result["comments"]) == 1
+        assert result["comments"][0]["path"] == "main.py"
+
+    def test_defaults_body_to_empty_string(self, review_file: Path):
+        _write(review_file, {"event": "APPROVE"})
+        result = _parse_review_file(review_file)
+        assert result["body"] == ""
+
+    def test_defaults_comments_to_empty_list(self, review_file: Path):
+        _write(review_file, {"event": "COMMENT", "body": "Looks fine"})
+        result = _parse_review_file(review_file)
+        assert result["comments"] == []
+
+    def test_raises_when_file_missing(self, tmp_path: Path):
+        missing = tmp_path / "nope.json"
+        with pytest.raises(RuntimeError, match="did not produce"):
+            _parse_review_file(missing)
+
+    def test_raises_on_invalid_json(self, review_file: Path):
+        review_file.write_text("not json {{{")
+        with pytest.raises(RuntimeError, match="not valid JSON"):
+            _parse_review_file(review_file)
+
+    def test_raises_on_non_object(self, review_file: Path):
+        review_file.write_text('"just a string"')
+        with pytest.raises(RuntimeError, match="must be a JSON object"):
+            _parse_review_file(review_file)
+
+    def test_raises_on_invalid_event(self, review_file: Path):
+        _write(review_file, {"event": "MERGE", "body": "lol"})
+        with pytest.raises(RuntimeError, match="Invalid review event"):
+            _parse_review_file(review_file)
+
+    def test_raises_on_missing_event(self, review_file: Path):
+        _write(review_file, {"body": "no event field"})
+        with pytest.raises(RuntimeError, match="Invalid review event"):
+            _parse_review_file(review_file)
+
+    def test_raises_on_comment_missing_required_keys(self, review_file: Path):
+        _write(
+            review_file,
+            {"event": "APPROVE", "comments": [{"path": "f.py", "body": "x"}]},
+        )
+        with pytest.raises(RuntimeError, match="missing required key 'line'"):
+            _parse_review_file(review_file)
+
+    def test_strips_markdown_code_fences(self, review_file: Path):
+        review_file.write_text(
+            '```json\n{"event": "APPROVE", "body": "Clean", "comments": []}\n```'
+        )
+        result = _parse_review_file(review_file)
+        assert result["event"] == "APPROVE"
+
+    def test_handles_multiline_comment_body(self, review_file: Path):
+        _write(
+            review_file,
+            {
+                "event": "REQUEST_CHANGES",
+                "body": "Issues",
+                "comments": [
+                    {"path": "a.py", "line": 5, "body": "🚫 **Blocker**\n\nDetailed explanation"}
+                ],
+            },
+        )
+        result = _parse_review_file(review_file)
+        assert "Blocker" in result["comments"][0]["body"]


### PR DESCRIPTION
Closes #40

## Summary

Refactors the token architecture so the Copilot CLI **never** receives a GitHub API token. This is a prerequisite for adding `contents:write` to the GitHub App — without this change, the review CLI would inherit push access (prompt injection risk).

### Changes

| File | Change |
|------|--------|
| `SKILL.md` | CLI writes review JSON to `.copilot-review.json` instead of calling `gh api` |
| `copilot.py` | Removed `gh_token` param; explicitly pops `GH_TOKEN` from env |
| `review.py` | Reads review JSON from worktree, posts via `post_review()`, inlines stats |
| `github.py` | Added `post_review()`; removed dead `append_stats_to_review` and `count_bot_reviews` |

### Token flow (before → after)

**Before:** CLI gets App token as `GH_TOKEN` → calls `gh api` to post review
**After:** CLI gets NO GitHub token → writes JSON file → orchestrator posts via App token

### Next steps (after merge)

1. Add `contents:write` to the homelab-review-bot GitHub App
2. Re-trigger #38 (Prometheus metrics) with `/implement`