### PR TITLE
fix: thread review findings through implement fix loop

### DIFF
--- a/stacks/agents/app/implement.py
+++ b/stacks/agents/app/implement.py
@@ -12,7 +12,6 @@ from github import (
     create_pull_request,
     get_issue,
     get_token,
-    get_unresolved_threads,
 )
 from review import review_pr
 
@@ -120,6 +119,7 @@ async def implement_issue(
         # We allow MAX_FIX_ITERATIONS fix attempts. Each fix is followed by a
         # re-review, so we run up to MAX_FIX_ITERATIONS + 1 review rounds
         # (initial + one after each fix).
+        previous_review_threads = ""
         for review_round in range(MAX_FIX_ITERATIONS + 1):
             logger.info(
                 "Review round %d/%d for %s#%d (PR #%d)",
@@ -136,6 +136,7 @@ async def implement_issue(
                     pr_number=pr_number,
                     model=model,
                     reasoning_effort=reasoning_effort,
+                    previous_comments=previous_review_threads,
                 )
             except TaskError as exc:
                 total_premium_requests += exc.premium_requests
@@ -192,12 +193,9 @@ async def implement_issue(
                     "error": "Review requested changes but session resumption unavailable",
                 }
 
-            threads = await get_unresolved_threads(repo, pr_number)
-            if not threads:
-                logger.warning(
-                    "REQUEST_CHANGES but no unresolved threads — "
-                    "findings may be in review body only"
-                )
+            review_threads = review_result.get("review_threads", "")
+            if not review_threads:
+                logger.warning("REQUEST_CHANGES but no inline findings to fix")
                 return {
                     "status": "partial",
                     "pr_number": pr_number,
@@ -206,13 +204,13 @@ async def implement_issue(
                     "review_rounds": review_round + 1,
                     "elapsed_seconds": time.monotonic() - start,
                     "premium_requests": total_premium_requests,
-                    "error": "Review requested changes but findings are in "
-                    "review body (not inline threads) — needs manual attention",
+                    "error": "Review requested changes but no inline comments "
+                    "were posted — needs manual attention",
                 }
 
             fix_prompt = FIX_PROMPT_TEMPLATE.format(
                 issue_number=issue_number,
-                threads=threads,
+                threads=review_threads,
             )
 
             try:
@@ -242,6 +240,7 @@ async def implement_issue(
                     repo=repo,
                     branch=branch_name,
                 )
+                previous_review_threads = review_threads
             except RuntimeError as exc:
                 if "No changes to commit" in str(exc):
                     logger.warning(

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -152,6 +152,17 @@ REVIEW_OUTPUT_FILE = ".copilot-review.json"
 # ── Helpers ────────────────────────────────────────────────
 
 
+def _format_review_threads(comments: list[ReviewComment]) -> str:
+    """Format review comments as a thread summary for fix prompts and re-review context.
+
+    Produces a format compatible with get_unresolved_threads() output so the fix
+    prompt and PREVIOUS_REVIEW_SECTION work identically regardless of source.
+    """
+    if not comments:
+        return ""
+    return "\n".join(f"- **{c.path}:{c.line}**\n  {c.body}" for c in comments)
+
+
 def _parse_linked_issues(text: str) -> list[int]:
     """Extract issue numbers from 'Fixes #N' / 'Closes #N' / 'Resolves #N' in text."""
     return sorted(set(int(m) for m in _LINKED_ISSUE_RE.findall(text)))
@@ -225,8 +236,16 @@ async def review_pr(
     pr_number: int,
     model: str = "gpt-5.4",
     reasoning_effort: str = "high",
+    previous_comments: str = "",
 ) -> dict:
-    """Full review pipeline: worktree → Copilot CLI → read JSON → post review."""
+    """Full review pipeline: worktree → Copilot CLI → read JSON → post review.
+
+    Args:
+        previous_comments: Thread summary from a prior review round. Used as
+            fallback for PREVIOUS_REVIEW_SECTION when get_unresolved_threads()
+            returns empty (e.g. self-PR where COMMENT reviews don't create
+            resolvable threads).
+    """
     logger.info("Starting review for %s#%d (model=%s)", repo, pr_number, model)
     start = time.monotonic()
     repo_url = f"https://github.com/{repo}.git"
@@ -248,6 +267,8 @@ async def review_pr(
 
         linked_issues_section = await _fetch_linked_issues_section(repo, description)
         threads = await get_unresolved_threads(repo, pr_number)
+        if not threads and previous_comments:
+            threads = previous_comments
         previous_section = PREVIOUS_REVIEW_SECTION.format(threads=threads) if threads else ""
         prompt = REVIEW_PROMPT_TEMPLATE.format(
             pr_number=pr_number,
@@ -360,6 +381,7 @@ async def review_pr(
             "premium_requests": result.total_premium_requests,
             "models": result.models,
             "original_event": review_data.event,
+            "review_threads": _format_review_threads(review_data.comments),
         }
 
     finally:

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -28,7 +28,14 @@ class TestImplementIssue:
         mock_pr = {"number": 99, "html_url": "https://github.com/user/repo/pull/99"}
 
         review_results = [
-            {"original_event": event, "premium_requests": 1} for event in review_events
+            {
+                "original_event": event,
+                "premium_requests": 1,
+                "review_threads": (
+                    "- **file.py:10**\n  bug here" if event == "REQUEST_CHANGES" else ""
+                ),
+            }
+            for event in review_events
         ]
 
         return [
@@ -50,11 +57,6 @@ class TestImplementIssue:
                 "implement.review_pr",
                 new_callable=AsyncMock,
                 side_effect=review_results,
-            ),
-            patch(
-                "implement.get_unresolved_threads",
-                new_callable=AsyncMock,
-                return_value="- **file.py:10** — bug here",
             ),
             patch("implement.comment_on_issue", new_callable=AsyncMock),
             patch("implement.cleanup_branch_worktree", new_callable=AsyncMock),
@@ -102,17 +104,21 @@ class TestImplementIssue:
         assert "session resumption unavailable" in result["error"]
 
     def test_no_threads_returns_partial(self):
-        """REQUEST_CHANGES with no threads returns partial, not complete."""
+        """REQUEST_CHANGES with no inline findings returns partial."""
         mocks = self._standard_mocks(review_events=["REQUEST_CHANGES"])
-        # Override get_unresolved_threads to return empty
-        mocks[7] = patch(
-            "implement.get_unresolved_threads",
+        # Override review_pr to return REQUEST_CHANGES with no inline comments
+        mocks[6] = patch(
+            "implement.review_pr",
             new_callable=AsyncMock,
-            return_value="",
+            return_value={
+                "original_event": "REQUEST_CHANGES",
+                "premium_requests": 1,
+                "review_threads": "",
+            },
         )
         result = self._run_with_mocks(mocks)
         assert result["status"] == "partial"
-        assert "review body" in result["error"]
+        assert "no inline comments" in result["error"]
 
     def test_accumulates_premium_requests(self):
         """Premium requests from implement + review + fix are all accumulated."""
@@ -121,3 +127,22 @@ class TestImplementIssue:
         )
         # 1 (implement) + 1 (review 1) + 1 (fix) + 1 (review 2) = 4
         assert result["premium_requests"] == 4
+
+    def test_passes_previous_threads_to_re_review(self):
+        """On second review round, previous findings are passed as context."""
+        mocks = self._standard_mocks(review_events=["REQUEST_CHANGES", "APPROVE"])
+
+        async def run():
+            with ExitStack() as stack:
+                entered = [stack.enter_context(m) for m in mocks]
+                review_mock = entered[6]  # review_pr mock
+                from implement import implement_issue
+
+                await implement_issue(repo="user/repo", issue_number=42)
+
+                # First call: no previous context
+                assert review_mock.call_args_list[0].kwargs["previous_comments"] == ""
+                # Second call: previous findings threaded through
+                assert "file.py:10" in review_mock.call_args_list[1].kwargs["previous_comments"]
+
+        asyncio.run(run())

--- a/stacks/agents/app/tests/test_review.py
+++ b/stacks/agents/app/tests/test_review.py
@@ -8,8 +8,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from review import (
+    ReviewComment,
     ReviewOutput,
     _fetch_linked_issues_section,
+    _format_review_threads,
     _parse_linked_issues,
     _parse_review_file,
 )
@@ -214,3 +216,23 @@ class TestFetchLinkedIssuesSection:
         }
         result = asyncio.run(_fetch_linked_issues_section("owner/repo", "Fixes #10"))
         assert "### #10: Legit issue" in result
+
+
+class TestFormatReviewThreads:
+    def test_formats_single_comment(self):
+        comments = [ReviewComment(path="main.py", line=10, body="Bug here")]
+        result = _format_review_threads(comments)
+        assert result == "- **main.py:10**\n  Bug here"
+
+    def test_formats_multiple_comments(self):
+        comments = [
+            ReviewComment(path="a.py", line=1, body="First issue"),
+            ReviewComment(path="b.py", line=42, body="Second issue"),
+        ]
+        result = _format_review_threads(comments)
+        assert "- **a.py:1**" in result
+        assert "- **b.py:42**" in result
+        assert result.count("- **") == 2
+
+    def test_returns_empty_for_no_comments(self):
+        assert _format_review_threads([]) == ""


### PR DESCRIPTION
## Problem

GitHub downgrades `REQUEST_CHANGES` to `COMMENT` on self-PRs (bot's own PRs). COMMENT reviews don't create resolvable threads, so `get_unresolved_threads()` returns empty. This broke the fix loop — it would enter based on `original_event` but immediately exit with `partial` status because there were no threads to fix.

Additionally, on re-review rounds for self-PRs, the `PREVIOUS_REVIEW_SECTION` was always empty (no threads to find via GraphQL), so the reviewer had no context about what was previously flagged.

## Solution

**Return review findings directly** — `review_pr()` now returns a `review_threads` string (formatted from the inline comments it just posted) in its result dict. `implement_issue()` uses these directly instead of round-tripping through the GraphQL threads API.

**Thread context across rounds** — Previous round's findings are passed back into the next `review_pr()` call via a `previous_comments` parameter, so re-reviews have full context of what was flagged — even on self-PRs where `get_unresolved_threads()` returns empty.

## Changes

- **review.py**: Add `_format_review_threads()` helper, `previous_comments` param on `review_pr()`, fallback logic when `get_unresolved_threads()` is empty, return `review_threads` in result
- **implement.py**: Remove `get_unresolved_threads` dependency, use returned `review_threads` for fix prompts, thread `previous_review_threads` across loop iterations
- **Tests**: 96 passing (3 new — format helper, no-threads partial, previous_comments threading verification)