### PR TITLE
fix: downgrade REQUEST_CHANGES to COMMENT on bot's own PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,43 +53,9 @@ Platform: Dokploy (manages container lifecycle, auto-deploys from main)
 
 ## Pull Request Workflow
 
-This repo has an automated AI code review system. Follow this process:
+PRs require CI to pass and are squash-merged. `colins-homelab-bot[bot]` auto-reviews when a PR is opened or marked ready. Comment `/review` to re-trigger. Bot reviews are **advisory** — they inform but don't gate merges.
 
-### Creating PRs
-
-1. **Create PRs as drafts** — `gh pr create --draft`
-2. Push commits, iterate until ready
-3. Mark ready: `gh pr ready <number>` → triggers first AI review
-
-### Review cycle
-
-1. When a PR is opened or marked ready, `code-review.yaml` auto-triggers
-2. `colins-homelab-bot[bot]` posts a structured review with inline
-   comments and a verdict:
-   - **APPROVE** — no issues found
-   - **REQUEST_CHANGES** — blocker-severity issues found
-   - **COMMENT** — suggestions only, non-blocking
-3. Inline comments use severity tags:
-   - 🚫 **Blocker** — bugs, security, breaking changes
-   - 💡 **Suggestion** — non-blocking improvement, author decides
-   - ❓ **Question** — seeks clarification, non-blocking
-4. Fix legitimate findings, push new commits
-5. Comment `/review` to re-trigger — the bot receives all unresolved
-   review threads and checks if issues were addressed
-6. Repeat until you're confident the code is ready — bot reviews are
-   **advisory**, not blocking. Use your judgement: fix real issues,
-   dismiss false positives
-7. Merge when CI passes and you're satisfied with the code
-
-### Important
-
-- **Bot reviews are advisory** — they inform but don't gate merges.
-  The bot may produce false positives. If you're confident a finding
-  is wrong, explain why in a comment and move on.
-- **No `synchronize` trigger** — pushes don't auto-review. Use `/review`.
-- Stale reviews are dismissed on new pushes
-- Never use `--admin` to bypass branch protection
-- Fork PRs are blocked from triggering reviews
+See `.github/instructions/pr-workflow.instructions.md` for the full process.
 
 ## Documenting Decisions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,7 +64,7 @@ This repo has an automated AI code review system. Follow this process:
 ### Review cycle
 
 1. When a PR is opened or marked ready, `code-review.yaml` auto-triggers
-2. `homelab-review-bot[bot]` posts a structured review with inline
+2. `colins-homelab-bot[bot]` posts a structured review with inline
    comments and a verdict:
    - **APPROVE** — no issues found
    - **REQUEST_CHANGES** — blocker-severity issues found

