### PR TITLE
feat: single-cycle implement → review → fix → merge

### DIFF
--- a/.github/skills/bot-implement/SKILL.md
+++ b/.github/skills/bot-implement/SKILL.md
@@ -31,9 +31,11 @@ You are implementing a GitHub issue. The issue details are provided in the promp
 - Prefer modifying existing tests over creating new test files
 - If you add a new module, add a corresponding test file
 
-## The Review Cycle
+## The Review
 
-After you finish, an automated review bot will review your changes. It checks for bugs, security issues, breaking changes, and operational risk. Each review round costs time and tokens — **aim for zero blockers on the first review.**
+After you finish, a single review round checks for bugs, security issues, breaking changes, and operational risk. If issues are found, you get **one fix attempt** — then the PR auto-merges. There is no re-review after the fix.
+
+Because there's only one cycle (implement → review → fix → merge), **aim for zero blockers on the first review.** Self-review thoroughly before finishing.
 
 ### Pre-completion checklist
 

--- a/.github/skills/bot-implement/SKILL.md
+++ b/.github/skills/bot-implement/SKILL.md
@@ -33,9 +33,9 @@ You are implementing a GitHub issue. The issue details are provided in the promp
 
 ## The Review
 
-After you finish, a single review round checks for bugs, security issues, breaking changes, and operational risk. If issues are found, you get **one fix attempt** — then the PR auto-merges. There is no re-review after the fix.
+After you finish, there are up to 2 review rounds that check for bugs, security issues, breaking changes, and operational risk. If the review requests changes, you get a fix attempt — then a second review may follow. After the final fix, the PR auto-merges.
 
-Because there's only one cycle (implement → review → fix → merge), **aim for zero blockers on the first review.** Self-review thoroughly before finishing.
+Because the review cycle is capped at 2 rounds (review → fix → review → fix → merge), **aim for zero blockers on the first review.** Self-review thoroughly before finishing.
 
 ### Pre-completion checklist
 

--- a/.github/skills/bot-review/SKILL.md
+++ b/.github/skills/bot-review/SKILL.md
@@ -26,7 +26,7 @@ Review for:
 - **Report root causes, not symptoms.** When you find a bug, ask: what's the underlying pattern, and where else does it appear? Report the class of issue with ALL affected locations in a single comment. If you'd file the same finding against 5 different lines, that's one finding with 5 locations, not 5 findings.
 - **Assess blast radius.** For each finding, think beyond the immediate line. What's the worst case? How many codepaths are affected? Does this interact with other systems (CI, deploy, auth)? A "small" bug in a hot path is worse than a "big" bug in dead code.
 - **Think about implications.** If you recommend "this should raise instead of log", also flag what happens to callers when it raises. Don't create a fix that introduces a new bug.
-- **Front-load everything.** There is only one review round — no re-review after fixes. Surface ALL issues in a single pass, including second-order effects of your own recommendations. If you miss something, it ships.
+- **Front-load everything.** There are at most 2 review rounds. Surface ALL issues in a single pass, including second-order effects of your own recommendations. Anything you miss may ship.
 
 ## Severity Levels
 

--- a/.github/skills/bot-review/SKILL.md
+++ b/.github/skills/bot-review/SKILL.md
@@ -26,7 +26,7 @@ Review for:
 - **Report root causes, not symptoms.** When you find a bug, ask: what's the underlying pattern, and where else does it appear? Report the class of issue with ALL affected locations in a single comment. If you'd file the same finding against 5 different lines, that's one finding with 5 locations, not 5 findings.
 - **Assess blast radius.** For each finding, think beyond the immediate line. What's the worst case? How many codepaths are affected? Does this interact with other systems (CI, deploy, auth)? A "small" bug in a hot path is worse than a "big" bug in dead code.
 - **Think about implications.** If you recommend "this should raise instead of log", also flag what happens to callers when it raises. Don't create a fix that introduces a new bug.
-- **Front-load everything.** Aim for one review round, not three. Surface all issues — including second-order effects of your own recommendations — in a single pass.
+- **Front-load everything.** There is only one review round — no re-review after fixes. Surface ALL issues in a single pass, including second-order effects of your own recommendations. If you miss something, it ships.
 
 ## Severity Levels
 

--- a/docs/decisions/009-single-cycle-review.md
+++ b/docs/decisions/009-single-cycle-review.md
@@ -1,7 +1,7 @@
-# ADR-009: Single-Cycle Review in the Implement Lifecycle
+# ADR-009: Capped Review Cycle in the Implement Lifecycle
 
 **Date:** 2026-04-12
-**Status:** Accepted
+**Status:** Accepted (updated from single-cycle to 2-round cap)
 
 ## Context
 
@@ -43,13 +43,12 @@ instability instead of damping it.
 ### B. Single cycle: implement → review → fix → merge
 
 - Pros: Predictable cost (2–3 premium requests). Forces the reviewer to
-  front-load all findings. Forces the implementer to get it right in one pass.
-  Eliminates the contradictory-feedback failure mode.
+  front-load all findings. Eliminates the contradictory-feedback failure mode.
 - Cons: Real bugs found in the fix round won't be caught by a re-review. The
-  fix itself could introduce regressions.
-- **Verdict:** Accepted. The fix-round regression risk is mitigated by the
-  implementer's self-review checklist and `mise run ci`. The cost of missed
-  bugs is lower than the cost of non-convergent loops.
+  fix itself could introduce regressions. One round often isn't enough — the
+  reviewer catches real bugs that only surface after the first fix.
+- **Verdict:** Rejected (initially accepted, then revised). One round turned out
+  to be too aggressive — fix-round regressions shipped unchecked.
 
 ### C. Advisory-only review (no fix round)
 
@@ -59,14 +58,32 @@ instability instead of damping it.
 - **Verdict:** Rejected. One fix round is worth the cost. Zero is wasteful of
   good feedback.
 
+### D. Capped at 2 rounds: implement → review → fix → review → fix → merge
+
+- Pros: Catches fix-round regressions without unlimited looping. The second
+  review has full memory (session resume + prior threads). 2 rounds hit the
+  sweet spot from PR #76 data: rounds 1–4 found real bugs, divergence started
+  at round 5. With session resume providing memory, 2 rounds should capture
+  most value without the contradiction spiral.
+- Cons: Costs 1–2 more premium requests than single-cycle. Still possible for
+  the reviewer to contradict itself, but the cap prevents runaway loops.
+- **Verdict:** Accepted. 2 rounds capture the value of re-reviewing fixes
+  without the unbounded divergence of the original multi-round loop.
+
 ## Decision
 
-The implement lifecycle runs exactly one cycle:
+The implement lifecycle runs up to 2 review/fix cycles:
 
 1. **Implement** — Copilot CLI writes the code
-2. **Review** — single round, catches catastrophic bugs
-3. **Fix** — one pass if the review requested changes (no re-review)
-4. **Merge** — auto-merge via GitHub API
+2. **Review round 1** — catches bugs, security issues, breaking changes
+3. **Fix round 1** — if the review requested changes
+4. **Review round 2** — catches regressions from the fix (if round 1 had fixes)
+5. **Fix round 2** — if round 2 requests changes (final fix, no re-review)
+6. **Merge** — auto-merge via GitHub API
+
+If any review approves or errors out, the loop breaks early and proceeds to
+merge. If a fix produces no changes, the loop breaks. The cap prevents the
+contradiction spiral observed in PR #76 rounds 5–7.
 
 The review is mandatory but advisory in the sense that review failure doesn't
 block merge. If the review errors out (API failure, timeout), the lifecycle
@@ -74,24 +91,25 @@ proceeds to merge. If the review requests changes but provides no inline
 findings or the session can't be resumed, the lifecycle skips the fix and
 merges anyway.
 
