### PR TITLE
revert: remove unnecessary agent/ branch gate from code-review

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -17,8 +17,7 @@ jobs:
     if: >
       (github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      !startsWith(github.event.pull_request.head.ref, 'agent/')) ||
+      github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.comment.body == '/review' &&


### PR DESCRIPTION
The draft PR pattern already prevents review during the implement lifecycle — no gate needed on `agent/` branches.

**Why the gate was wrong**: `ready_for_review` only fires after `mark_pr_ready()` in the finally block, by which point the lifecycle is done. The external review is a useful final check, not a race.