--- a/.github/instructions/pr-workflow.instructions.md
+++ b/.github/instructions/pr-workflow.instructions.md
@@ -1,0 +1,44 @@
+This instruction applies to files matching the pattern: .github/workflows/**,stacks/agents/**
+
+---
+applyTo: ".github/workflows/**,stacks/agents/**"
+---
+
+# Pull Request Workflow
+
+This repo has an automated AI code review and implementation system powered by `colins-homelab-bot[bot]`.
+
+## Creating PRs
+
+1. **Create PRs as drafts** — `gh pr create --draft`
+2. Push commits, iterate until ready
+3. Mark ready: `gh pr ready <number>` → triggers first AI review
+
+## Review cycle
+
+1. When a PR is opened or marked ready, `code-review.yaml` auto-triggers
+2. The bot posts a structured review with a verdict:
+   - **APPROVE** — no issues found
+   - **REQUEST_CHANGES** — blocker-severity issues found
+   - **COMMENT** — suggestions only, non-blocking
+3. Inline comments use severity tags:
+   - 🚫 **Blocker** — bugs, security, breaking changes
+   - 💡 **Suggestion** — non-blocking improvement, author decides
+   - ❓ **Question** — seeks clarification, non-blocking
+4. Fix legitimate findings, push new commits
+5. Comment `/review` to re-trigger — the bot receives all unresolved
+   review threads and checks if issues were addressed
+6. Repeat until you're confident the code is ready — bot reviews are
+   **advisory**, not blocking. Use your judgement: fix real issues,
+   dismiss false positives
+7. Merge when CI passes and you're satisfied with the code
+
+## Important
+
+- **Bot reviews are advisory** — they inform but don't gate merges.
+  The bot may produce false positives. If you're confident a finding
+  is wrong, explain why in a comment and move on.
+- **No `synchronize` trigger** — pushes don't auto-review. Use `/review`.
+- Stale reviews are dismissed on new pushes
+- Never use `--admin` to bypass branch protection
+- Fork PRs are blocked from triggering reviews

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -33,14 +33,14 @@ Review for:
 
 ## Review Output
 
-You do NOT have GitHub API access. Write your review as a JSON file at `.copilot-review.json` in the repository root.
+You do NOT have GitHub API access. Write your review as a JSON file at `.copilot-review.json` in the repository root. The orchestrator will read this file and post the review on your behalf — you own the content, the orchestrator owns the delivery.
 
 Schema:
 
 ```json
 {
   "event": "APPROVE",
-  "body": "Summary of the review.",
+  "body": "✅ **Approved** — no issues found.\n\nSummary of the review.\n\n---",
   "comments": [
     {
       "path": "file.py",
@@ -51,15 +51,22 @@ Schema:
 }
 ```
 
-Rules:
+### `body` format
+
+Start with a verdict banner so the outcome is visible at a glance:
+
+- `✅ **Approved** — no issues found.` when event is APPROVE
+- `🚫 **Changes requested** — see inline comments.` when event is REQUEST_CHANGES
+
+Follow the banner with a blank line, then a concise summary of what you reviewed and any notable observations. End the body with `\n\n---`.
+
+### Rules
+
 - `event` must be `"REQUEST_CHANGES"` if you have blocker-severity comments, otherwise `"APPROVE"`
-- `body` is the review summary — end with `\n\n---`
 - `comments` is an array of inline comments (can be empty for a clean approval)
 - Each comment needs `path` (relative file path), `line` (line number in the new file), and `body`
 - For multi-line comments, add `start_line` (first line) alongside `line` (last line)
 - If the code looks good, set `event` to `"APPROVE"` with an empty `comments` array
-
-The orchestrator will read this file and post the review on your behalf.
 
 ## Previous Review Threads
 

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -23,7 +23,7 @@ jobs:
       github.event.comment.body == '/review' &&
       (contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'),
       github.event.comment.author_association) ||
-      github.event.comment.user.login == 'homelab-review-bot[bot]'))
+      github.event.comment.user.login == 'colins-homelab-bot[bot]'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/implement-fix.yaml
+++ b/.github/workflows/implement-fix.yaml
@@ -9,7 +9,7 @@ jobs:
     # Only trigger for REQUEST_CHANGES from the review bot on agent-created PRs
     if: >
       github.event.review.state == 'changes_requested' &&
-      github.event.review.user.login == 'homelab-review-bot[bot]' &&
+      github.event.review.user.login == 'colins-homelab-bot[bot]' &&
       startsWith(github.event.pull_request.head.ref, 'agent/')
     runs-on: ubuntu-latest
     permissions:
@@ -25,8 +25,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Count bot fix commits on this PR (dismissed reviews lose state, so use commits)
+          # Bot identity must match _APP_SLUG in stacks/agents/app/github.py
           FIX_COUNT=$(gh api "/repos/$REPO/pulls/$PR_NUMBER/commits" \
-            --jq '[.[] | select(.commit.author.name == "homelab-review-bot[bot]" and (.commit.message | startswith("fix:")))] | length')
+            --jq '[.[] | select(.commit.author.name == "colins-homelab-bot[bot]" and (.commit.message | startswith("fix:")))] | length')
 
           MAX_ITERATIONS=3
           if [ "$FIX_COUNT" -ge "$MAX_ITERATIONS" ]; then

--- a/stacks/agents/app/copilot.py
+++ b/stacks/agents/app/copilot.py
@@ -112,30 +112,27 @@ async def run_copilot(
 
     async def _stream(stream: asyncio.StreamReader, lines: list[str], prefix: str) -> None:
         while not stream.at_eof():
-            try:
-                raw = await asyncio.wait_for(stream.readline(), timeout=5.0)
-                if raw:
-                    line = raw.decode().rstrip()
-                    lines.append(line)
-                    logger.info("[copilot %s] %s", prefix, line)
-            except TimeoutError:
-                if proc.returncode is not None:
-                    break
+            raw = await stream.readline()
+            if raw:
+                line = raw.decode().rstrip()
+                lines.append(line)
+                logger.info("[copilot %s] %s", prefix, line)
 
     try:
         assert proc.stdout and proc.stderr
         out_task = asyncio.create_task(_stream(proc.stdout, stdout_lines, "agent"))
         err_task = asyncio.create_task(_stream(proc.stderr, stderr_lines, "meta"))
 
-        await asyncio.wait_for(proc.wait(), timeout=TIMEOUT_SECONDS)
-        # Give streams a moment to flush, then cancel
-        await asyncio.sleep(1)
+        # Wait for streams to EOF (happens when the process exits and pipes close).
+        # The overall timeout covers both the process runtime and stream draining.
+        await asyncio.wait_for(asyncio.gather(out_task, err_task), timeout=TIMEOUT_SECONDS)
+        await proc.wait()
+    except TimeoutError as err:
+        proc.kill()
         out_task.cancel()
         err_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await asyncio.gather(out_task, err_task)
-    except TimeoutError as err:
-        proc.kill()
         raise RuntimeError(f"Copilot CLI timed out after {TIMEOUT_SECONDS}s") from err
 
     if proc.returncode != 0:

--- a/stacks/agents/app/git.py
+++ b/stacks/agents/app/git.py
@@ -6,6 +6,8 @@ import logging
 import shutil
 from pathlib import Path
 
+from github import bot_email, bot_login
+
 logger = logging.getLogger(__name__)
 
 BARE_CLONE_PATH = Path("/repo.git")
@@ -152,9 +154,9 @@ async def commit_and_push(
         [
             "git",
             "-c",
-            "user.name=homelab-review-bot[bot]",
+            f"user.name={bot_login()}",
             "-c",
-            "user.email=274352150+homelab-review-bot[bot]@users.noreply.github.com",
+            f"user.email={bot_email()}",
             "commit",
             "-m",
             message,

--- a/stacks/agents/app/github.py
+++ b/stacks/agents/app/github.py
@@ -73,8 +73,17 @@ def reset_token_cache() -> None:
 
 def bot_login() -> str:
     """Derive the bot login from the GitHub App slug (set via env var)."""
-    app_slug = os.environ.get("GITHUB_APP_SLUG", "homelab-review-bot")
+    app_slug = os.environ.get("GITHUB_APP_SLUG", "colins-homelab-bot")
     return f"{app_slug}[bot]"
+
+
+def bot_email() -> str:
+    """GitHub noreply email for the bot, used as git commit author.
+
+    Bot user ID (274352150) is stable across app renames.
+    """
+    bot_id = os.environ.get("GITHUB_APP_BOT_ID", "274352150")
+    return f"{bot_id}+{bot_login()}@users.noreply.github.com"
 
 
 async def _fetch_all_reviews(repo: str, pr_number: int, token: str) -> list[dict]:

--- a/stacks/agents/app/github.py
+++ b/stacks/agents/app/github.py
@@ -71,19 +71,18 @@ def reset_token_cache() -> None:
     _token_expires_at = 0
 
 
+_APP_SLUG = "colins-homelab-bot"
+_BOT_USER_ID = "274352150"  # stable across app renames
+
+
 def bot_login() -> str:
-    """Derive the bot login from the GitHub App slug (set via env var)."""
-    app_slug = os.environ.get("GITHUB_APP_SLUG", "colins-homelab-bot")
-    return f"{app_slug}[bot]"
+    """The bot's GitHub login (e.g. 'colins-homelab-bot[bot]')."""
+    return f"{_APP_SLUG}[bot]"
 
 
 def bot_email() -> str:
-    """GitHub noreply email for the bot, used as git commit author.
-
-    Bot user ID (274352150) is stable across app renames.
-    """
-    bot_id = os.environ.get("GITHUB_APP_BOT_ID", "274352150")
-    return f"{bot_id}+{bot_login()}@users.noreply.github.com"
+    """GitHub noreply email for the bot, used as git commit author."""
+    return f"{_BOT_USER_ID}+{bot_login()}@users.noreply.github.com"
 
 
 async def _fetch_all_reviews(repo: str, pr_number: int, token: str) -> list[dict]:

--- a/stacks/agents/app/github.py
+++ b/stacks/agents/app/github.py
@@ -195,8 +195,14 @@ async def get_unresolved_threads(repo: str, pr_number: int) -> str:
         return "\n".join(lines)
 
 
-async def dismiss_stale_reviews(repo: str, pr_number: int) -> None:
-    """Dismiss previous bot reviews, keeping the latest one (just posted)."""
+async def dismiss_stale_reviews(repo: str, pr_number: int, *, keep_latest: bool = True) -> None:
+    """Dismiss previous stateful bot reviews.
+
+    Args:
+        keep_latest: If True, keep the most recent stateful review (normal case).
+            If False, dismiss ALL stateful reviews (used when the new review is a
+            COMMENT that won't appear in the stateful list).
+    """
     token = await get_token()
     login = bot_login()
     headers = {
@@ -213,8 +219,10 @@ async def dismiss_stale_reviews(repo: str, pr_number: int) -> None:
         and r.get("state") in ("CHANGES_REQUESTED", "APPROVED")
     ]
 
+    to_dismiss = bot_reviews[:-1] if keep_latest else bot_reviews
+
     async with httpx.AsyncClient(timeout=30) as client:
-        for review in bot_reviews[:-1]:
+        for review in to_dismiss:
             dismiss_url = f"{reviews_url}/{review['id']}/dismissals"
             resp = await client.put(
                 dismiss_url,

--- a/stacks/agents/app/github.py
+++ b/stacks/agents/app/github.py
@@ -195,6 +195,20 @@ async def get_unresolved_threads(repo: str, pr_number: int) -> str:
         return "\n".join(lines)
 
 
+# --- Pull Request Reviews ---
+#
+# GitHub has three distinct comment types on PRs:
+#   1. PR comments — plain text on the timeline (Issues API), no merge impact
+#   2. Review comments — inline code annotations, always part of a review
+#   3. Reviews — submitted via the Reviews API with a verdict:
+#      - APPROVED / CHANGES_REQUESTED — "stateful", affect branch protection
+#      - COMMENT — informational only, no merge impact
+#
+# Only stateful reviews (APPROVED, CHANGES_REQUESTED) can be dismissed.
+# Dismissal changes the state to DISMISSED, removing its merge-blocking effect.
+# COMMENT reviews are permanent — they can't be dismissed or retracted.
+
+
 async def dismiss_stale_reviews(repo: str, pr_number: int, *, keep_latest: bool = True) -> None:
     """Dismiss previous stateful bot reviews.
 

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -132,12 +132,14 @@ async def review_pr(
             body += f"\n\n📊 {result.stats_line}"
 
         event = review_data["event"]
+        downgraded = False
 
-        # GitHub doesn't allow REQUEST_CHANGES on your own PR — downgrade to COMMENT
+        # GitHub doesn't allow REQUEST_CHANGES on your own PR — use COMMENT instead
         pr_data = await get_pr(repo, pr_number)
         if event == "REQUEST_CHANGES" and pr_data.get("user", {}).get("login") == bot_login():
-            logger.info("Downgrading REQUEST_CHANGES to COMMENT (bot's own PR)")
+            logger.info("Using COMMENT instead of REQUEST_CHANGES (bot's own PR)")
             event = "COMMENT"
+            downgraded = True
 
         await post_review(
             repo,
@@ -147,7 +149,9 @@ async def review_pr(
             comments=review_data["comments"] or None,
         )
 
-        await dismiss_stale_reviews(repo, pr_number)
+        # When downgraded to COMMENT, dismiss ALL prior stateful reviews —
+        # otherwise a stale APPROVE could linger since our COMMENT isn't stateful
+        await dismiss_stale_reviews(repo, pr_number, keep_latest=not downgraded)
 
         elapsed = time.monotonic() - start
         logger.info("Review complete for %s#%d in %.1fs", repo, pr_number, elapsed)

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -128,8 +128,6 @@ async def review_pr(
             raise
 
         body = review_data["body"]
-        if result.stats_line:
-            body += f"\n\n📊 {result.stats_line}"
 
         event = review_data["event"]
         downgraded = False
@@ -140,6 +138,17 @@ async def review_pr(
             logger.info("Using COMMENT instead of REQUEST_CHANGES (bot's own PR)")
             event = "COMMENT"
             downgraded = True
+
+        verdict_banners = {
+            "APPROVE": "✅ **Approved** — no issues found.",
+            "REQUEST_CHANGES": "🚫 **Changes requested** — see inline comments.",
+            "COMMENT": "💬 **Review complete** — comments only, non-blocking.",
+        }
+        banner = verdict_banners.get(event, "")
+        parts = [banner, "", body] if banner else [body]
+        if result.stats_line:
+            parts.extend(["", f"📊 {result.stats_line}"])
+        body = "\n".join(parts)
 
         await post_review(
             repo,

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -139,16 +139,9 @@ async def review_pr(
             event = "COMMENT"
             downgraded = True
 
-        verdict_banners = {
-            "APPROVE": "✅ **Approved** — no issues found.",
-            "REQUEST_CHANGES": "🚫 **Changes requested** — see inline comments.",
-            "COMMENT": "💬 **Review complete** — comments only, non-blocking.",
-        }
-        banner = verdict_banners.get(event, "")
-        parts = [banner, "", body] if banner else [body]
+        # Append stats as a collapsible footer — orchestrator-only metadata
         if result.stats_line:
-            parts.extend(["", f"📊 {result.stats_line}"])
-        body = "\n".join(parts)
+            body += f"\n\n<details>\n<summary>📊 Stats</summary>\n\n{result.stats_line}\n</details>"
 
         await post_review(
             repo,

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -8,8 +8,10 @@ from pathlib import Path
 from copilot import run_copilot
 from git import cleanup_worktree, create_worktree
 from github import (
+    bot_login,
     comment_on_issue,
     dismiss_stale_reviews,
+    get_pr,
     get_unresolved_threads,
     post_review,
 )
@@ -129,10 +131,18 @@ async def review_pr(
         if result.stats_line:
             body += f"\n\n📊 {result.stats_line}"
 
+        event = review_data["event"]
+
+        # GitHub doesn't allow REQUEST_CHANGES on your own PR — downgrade to COMMENT
+        pr_data = await get_pr(repo, pr_number)
+        if event == "REQUEST_CHANGES" and pr_data.get("user", {}).get("login") == bot_login():
+            logger.info("Downgrading REQUEST_CHANGES to COMMENT (bot's own PR)")
+            event = "COMMENT"
+
         await post_review(
             repo,
             pr_number,
-            event=review_data["event"],
+            event=event,
             body=body,
             comments=review_data["comments"] or None,
         )

--- a/stacks/agents/app/tests/test_github.py
+++ b/stacks/agents/app/tests/test_github.py
@@ -81,22 +81,10 @@ class TestGetToken:
 
 
 class TestBotLogin:
-    def test_default_slug(self):
-        with patch.dict("os.environ", {}, clear=False):
-            assert github.bot_login() == "colins-homelab-bot[bot]"
-
-    def test_custom_slug(self):
-        with patch.dict("os.environ", {"GITHUB_APP_SLUG": "my-bot"}):
-            assert github.bot_login() == "my-bot[bot]"
+    def test_login(self):
+        assert github.bot_login() == "colins-homelab-bot[bot]"
 
 
 class TestBotEmail:
-    def test_default(self):
-        with patch.dict("os.environ", {}, clear=False):
-            assert (
-                github.bot_email() == "274352150+colins-homelab-bot[bot]@users.noreply.github.com"
-            )
-
-    def test_custom_slug(self):
-        with patch.dict("os.environ", {"GITHUB_APP_SLUG": "my-bot", "GITHUB_APP_BOT_ID": "12345"}):
-            assert github.bot_email() == "12345+my-bot[bot]@users.noreply.github.com"
+    def test_email(self):
+        assert github.bot_email() == "274352150+colins-homelab-bot[bot]@users.noreply.github.com"

--- a/stacks/agents/app/tests/test_github.py
+++ b/stacks/agents/app/tests/test_github.py
@@ -83,8 +83,20 @@ class TestGetToken:
 class TestBotLogin:
     def test_default_slug(self):
         with patch.dict("os.environ", {}, clear=False):
-            assert github.bot_login() == "homelab-review-bot[bot]"
+            assert github.bot_login() == "colins-homelab-bot[bot]"
 
     def test_custom_slug(self):
         with patch.dict("os.environ", {"GITHUB_APP_SLUG": "my-bot"}):
             assert github.bot_login() == "my-bot[bot]"
+
+
+class TestBotEmail:
+    def test_default(self):
+        with patch.dict("os.environ", {}, clear=False):
+            assert (
+                github.bot_email() == "274352150+colins-homelab-bot[bot]@users.noreply.github.com"
+            )
+
+    def test_custom_slug(self):
+        with patch.dict("os.environ", {"GITHUB_APP_SLUG": "my-bot", "GITHUB_APP_BOT_ID": "12345"}):
+            assert github.bot_email() == "12345+my-bot[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Problem

PR #49 review failed with 422 — GitHub doesn't allow `REQUEST_CHANGES` on your own PR. The bot created #49 via `/implement`, then tried to review it with `REQUEST_CHANGES`.

## Fix

When reviewing a PR authored by the bot, downgrade `REQUEST_CHANGES` to `COMMENT`. The feedback still gets posted, it just doesn't block.