-Both skills (`bot-review`, `bot-implement`) are updated to make the single-cycle
-contract explicit. The reviewer knows there's one shot — it must front-load
-everything.
+Both the reviewer and implementer sessions resume across rounds — the reviewer
+sees its own prior comments (via session resume + unresolved threads), and the
+implementer has full conversation history for context-aware fixes.
 
 ## Known Risks
 
-- **Fix-round regressions ship uncaught.** The fix could introduce new bugs
-  that a re-review would have caught. Mitigated by: the implementer's
-  self-review checklist, `mise run ci`, and the fact that a human can still
-  `/review` the PR manually before or after merge.
-- **Reviewer may not front-load.** Despite the skill saying "one round only,"
+- **Round 2 contradiction.** The reviewer may still contradict round 1 findings
+  in round 2. Mitigated by: session resume giving the reviewer memory of what
+  it said, and the hard cap preventing a spiral.
+- **Cost increase.** 2 rounds costs 1–2 more premium requests than single-cycle.
+  Acceptable given the bug-catching value demonstrated by PR #76 rounds 1–4.
+- **Reviewer may not front-load.** Despite the skill saying "at most 2 rounds,"
   the model may still hold back findings. This is a model behaviour issue, not
   an architecture issue — monitor and adjust the skill prompt if needed.
 
 ## References
 
-- PR #76: 8-round review cycle that motivated this change
-- PR #78: Implementation of single-cycle flow
-- `stacks/agents/app/implement.py`: Lifecycle orchestrator
-- `.github/skills/bot-review/SKILL.md`: Review skill with single-round language
-- `.github/skills/bot-implement/SKILL.md`: Implement skill with one-cycle contract
+- PR #76: 8-round review cycle that motivated the original single-cycle decision
+- PR #78: Implementation of capped review cycle
+- `stacks/agents/app/implement.py`: Lifecycle orchestrator (MAX_REVIEW_ROUNDS)
+- `.github/skills/bot-review/SKILL.md`: Review skill with 2-round language
+- `.github/skills/bot-implement/SKILL.md`: Implement skill with capped-cycle contract

--- a/docs/decisions/009-single-cycle-review.md
+++ b/docs/decisions/009-single-cycle-review.md
@@ -1,0 +1,97 @@
+# ADR-009: Single-Cycle Review in the Implement Lifecycle
+
+**Date:** 2026-04-12
+**Status:** Accepted
+
+## Context
+
+The implement lifecycle originally ran a multi-round review/fix loop: after the
+initial implementation, the bot reviewed the PR, requested changes, the
+implementer fixed them, the bot re-reviewed, and so on up to
+`MAX_FIX_ITERATIONS` (3 fix rounds, 4 total review rounds).
+
+PR #76 exposed the failure mode. Over 8 review rounds (4 from the bot
+implementer, 4 from manual `/review` triggers), the reviewer:
+
+- **Rounds 1–4:** Found 5 genuine bugs — over-strict mergeability gating,
+  premature mergeability cutoff, unpaginated check-run scan, unhandled API
+  errors, and a leaked runtime artifact. Each was a real issue introduced or
+  exposed by the previous fix. This was valuable.
+- **Rounds 5–7:** Flip-flopped on a design question (should CI status gate
+  merging?). Round 5 said "don't treat CI as authoritative," round 7 said "CI
+  failure IS terminal — stop immediately." These rounds consumed tokens and time
+  without converging.
+
+The root cause is that LLM-powered reviewers are good at spotting concrete bugs
+but bad at holding stable design opinions across rounds. Each fix changes
+100–250 lines of code, creating new surface area for the reviewer to find new
+(often contradictory) opinions about. The review/fix loop amplifies this
+instability instead of damping it.
+
+## Options Considered
+
+### A. Keep multi-round loop (status quo)
+
+- Pros: More chances to catch bugs; fixes can be verified by re-review.
+- Cons: Doesn't converge — reviewer contradicts itself across rounds. 53-minute
+  run times, 8+ premium requests per issue. Each fix introduces new code surface
+  that triggers new findings. Drip-feeding despite skill instructions to
+  front-load.
+- **Verdict:** Rejected. The theoretical benefit of convergence doesn't hold in
+  practice. The loop amplifies instability.
+
+### B. Single cycle: implement → review → fix → merge
+
+- Pros: Predictable cost (2–3 premium requests). Forces the reviewer to
+  front-load all findings. Forces the implementer to get it right in one pass.
+  Eliminates the contradictory-feedback failure mode.
+- Cons: Real bugs found in the fix round won't be caught by a re-review. The
+  fix itself could introduce regressions.
+- **Verdict:** Accepted. The fix-round regression risk is mitigated by the
+  implementer's self-review checklist and `mise run ci`. The cost of missed
+  bugs is lower than the cost of non-convergent loops.
+
+### C. Advisory-only review (no fix round)
+
+- Pros: Simplest. Fastest.
+- Cons: Throws away the value of rounds 1–4 from PR #76 — the reviewer did
+  catch real bugs that the fix round addressed.
+- **Verdict:** Rejected. One fix round is worth the cost. Zero is wasteful of
+  good feedback.
+
+## Decision
+
+The implement lifecycle runs exactly one cycle:
+
+1. **Implement** — Copilot CLI writes the code
+2. **Review** — single round, catches catastrophic bugs
+3. **Fix** — one pass if the review requested changes (no re-review)
+4. **Merge** — auto-merge via GitHub API
+
+The review is mandatory but advisory in the sense that review failure doesn't
+block merge. If the review errors out (API failure, timeout), the lifecycle
+proceeds to merge. If the review requests changes but provides no inline
+findings or the session can't be resumed, the lifecycle skips the fix and
+merges anyway.
+
+Both skills (`bot-review`, `bot-implement`) are updated to make the single-cycle
+contract explicit. The reviewer knows there's one shot — it must front-load
+everything.
+
+## Known Risks
+
+- **Fix-round regressions ship uncaught.** The fix could introduce new bugs
+  that a re-review would have caught. Mitigated by: the implementer's
+  self-review checklist, `mise run ci`, and the fact that a human can still
+  `/review` the PR manually before or after merge.
+- **Reviewer may not front-load.** Despite the skill saying "one round only,"
+  the model may still hold back findings. This is a model behaviour issue, not
+  an architecture issue — monitor and adjust the skill prompt if needed.
+
+## References
+
+- PR #76: 8-round review cycle that motivated this change
+- PR #78: Implementation of single-cycle flow
+- `stacks/agents/app/implement.py`: Lifecycle orchestrator
+- `.github/skills/bot-review/SKILL.md`: Review skill with single-round language
+- `.github/skills/bot-implement/SKILL.md`: Implement skill with one-cycle contract

--- a/stacks/agents/app/github.py
+++ b/stacks/agents/app/github.py
@@ -187,7 +187,7 @@ async def get_unresolved_threads(repo: str, pr_number: int) -> str:
 
         lines = []
         for t in threads:
-            if t["isResolved"] or t["isOutdated"]:
+            if t["isResolved"]:
                 continue
             comments = t.get("comments", {}).get("nodes", [])
             if not comments:

--- a/stacks/agents/app/implement.py
+++ b/stacks/agents/app/implement.py
@@ -435,8 +435,25 @@ async def implement_issue(
             review_threads = review_result.get("review_threads", "")
             if not review_threads or not implement_session_id:
                 reason = "no session ID" if not implement_session_id else "no inline findings"
-                logger.warning("Skipping fix (%s) — proceeding to merge", reason)
-                break
+                logger.error(
+                    "Cannot fix review findings (%s) for %s#%d — needs manual attention",
+                    reason,
+                    repo,
+                    issue_number,
+                )
+                lifecycle_result = _lifecycle_result(
+                    status="partial",
+                    pr_number=pr_number,
+                    pr_url=pr_url,
+                    commit_sha=sha,
+                    review_rounds=review_rounds,
+                    start=start,
+                    premium_requests=total_premium_requests,
+                    session_id=implement_session_id,
+                    error=f"Review requested changes but fix cannot run ({reason})"
+                    " — needs manual attention",
+                )
+                return lifecycle_result
 
             is_final_round = round_num == MAX_REVIEW_ROUNDS
             round_context = (
@@ -488,10 +505,26 @@ async def implement_issue(
                 )
             except RuntimeError as exc:
                 if "No changes to commit" in str(exc):
-                    logger.warning(
-                        "Fix round %d produced no changes — proceeding to merge", round_num
+                    logger.error(
+                        "Fix round %d produced no changes for %s#%d"
+                        " — review found issues but nothing was fixed",
+                        round_num,
+                        repo,
+                        issue_number,
                     )
-                    break
+                    lifecycle_result = _lifecycle_result(
+                        status="partial",
+                        pr_number=pr_number,
+                        pr_url=pr_url,
+                        commit_sha=sha,
+                        review_rounds=review_rounds,
+                        start=start,
+                        premium_requests=total_premium_requests,
+                        session_id=implement_session_id,
+                        error=f"Fix round {round_num} produced no changes"
+                        " — review issues unresolved, needs manual attention",
+                    )
+                    return lifecycle_result
                 else:
                     lifecycle_result = _lifecycle_result(
                         status="failed",

--- a/stacks/agents/app/implement.py
+++ b/stacks/agents/app/implement.py
@@ -24,14 +24,12 @@ from review import review_pr
 
 logger = logging.getLogger(__name__)
 
-MAX_FIX_ITERATIONS = 3
 MERGE_READY_TIMEOUT_SECONDS = 15 * 60
 MERGE_POLL_INTERVAL_SECONDS = 10
 
 STATUS_EMOJI = {
     "complete": "✅",
     "partial": "⚠️",
-    "max_iterations": "⚠️",
     "failed": "❌",
 }
 
@@ -42,8 +40,7 @@ def _format_stats_comment(result: dict) -> str:
     emoji = STATUS_EMOJI.get(status, "❓")
     lines = [f"{emoji} **Implementation {status}**"]
 
-    rounds = result.get("review_rounds", 0)
-    lines.append(f"- Review rounds: {rounds}/{MAX_FIX_ITERATIONS + 1}")
+    lines.append("- Review: single round (advisory)")
 
     premium = result.get("premium_requests", 0)
     if premium:
@@ -88,7 +85,7 @@ Fix all reported problems. Use the skill `bot-implement` for guidance.
 
 ## After Fixing
 
-Each fix round costs time and tokens — aim for zero new issues.
+This is your only fix round — there is no re-review. Get it right.
 
 1. **Self-review your fix for second-order effects.** If you changed control flow, \
 error handling, or added new API calls, audit the surrounding code for issues \
@@ -392,207 +389,105 @@ async def implement_issue(
         pr_number = pr["number"]
         pr_url = pr["html_url"]
 
-        # Review+fix loop — review first, then fix if needed.
-        # We allow MAX_FIX_ITERATIONS fix attempts. Each fix is followed by a
-        # re-review, so we run up to MAX_FIX_ITERATIONS + 1 review rounds
-        # (initial + one after each fix).
-        previous_review_threads = ""
-        for review_round in range(MAX_FIX_ITERATIONS + 1):
+        # Single cycle: review → fix (if needed) → merge. No re-review.
+        try:
+            review_result = await review_pr(
+                repo=repo,
+                pr_number=pr_number,
+                model=model,
+                reasoning_effort=reasoning_effort,
+            )
+            total_premium_requests += review_result.get("premium_requests", 0)
+            original_event = review_result.get("original_event", "COMMENT")
             logger.info(
-                "Review round %d/%d for %s#%d (PR #%d)",
-                review_round + 1,
-                MAX_FIX_ITERATIONS + 1,
+                "Review complete (%s) for %s#%d (PR #%d)",
+                original_event,
                 repo,
                 issue_number,
                 pr_number,
             )
-
-            try:
-                review_result = await review_pr(
-                    repo=repo,
-                    pr_number=pr_number,
-                    model=model,
-                    reasoning_effort=reasoning_effort,
-                    previous_comments=previous_review_threads,
-                )
-            except TaskError as exc:
-                total_premium_requests += exc.premium_requests
-                logger.warning("Review failed on round %d: %s", review_round + 1, exc)
-                lifecycle_result = _lifecycle_result(
-                    status="partial",
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    commit_sha=sha,
-                    review_rounds=review_round + 1,
-                    start=start,
-                    premium_requests=total_premium_requests,
-                    session_id=implement_session_id,
-                    error=f"Review failed on round {review_round + 1}: {exc}",
-                )
-                return lifecycle_result
-
-            total_premium_requests += review_result.get("premium_requests", 0)
-            original_event = review_result.get("original_event", "COMMENT")
-
-            if original_event != "REQUEST_CHANGES":
-                logger.info(
-                    "Review passed (%s) on round %d for %s#%d",
-                    original_event,
-                    review_round + 1,
-                    repo,
-                    issue_number,
-                )
-                lifecycle_result = await _merge_when_eligible(
-                    repo=repo,
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    branch_name=branch_name,
-                    commit_sha=sha,
-                    review_rounds=review_round + 1,
-                    start=start,
-                    premium_requests=total_premium_requests,
-                    session_id=implement_session_id,
-                )
-                return lifecycle_result
-
-            # REQUEST_CHANGES — check if we have fix attempts remaining
-            if review_round == MAX_FIX_ITERATIONS:
-                # Final review after last fix still found issues
-                break
-
-            if not implement_session_id:
-                logger.warning(
-                    "Cannot resume session — no session ID captured. Stopping after review."
-                )
-                lifecycle_result = _lifecycle_result(
-                    status="partial",
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    commit_sha=sha,
-                    review_rounds=review_round + 1,
-                    start=start,
-                    premium_requests=total_premium_requests,
-                    session_id=implement_session_id,
-                    error="Review requested changes but session resumption unavailable",
-                )
-                return lifecycle_result
-
-            review_threads = review_result.get("review_threads", "")
-            if not review_threads:
-                logger.warning("REQUEST_CHANGES but no inline findings to fix")
-                lifecycle_result = _lifecycle_result(
-                    status="partial",
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    commit_sha=sha,
-                    review_rounds=review_round + 1,
-                    start=start,
-                    premium_requests=total_premium_requests,
-                    session_id=implement_session_id,
-                    error="Review requested changes but no inline comments "
-                    "were posted — needs manual attention",
-                )
-                return lifecycle_result
-
-            fix_prompt = FIX_PROMPT_TEMPLATE.format(
-                issue_number=issue_number,
-                threads=review_threads,
+        except TaskError as exc:
+            total_premium_requests += exc.premium_requests
+            logger.warning(
+                "Review failed for %s#%d: %s — proceeding to merge",
+                repo,
+                issue_number,
+                exc,
             )
+            original_event = "ERROR"
 
-            try:
-                fix_result = await run_copilot(
-                    worktree_path,
-                    fix_prompt,
-                    model=model,
-                    effort=reasoning_effort,
-                    session_id=implement_session_id,
+        # Fix pass — if the review requested changes, attempt one fix round.
+        if original_event == "REQUEST_CHANGES":
+            review_threads = review_result.get("review_threads", "")
+            if review_threads and implement_session_id:
+                fix_prompt = FIX_PROMPT_TEMPLATE.format(
+                    issue_number=issue_number,
+                    threads=review_threads,
                 )
-                total_premium_requests += fix_result.total_premium_requests
-                if fix_result.session_id:
-                    implement_session_id = fix_result.session_id
-            except TaskError as exc:
-                total_premium_requests += exc.premium_requests
-                lifecycle_result = _lifecycle_result(
-                    status="failed",
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    commit_sha=sha,
-                    review_rounds=review_round + 1,
-                    start=start,
-                    premium_requests=total_premium_requests,
-                    session_id=implement_session_id,
-                    error=f"Fix failed on round {review_round + 1}: {exc}",
-                )
-                raise TaskError(
-                    f"Fix failed on round {review_round + 1}: {exc}",
-                    premium_requests=total_premium_requests,
-                ) from exc
-
-            try:
-                sha = await commit_and_push(
-                    worktree_path,
-                    message=f"fix: address review feedback on #{issue_number} "
-                    f"(round {review_round + 1})",
-                    token=token,
-                    repo=repo,
-                    branch=branch_name,
-                )
-                previous_review_threads = review_threads
-            except RuntimeError as exc:
-                if "No changes to commit" in str(exc):
-                    logger.warning(
-                        "No changes after fix round %d — needs manual attention",
-                        review_round + 1,
+                try:
+                    fix_result = await run_copilot(
+                        worktree_path,
+                        fix_prompt,
+                        model=model,
+                        effort=reasoning_effort,
+                        session_id=implement_session_id,
                     )
+                    total_premium_requests += fix_result.total_premium_requests
+                    if fix_result.session_id:
+                        implement_session_id = fix_result.session_id
+                except TaskError as exc:
+                    total_premium_requests += exc.premium_requests
                     lifecycle_result = _lifecycle_result(
-                        status="partial",
+                        status="failed",
                         pr_number=pr_number,
                         pr_url=pr_url,
                         commit_sha=sha,
-                        review_rounds=review_round + 1,
+                        review_rounds=1,
                         start=start,
                         premium_requests=total_premium_requests,
                         session_id=implement_session_id,
-                        error="Fix produced no changes — remaining findings need manual attention",
+                        error=f"Fix failed: {exc}",
                     )
-                    return lifecycle_result
-                lifecycle_result = _lifecycle_result(
-                    status="failed",
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    commit_sha=sha,
-                    review_rounds=review_round + 1,
-                    start=start,
-                    premium_requests=total_premium_requests,
-                    session_id=implement_session_id,
-                    error=f"Commit/push failed on round {review_round + 1}: {exc}",
-                )
-                raise TaskError(str(exc), premium_requests=total_premium_requests) from exc
-            except Exception as exc:
-                lifecycle_result = _lifecycle_result(
-                    status="failed",
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    commit_sha=sha,
-                    review_rounds=review_round + 1,
-                    start=start,
-                    premium_requests=total_premium_requests,
-                    session_id=implement_session_id,
-                    error=f"Commit/push failed on round {review_round + 1}: {exc}",
-                )
-                raise TaskError(str(exc), premium_requests=total_premium_requests) from exc
+                    raise TaskError(
+                        f"Fix failed: {exc}",
+                        premium_requests=total_premium_requests,
+                    ) from exc
 
-        # Exhausted all fix iterations — last review still requested changes
-        logger.warning(
-            "Hit max fix iterations (%d) for %s#%d", MAX_FIX_ITERATIONS, repo, issue_number
-        )
+                try:
+                    sha = await commit_and_push(
+                        worktree_path,
+                        message=f"fix: address review feedback on #{issue_number}",
+                        token=token,
+                        repo=repo,
+                        branch=branch_name,
+                    )
+                except RuntimeError as exc:
+                    if "No changes to commit" in str(exc):
+                        logger.warning("Fix produced no changes — proceeding to merge")
+                    else:
+                        lifecycle_result = _lifecycle_result(
+                            status="failed",
+                            pr_number=pr_number,
+                            pr_url=pr_url,
+                            commit_sha=sha,
+                            review_rounds=1,
+                            start=start,
+                            premium_requests=total_premium_requests,
+                            session_id=implement_session_id,
+                            error=f"Commit/push failed: {exc}",
+                        )
+                        raise TaskError(str(exc), premium_requests=total_premium_requests) from exc
+            else:
+                reason = "no session ID" if not implement_session_id else "no inline findings"
+                logger.warning("Skipping fix (%s) — proceeding to merge", reason)
 
-        lifecycle_result = _lifecycle_result(
-            status="max_iterations",
+        lifecycle_result = await _merge_when_eligible(
+            repo=repo,
             pr_number=pr_number,
             pr_url=pr_url,
+            branch_name=branch_name,
             commit_sha=sha,
-            review_rounds=MAX_FIX_ITERATIONS + 1,
+            review_rounds=1,
             start=start,
             premium_requests=total_premium_requests,
             session_id=implement_session_id,

--- a/stacks/agents/app/implement.py
+++ b/stacks/agents/app/implement.py
@@ -24,6 +24,7 @@ from review import review_pr
 
 logger = logging.getLogger(__name__)
 
+MAX_REVIEW_ROUNDS = 2
 MERGE_READY_TIMEOUT_SECONDS = 15 * 60
 MERGE_POLL_INTERVAL_SECONDS = 10
 
@@ -40,7 +41,8 @@ def _format_stats_comment(result: dict) -> str:
     emoji = STATUS_EMOJI.get(status, "❓")
     lines = [f"{emoji} **Implementation {status}**"]
 
-    lines.append("- Review: single round (advisory)")
+    rounds = result.get("review_rounds", 0)
+    lines.append(f"- Review: {rounds} round{'s' if rounds != 1 else ''} (max {MAX_REVIEW_ROUNDS})")
 
     premium = result.get("premium_requests", 0)
     if premium:
@@ -85,7 +87,7 @@ Fix all reported problems. Use the skill `bot-implement` for guidance.
 
 ## After Fixing
 
-This is your only fix round — there is no re-review. Get it right.
+{round_context}
 
 1. **Self-review your fix for second-order effects.** If you changed control flow, \
 error handling, or added new API calls, audit the surrounding code for issues \
@@ -388,98 +390,121 @@ async def implement_issue(
 
         pr_number = pr["number"]
         pr_url = pr["html_url"]
+        review_session_id: str | None = None
 
-        # Single cycle: review → fix (if needed) → merge. No re-review.
-        try:
-            review_result = await review_pr(
-                repo=repo,
-                pr_number=pr_number,
-                model=model,
-                reasoning_effort=reasoning_effort,
-            )
-            total_premium_requests += review_result.get("premium_requests", 0)
-            original_event = review_result.get("original_event", "COMMENT")
-            logger.info(
-                "Review complete (%s) for %s#%d (PR #%d)",
-                original_event,
-                repo,
-                issue_number,
-                pr_number,
-            )
-        except TaskError as exc:
-            total_premium_requests += exc.premium_requests
-            logger.warning(
-                "Review failed for %s#%d: %s — proceeding to merge",
-                repo,
-                issue_number,
-                exc,
-            )
-            original_event = "ERROR"
-
-        # Fix pass — if the review requested changes, attempt one fix round.
-        if original_event == "REQUEST_CHANGES":
-            review_threads = review_result.get("review_threads", "")
-            if review_threads and implement_session_id:
-                fix_prompt = FIX_PROMPT_TEMPLATE.format(
-                    issue_number=issue_number,
-                    threads=review_threads,
+        # Review/fix loop — up to MAX_REVIEW_ROUNDS rounds.
+        review_rounds = 0
+        for round_num in range(1, MAX_REVIEW_ROUNDS + 1):
+            try:
+                review_result = await review_pr(
+                    repo=repo,
+                    pr_number=pr_number,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                    session_id=review_session_id,
                 )
-                try:
-                    fix_result = await run_copilot(
-                        worktree_path,
-                        fix_prompt,
-                        model=model,
-                        effort=reasoning_effort,
-                        session_id=implement_session_id,
+                total_premium_requests += review_result.get("premium_requests", 0)
+                review_session_id = review_result.get("session_id")
+                original_event = review_result.get("original_event", "COMMENT")
+                review_rounds += 1
+                logger.info(
+                    "Review round %d/%d (%s) for %s#%d (PR #%d)",
+                    round_num,
+                    MAX_REVIEW_ROUNDS,
+                    original_event,
+                    repo,
+                    issue_number,
+                    pr_number,
+                )
+            except TaskError as exc:
+                total_premium_requests += exc.premium_requests
+                review_rounds += 1
+                logger.warning(
+                    "Review round %d failed for %s#%d: %s — proceeding to merge",
+                    round_num,
+                    repo,
+                    issue_number,
+                    exc,
+                )
+                break  # Review errored — skip fix, go to merge
+
+            if original_event != "REQUEST_CHANGES":
+                break  # Approved or commented — no fix needed
+
+            # Fix pass
+            review_threads = review_result.get("review_threads", "")
+            if not review_threads or not implement_session_id:
+                reason = "no session ID" if not implement_session_id else "no inline findings"
+                logger.warning("Skipping fix (%s) — proceeding to merge", reason)
+                break
+
+            is_final_round = round_num == MAX_REVIEW_ROUNDS
+            round_context = (
+                "This is your final fix round — there is no re-review after this. Get it right."
+                if is_final_round
+                else "After this fix, one more review round remains. Focus on correctness."
+            )
+            fix_prompt = FIX_PROMPT_TEMPLATE.format(
+                issue_number=issue_number,
+                threads=review_threads,
+                round_context=round_context,
+            )
+            try:
+                fix_result = await run_copilot(
+                    worktree_path,
+                    fix_prompt,
+                    model=model,
+                    effort=reasoning_effort,
+                    session_id=implement_session_id,
+                )
+                total_premium_requests += fix_result.total_premium_requests
+                if fix_result.session_id:
+                    implement_session_id = fix_result.session_id
+            except TaskError as exc:
+                total_premium_requests += exc.premium_requests
+                lifecycle_result = _lifecycle_result(
+                    status="failed",
+                    pr_number=pr_number,
+                    pr_url=pr_url,
+                    commit_sha=sha,
+                    review_rounds=review_rounds,
+                    start=start,
+                    premium_requests=total_premium_requests,
+                    session_id=implement_session_id,
+                    error=f"Fix round {round_num} failed: {exc}",
+                )
+                raise TaskError(
+                    f"Fix round {round_num} failed: {exc}",
+                    premium_requests=total_premium_requests,
+                ) from exc
+
+            try:
+                sha = await commit_and_push(
+                    worktree_path,
+                    message=f"fix: address review feedback (round {round_num}) on #{issue_number}",
+                    token=token,
+                    repo=repo,
+                    branch=branch_name,
+                )
+            except RuntimeError as exc:
+                if "No changes to commit" in str(exc):
+                    logger.warning(
+                        "Fix round %d produced no changes — proceeding to merge", round_num
                     )
-                    total_premium_requests += fix_result.total_premium_requests
-                    if fix_result.session_id:
-                        implement_session_id = fix_result.session_id
-                except TaskError as exc:
-                    total_premium_requests += exc.premium_requests
+                    break
+                else:
                     lifecycle_result = _lifecycle_result(
                         status="failed",
                         pr_number=pr_number,
                         pr_url=pr_url,
                         commit_sha=sha,
-                        review_rounds=1,
+                        review_rounds=review_rounds,
                         start=start,
                         premium_requests=total_premium_requests,
                         session_id=implement_session_id,
-                        error=f"Fix failed: {exc}",
+                        error=f"Commit/push failed: {exc}",
                     )
-                    raise TaskError(
-                        f"Fix failed: {exc}",
-                        premium_requests=total_premium_requests,
-                    ) from exc
-
-                try:
-                    sha = await commit_and_push(
-                        worktree_path,
-                        message=f"fix: address review feedback on #{issue_number}",
-                        token=token,
-                        repo=repo,
-                        branch=branch_name,
-                    )
-                except RuntimeError as exc:
-                    if "No changes to commit" in str(exc):
-                        logger.warning("Fix produced no changes — proceeding to merge")
-                    else:
-                        lifecycle_result = _lifecycle_result(
-                            status="failed",
-                            pr_number=pr_number,
-                            pr_url=pr_url,
-                            commit_sha=sha,
-                            review_rounds=1,
-                            start=start,
-                            premium_requests=total_premium_requests,
-                            session_id=implement_session_id,
-                            error=f"Commit/push failed: {exc}",
-                        )
-                        raise TaskError(str(exc), premium_requests=total_premium_requests) from exc
-            else:
-                reason = "no session ID" if not implement_session_id else "no inline findings"
-                logger.warning("Skipping fix (%s) — proceeding to merge", reason)
+                    raise TaskError(str(exc), premium_requests=total_premium_requests) from exc
 
         lifecycle_result = await _merge_when_eligible(
             repo=repo,
@@ -487,7 +512,7 @@ async def implement_issue(
             pr_url=pr_url,
             branch_name=branch_name,
             commit_sha=sha,
-            review_rounds=1,
+            review_rounds=review_rounds,
             start=start,
             premium_requests=total_premium_requests,
             session_id=implement_session_id,

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -113,6 +113,10 @@ async def handle_review(req: ReviewRequest, background_tasks: BackgroundTasks):
             content={"status": "already_in_progress", "pr_number": req.pr_number},
         )
 
+    prior_session_id = (
+        existing.get("session_id") if existing and existing["status"] != "in_progress" else None
+    )
+
     _review_status[key] = {"status": "in_progress", "repo": req.repo, "pr_number": req.pr_number}
 
     background_tasks.add_task(
@@ -121,6 +125,7 @@ async def handle_review(req: ReviewRequest, background_tasks: BackgroundTasks):
         pr_number=req.pr_number,
         model=model,
         reasoning_effort=effort,
+        session_id=prior_session_id,
     )
 
     return {"status": "accepted", "pr_number": req.pr_number}
@@ -193,7 +198,9 @@ async def get_implement_status(issue_number: int, repo: str = "") -> dict:
 # --- Background tasks ---
 
 
-async def _run_review(*, repo: str, pr_number: int, model: str, reasoning_effort: str) -> None:
+async def _run_review(
+    *, repo: str, pr_number: int, model: str, reasoning_effort: str, session_id: str | None = None
+) -> None:
     key = _review_key(repo, pr_number)
     status = "failed"
     premium_requests = 0
@@ -205,6 +212,7 @@ async def _run_review(*, repo: str, pr_number: int, model: str, reasoning_effort
             pr_number=pr_number,
             model=model,
             reasoning_effort=reasoning_effort,
+            session_id=session_id,
         )
         status = _task_status_label(result.get("status"))
         premium_requests = _premium_requests(result)

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -55,7 +55,7 @@ def _implement_key(repo: str, issue_number: int) -> str:
 def _task_status_label(status: object) -> str:
     if status == "failed":
         return "failed"
-    if status in ("partial", "max_iterations"):
+    if status == "partial":
         return "partial"
     return "complete"
 

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -237,6 +237,7 @@ async def review_pr(
     model: str = "gpt-5.4",
     reasoning_effort: str = "high",
     previous_comments: str = "",
+    session_id: str | None = None,
 ) -> dict:
     """Full review pipeline: worktree → Copilot CLI → read JSON → post review.
 
@@ -245,6 +246,9 @@ async def review_pr(
             fallback for PREVIOUS_REVIEW_SECTION when get_unresolved_threads()
             returns empty (e.g. self-PR where COMMENT reviews don't create
             resolvable threads).
+        session_id: Session ID from a prior review. When provided, the CLI
+            resumes the conversation so the reviewer has full memory of what
+            it said in previous rounds.
     """
     logger.info("Starting review for %s#%d (model=%s)", repo, pr_number, model)
     start = time.monotonic()
@@ -285,6 +289,7 @@ async def review_pr(
             prompt,
             model=model,
             effort=reasoning_effort,
+            session_id=session_id,
         )
 
         # Everything after run_copilot can fail — wrap in a single handler
@@ -382,6 +387,7 @@ async def review_pr(
             "models": result.models,
             "original_event": review_data.event,
             "review_threads": _format_review_threads(review_data.comments),
+            "session_id": result.session_id,
         }
 
     finally:

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -16,17 +16,19 @@ class TestImplementIssue:
     def _standard_mocks(
         self,
         *,
-        review_events: list[str],
+        review_event: str = "APPROVE",
         session_id: str | None = "sess-123",
         pr_sequence: list[dict] | None = None,
         ci_results: list[dict] | None = None,
         merge_result: dict | list[dict] | None = None,
+        review_threads: str = "",
     ):
         """Create the standard set of mocks for implement_issue tests.
 
         Args:
-            review_events: List of original_event values review_pr will return.
+            review_event: The original_event value review_pr will return.
             session_id: Session ID the CLI returns (None to test no-session path).
+            review_threads: Inline findings text for REQUEST_CHANGES reviews.
         """
         mock_cli_result = CLIResult(output="done", total_premium_requests=1, session_id=session_id)
         mock_fix_result = CLIResult(output="fixed", total_premium_requests=1, session_id=session_id)
@@ -65,16 +67,18 @@ class TestImplementIssue:
                 return_value=merge_result,
             )
 
-        review_results = [
-            {
-                "original_event": event,
-                "premium_requests": 1,
-                "review_threads": (
-                    "- **file.py:10**\n  bug here" if event == "REQUEST_CHANGES" else ""
-                ),
-            }
-            for event in review_events
-        ]
+        if review_event == "REQUEST_CHANGES" and not review_threads:
+            review_threads = "- **file.py:10**\n  bug here"
+        review_result = {
+            "original_event": review_event,
+            "premium_requests": 1,
+            "review_threads": review_threads,
+        }
+
+        # run_copilot: first call is implement, second (if any) is fix
+        copilot_side_effect = [mock_cli_result]
+        if review_event == "REQUEST_CHANGES":
+            copilot_side_effect.append(mock_fix_result)
 
         return [
             patch("implement.get_token", new_callable=AsyncMock, return_value="token"),
@@ -87,14 +91,14 @@ class TestImplementIssue:
             patch(
                 "implement.run_copilot",
                 new_callable=AsyncMock,
-                side_effect=[mock_cli_result] + [mock_fix_result] * len(review_events),
+                side_effect=copilot_side_effect,
             ),
             patch("implement.commit_and_push", new_callable=AsyncMock, return_value="abc123"),
             patch("implement.create_pull_request", new_callable=AsyncMock, return_value=mock_pr),
             patch(
                 "implement.review_pr",
                 new_callable=AsyncMock,
-                side_effect=review_results,
+                return_value=review_result,
             ),
             patch(
                 "implement.get_pr",
@@ -124,8 +128,8 @@ class TestImplementIssue:
         return asyncio.run(run())
 
     def test_creates_pr_and_review_approves(self):
-        """Happy path: implement → PR → review approves on first pass."""
-        result = self._run_with_mocks(self._standard_mocks(review_events=["APPROVE"]))
+        """Happy path: implement → PR → review approves → merge."""
+        result = self._run_with_mocks(self._standard_mocks(review_event="APPROVE"))
         assert result["status"] == "complete"
         assert result["merged"] is True
         assert result["merge_commit_sha"] == "merge123"
@@ -134,7 +138,7 @@ class TestImplementIssue:
 
     def test_pr_body_uses_auto_close_keyword(self):
         """Generated PR body uses a GitHub auto-closing keyword."""
-        mocks = self._standard_mocks(review_events=["APPROVE"])
+        mocks = self._standard_mocks(review_event="APPROVE")
 
         async def run():
             with ExitStack() as stack:
@@ -148,19 +152,75 @@ class TestImplementIssue:
 
         asyncio.run(run())
 
-    def test_review_fix_loop_converges(self):
-        """Review requests changes, fix succeeds, second review approves."""
+    def test_review_requests_changes_then_fixes_and_merges(self):
+        """Single cycle: review requests changes → fix → merge (no re-review)."""
+        mocks = self._standard_mocks(review_event="REQUEST_CHANGES")
+
+        async def run():
+            with ExitStack() as stack:
+                entered = [stack.enter_context(m) for m in mocks]
+                copilot_mock = entered[3]
+                commit_mock = entered[4]
+                review_mock = entered[6]
+                from implement import implement_issue
+
+                result = await implement_issue(repo="user/repo", issue_number=42)
+
+                # Review called once (no re-review)
+                review_mock.assert_awaited_once()
+                # Copilot called twice: implement + fix
+                assert copilot_mock.await_count == 2
+                # Commit called twice: initial + fix
+                assert commit_mock.await_count == 2
+                assert result["status"] == "complete"
+                assert result["merged"] is True
+
+        asyncio.run(run())
+
+    def test_review_failure_still_merges(self):
+        """Review errors don't block — lifecycle proceeds to merge."""
+        from copilot import TaskError
+
+        mocks = self._standard_mocks(review_event="APPROVE")
+        mocks[6] = patch(
+            "implement.review_pr",
+            new_callable=AsyncMock,
+            side_effect=TaskError("review exploded", premium_requests=1),
+        )
+
+        result = self._run_with_mocks(mocks)
+        assert result["status"] == "complete"
+        assert result["merged"] is True
+
+    def test_no_session_skips_fix_and_merges(self):
+        """Without session ID, fix is skipped but merge still proceeds."""
         result = self._run_with_mocks(
-            self._standard_mocks(review_events=["REQUEST_CHANGES", "APPROVE"])
+            self._standard_mocks(review_event="REQUEST_CHANGES", session_id=None)
         )
         assert result["status"] == "complete"
         assert result["merged"] is True
-        assert result["review_rounds"] == 2
+
+    def test_no_threads_skips_fix_and_merges(self):
+        """REQUEST_CHANGES with no inline findings skips fix, still merges."""
+        mocks = self._standard_mocks(review_event="REQUEST_CHANGES", review_threads="")
+        # Override review to return empty threads
+        mocks[6] = patch(
+            "implement.review_pr",
+            new_callable=AsyncMock,
+            return_value={
+                "original_event": "REQUEST_CHANGES",
+                "premium_requests": 1,
+                "review_threads": "",
+            },
+        )
+        result = self._run_with_mocks(mocks)
+        assert result["status"] == "complete"
+        assert result["merged"] is True
 
     def test_waits_for_pending_ci_before_merging(self):
         """Pending CI is polled until checks pass and the PR can be merged."""
         mocks = self._standard_mocks(
-            review_events=["APPROVE"],
+            review_event="APPROVE",
             pr_sequence=[
                 {
                     "state": "open",
@@ -212,7 +272,7 @@ class TestImplementIssue:
     def test_waits_when_branch_protection_blocks_merge_until_ci_finishes(self):
         """Protected branches can report blocked/unmergeable until required checks finish."""
         mocks = self._standard_mocks(
-            review_events=["APPROVE"],
+            review_event="APPROVE",
             pr_sequence=[
                 {
                     "state": "open",
@@ -265,7 +325,7 @@ class TestImplementIssue:
         """A mergeable non-clean state should not block a merge GitHub allows."""
         result = self._run_with_mocks(
             self._standard_mocks(
-                review_events=["APPROVE"],
+                review_event="APPROVE",
                 pr_sequence=[
                     {
                         "state": "open",
@@ -286,7 +346,7 @@ class TestImplementIssue:
     def test_retries_non_clean_merge_rejection_until_timeout_or_success(self):
         """Transient merge API rejections in non-clean states are retried."""
         mocks = self._standard_mocks(
-            review_events=["APPROVE"],
+            review_event="APPROVE",
             pr_sequence=[
                 {
                     "state": "open",
@@ -347,7 +407,7 @@ class TestImplementIssue:
         """GitHub's merge API is the sole authority — CI failure doesn't block."""
         result = self._run_with_mocks(
             self._standard_mocks(
-                review_events=["APPROVE"],
+                review_event="APPROVE",
                 ci_results=[
                     {
                         "state": "failure",
@@ -362,7 +422,7 @@ class TestImplementIssue:
     def test_merge_rejection_returns_partial(self):
         """Persistent merge rejection results in timeout partial."""
         mocks = self._standard_mocks(
-            review_events=["APPROVE"],
+            review_event="APPROVE",
             merge_result={
                 "merged": False,
                 "message": "Pull Request is not mergeable",
@@ -386,7 +446,7 @@ class TestImplementIssue:
         """Auto-merge refuses PRs that are no longer bot-authored."""
         result = self._run_with_mocks(
             self._standard_mocks(
-                review_events=["APPROVE"],
+                review_event="APPROVE",
                 pr_sequence=[
                     {
                         "state": "open",
@@ -406,7 +466,7 @@ class TestImplementIssue:
 
     def test_merge_polling_http_error_returns_partial(self):
         """GitHub polling errors stay explicit partial/manual-attention states."""
-        mocks = self._standard_mocks(review_events=["APPROVE"])
+        mocks = self._standard_mocks(review_event="APPROVE")
         mocks[8] = patch(
             "implement.get_commit_ci_status",
             new_callable=AsyncMock,
@@ -426,61 +486,8 @@ class TestImplementIssue:
         assert result["merged"] is False
         assert "GitHub merge polling failed" in result["error"]
 
-    def test_max_iterations_posts_comment(self):
-        """Exhausting all fix iterations returns max_iterations status."""
-        # 3 fixes + 1 final review = 4 review rounds, all REQUEST_CHANGES
-        result = self._run_with_mocks(self._standard_mocks(review_events=["REQUEST_CHANGES"] * 4))
-        assert result["status"] == "max_iterations"
-        assert result["review_rounds"] == 4
-
-    def test_no_session_id_returns_partial(self):
-        """Without session ID, cannot resume — returns partial after first review."""
-        result = self._run_with_mocks(
-            self._standard_mocks(review_events=["REQUEST_CHANGES"], session_id=None)
-        )
-        assert result["status"] == "partial"
-        assert "session resumption unavailable" in result["error"]
-
-    def test_no_threads_returns_partial(self):
-        """REQUEST_CHANGES with no inline findings returns partial."""
-        mocks = self._standard_mocks(review_events=["REQUEST_CHANGES"])
-        # Override review_pr to return REQUEST_CHANGES with no inline comments
-        mocks[6] = patch(
-            "implement.review_pr",
-            new_callable=AsyncMock,
-            return_value={
-                "original_event": "REQUEST_CHANGES",
-                "premium_requests": 1,
-                "review_threads": "",
-            },
-        )
-        result = self._run_with_mocks(mocks)
-        assert result["status"] == "partial"
-        assert "no inline comments" in result["error"]
-
     def test_accumulates_premium_requests(self):
-        """Premium requests from implement + review + fix are all accumulated."""
-        result = self._run_with_mocks(
-            self._standard_mocks(review_events=["REQUEST_CHANGES", "APPROVE"])
-        )
-        # 1 (implement) + 1 (review 1) + 1 (fix) + 1 (review 2) = 4
-        assert result["premium_requests"] == 4
-
-    def test_passes_previous_threads_to_re_review(self):
-        """On second review round, previous findings are passed as context."""
-        mocks = self._standard_mocks(review_events=["REQUEST_CHANGES", "APPROVE"])
-
-        async def run():
-            with ExitStack() as stack:
-                entered = [stack.enter_context(m) for m in mocks]
-                review_mock = entered[6]  # review_pr mock
-                from implement import implement_issue
-
-                await implement_issue(repo="user/repo", issue_number=42)
-
-                # First call: no previous context
-                assert review_mock.call_args_list[0].kwargs["previous_comments"] == ""
-                # Second call: previous findings threaded through
-                assert "file.py:10" in review_mock.call_args_list[1].kwargs["previous_comments"]
-
-        asyncio.run(run())
+        """Premium requests from implement + review + fix are accumulated."""
+        result = self._run_with_mocks(self._standard_mocks(review_event="REQUEST_CHANGES"))
+        # 1 (implement) + 1 (review) + 1 (fix) = 3
+        assert result["premium_requests"] == 3

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -252,16 +252,17 @@ class TestImplementIssue:
         assert result["status"] == "complete"
         assert result["merged"] is True
 
-    def test_no_session_skips_fix_and_merges(self):
-        """Without session ID, fix is skipped but merge still proceeds."""
+    def test_no_session_bails_out_with_partial(self):
+        """Without session ID, fix can't run — returns partial for manual attention."""
         result = self._run_with_mocks(
             self._standard_mocks(review_event="REQUEST_CHANGES", session_id=None)
         )
-        assert result["status"] == "complete"
-        assert result["merged"] is True
+        assert result["status"] == "partial"
+        assert result["merged"] is False
+        assert "no session ID" in result["error"]
 
-    def test_no_threads_skips_fix_and_merges(self):
-        """REQUEST_CHANGES with no inline findings skips fix, still merges."""
+    def test_no_threads_bails_out_with_partial(self):
+        """REQUEST_CHANGES with no inline findings — returns partial for manual attention."""
         mocks = self._standard_mocks(review_event="REQUEST_CHANGES", review_threads="")
         # Override review to return empty threads
         mocks[6] = patch(
@@ -271,11 +272,29 @@ class TestImplementIssue:
                 "original_event": "REQUEST_CHANGES",
                 "premium_requests": 1,
                 "review_threads": "",
+                "session_id": "review-sess-1",
             },
         )
         result = self._run_with_mocks(mocks)
-        assert result["status"] == "complete"
-        assert result["merged"] is True
+        assert result["status"] == "partial"
+        assert result["merged"] is False
+        assert "no inline findings" in result["error"]
+
+    def test_fix_no_changes_bails_out_with_partial(self):
+        """Fix produces no file changes — returns partial for manual attention."""
+        mocks = self._standard_mocks(review_event="REQUEST_CHANGES")
+        mocks[4] = patch(
+            "implement.commit_and_push",
+            new_callable=AsyncMock,
+            side_effect=[
+                "abc123",  # initial commit succeeds
+                RuntimeError("No changes to commit"),  # fix commit fails
+            ],
+        )
+        result = self._run_with_mocks(mocks)
+        assert result["status"] == "partial"
+        assert result["merged"] is False
+        assert "no changes" in result["error"]
 
     def test_waits_for_pending_ci_before_merging(self):
         """Pending CI is polled until checks pass and the PR can be merged."""

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -11,11 +11,12 @@ from copilot import CLIResult
 
 
 class TestImplementIssue:
-    """Tests for implement_issue() — the unified implement+review+fix lifecycle."""
+    """Tests for implement_issue() — the implement+review+fix lifecycle."""
 
     def _standard_mocks(
         self,
         *,
+        review_events: list[str] | None = None,
         review_event: str = "APPROVE",
         session_id: str | None = "sess-123",
         pr_sequence: list[dict] | None = None,
@@ -26,10 +27,14 @@ class TestImplementIssue:
         """Create the standard set of mocks for implement_issue tests.
 
         Args:
-            review_event: The original_event value review_pr will return.
+            review_events: Per-round review events. Overrides review_event.
+            review_event: Single review event (used when review_events is None).
             session_id: Session ID the CLI returns (None to test no-session path).
             review_threads: Inline findings text for REQUEST_CHANGES reviews.
         """
+        if review_events is None:
+            review_events = [review_event]
+
         mock_cli_result = CLIResult(output="done", total_premium_requests=1, session_id=session_id)
         mock_fix_result = CLIResult(output="fixed", total_premium_requests=1, session_id=session_id)
         mock_issue = {
@@ -67,18 +72,25 @@ class TestImplementIssue:
                 return_value=merge_result,
             )
 
-        if review_event == "REQUEST_CHANGES" and not review_threads:
-            review_threads = "- **file.py:10**\n  bug here"
-        review_result = {
-            "original_event": review_event,
-            "premium_requests": 1,
-            "review_threads": review_threads,
-        }
+        # Build per-round review results
+        default_threads = "- **file.py:10**\n  bug here"
+        review_results = []
+        for evt in review_events:
+            threads = review_threads or (default_threads if evt == "REQUEST_CHANGES" else "")
+            review_results.append(
+                {
+                    "original_event": evt,
+                    "premium_requests": 1,
+                    "review_threads": threads,
+                    "session_id": "review-sess-1",
+                }
+            )
 
-        # run_copilot: first call is implement, second (if any) is fix
+        # run_copilot: first call is implement, then one fix per REQUEST_CHANGES round
         copilot_side_effect = [mock_cli_result]
-        if review_event == "REQUEST_CHANGES":
-            copilot_side_effect.append(mock_fix_result)
+        for evt in review_events:
+            if evt == "REQUEST_CHANGES":
+                copilot_side_effect.append(mock_fix_result)
 
         return [
             patch("implement.get_token", new_callable=AsyncMock, return_value="token"),
@@ -98,7 +110,7 @@ class TestImplementIssue:
             patch(
                 "implement.review_pr",
                 new_callable=AsyncMock,
-                return_value=review_result,
+                side_effect=review_results,
             ),
             patch(
                 "implement.get_pr",
@@ -153,8 +165,8 @@ class TestImplementIssue:
         asyncio.run(run())
 
     def test_review_requests_changes_then_fixes_and_merges(self):
-        """Single cycle: review requests changes → fix → merge (no re-review)."""
-        mocks = self._standard_mocks(review_event="REQUEST_CHANGES")
+        """Round 1 requests changes → fix → round 2 approves → merge."""
+        mocks = self._standard_mocks(review_events=["REQUEST_CHANGES", "APPROVE"])
 
         async def run():
             with ExitStack() as stack:
@@ -166,14 +178,62 @@ class TestImplementIssue:
 
                 result = await implement_issue(repo="user/repo", issue_number=42)
 
-                # Review called once (no re-review)
-                review_mock.assert_awaited_once()
+                # Review called twice (round 1 + round 2)
+                assert review_mock.await_count == 2
                 # Copilot called twice: implement + fix
                 assert copilot_mock.await_count == 2
                 # Commit called twice: initial + fix
                 assert commit_mock.await_count == 2
                 assert result["status"] == "complete"
                 assert result["merged"] is True
+                assert result["review_rounds"] == 2
+
+        asyncio.run(run())
+
+    def test_two_rounds_of_changes_fixes_both_and_merges(self):
+        """Both rounds request changes → fix twice → merge."""
+        mocks = self._standard_mocks(review_events=["REQUEST_CHANGES", "REQUEST_CHANGES"])
+
+        async def run():
+            with ExitStack() as stack:
+                entered = [stack.enter_context(m) for m in mocks]
+                copilot_mock = entered[3]
+                commit_mock = entered[4]
+                review_mock = entered[6]
+                from implement import implement_issue
+
+                result = await implement_issue(repo="user/repo", issue_number=42)
+
+                # Review called twice (max rounds)
+                assert review_mock.await_count == 2
+                # Copilot called 3 times: implement + fix1 + fix2
+                assert copilot_mock.await_count == 3
+                # Commit called 3 times: initial + fix1 + fix2
+                assert commit_mock.await_count == 3
+                assert result["status"] == "complete"
+                assert result["merged"] is True
+                assert result["review_rounds"] == 2
+
+        asyncio.run(run())
+
+    def test_review_passes_session_id_across_rounds(self):
+        """The review session_id from round 1 is passed to round 2."""
+        mocks = self._standard_mocks(review_events=["REQUEST_CHANGES", "APPROVE"])
+
+        async def run():
+            with ExitStack() as stack:
+                entered = [stack.enter_context(m) for m in mocks]
+                review_mock = entered[6]
+                from implement import implement_issue
+
+                await implement_issue(repo="user/repo", issue_number=42)
+
+                # First review: no prior session
+                first_call = review_mock.await_args_list[0]
+                assert first_call.kwargs.get("session_id") is None
+                # Second review: session from round 1
+                second_call = review_mock.await_args_list[1]
+                assert second_call.kwargs.get("session_id") == "review-sess-1"
 
         asyncio.run(run())
 
@@ -487,7 +547,17 @@ class TestImplementIssue:
         assert "GitHub merge polling failed" in result["error"]
 
     def test_accumulates_premium_requests(self):
-        """Premium requests from implement + review + fix are accumulated."""
-        result = self._run_with_mocks(self._standard_mocks(review_event="REQUEST_CHANGES"))
-        # 1 (implement) + 1 (review) + 1 (fix) = 3
-        assert result["premium_requests"] == 3
+        """Premium requests from implement + reviews + fixes are accumulated."""
+        result = self._run_with_mocks(
+            self._standard_mocks(review_events=["REQUEST_CHANGES", "APPROVE"])
+        )
+        # 1 (implement) + 1 (review1) + 1 (fix) + 1 (review2) = 4
+        assert result["premium_requests"] == 4
+
+    def test_accumulates_premium_requests_two_fix_rounds(self):
+        """Premium requests from implement + 2 reviews + 2 fixes are accumulated."""
+        result = self._run_with_mocks(
+            self._standard_mocks(review_events=["REQUEST_CHANGES", "REQUEST_CHANGES"])
+        )
+        # 1 (implement) + 1 (review1) + 1 (fix1) + 1 (review2) + 1 (fix2) = 5
+        assert result["premium_requests"] == 5

--- a/stacks/agents/app/tests/test_main.py
+++ b/stacks/agents/app/tests/test_main.py
@@ -201,24 +201,6 @@ def test_implement_metrics_record_partial_status(mock_implement):
 
 
 @patch("main.implement_issue", new_callable=AsyncMock)
-def test_implement_metrics_max_iterations_records_partial(mock_implement):
-    mock_implement.return_value = {"status": "max_iterations", "premium_requests": 6}
-
-    asyncio.run(
-        _run_implement(
-            repo="user/repo",
-            issue_number=303,
-            model="gpt-5.4",
-            reasoning_effort="high",
-        )
-    )
-
-    labels = {"task_type": "implement", "status": "partial"}
-    assert _metric_value("agent_task_total", labels) == 1.0
-    assert _metric_value("agent_premium_requests_total", {"task_type": "implement"}) == 6.0
-
-
-@patch("main.implement_issue", new_callable=AsyncMock)
 def test_implement_status_preserves_merge_details(mock_implement):
     mock_implement.return_value = {
         "status": "complete",


### PR DESCRIPTION
Remove the multi-round review/fix loop. The lifecycle now runs exactly one cycle:

**implement → review → fix → merge**

No re-review after the fix. The review catches catastrophic bugs, the fix addresses them, then we merge. Iterating further wastes tokens and time without converging (as seen in PR #76's 8-round cycle where the bot contradicted itself).

### Changes
- Remove `MAX_FIX_ITERATIONS` and `max_iterations` status
- Simplify `implement_issue` to linear flow (was 200+ line loop → clean sequence)
- Review errors don't block merge (advisory)
- Update bot-review skill: "There is only one review round"
- Update bot-implement skill: document one-cycle contract
- 120 tests pass, net -114 lines