### PR TITLE
fix: parse session time and tokens from new CLI stats format

### DIFF
--- a/stacks/agents/app/copilot.py
+++ b/stacks/agents/app/copilot.py
@@ -37,6 +37,7 @@ class CLIResult:
     api_time_seconds: int = 0
     session_time_seconds: int = 0
     models: dict[str, str] = field(default_factory=dict)
+    tokens_line: str = ""
     session_transcript: str | None = None
     session_id: str | None = None
 
@@ -48,6 +49,8 @@ class CLIResult:
             # Strip redundant "(Est. N Premium request(s))" — shown separately
             clean = re.sub(r"\s*\(Est\..*?\)", "", detail).strip().rstrip(",")
             parts.append(f"🤖 {model_name} ({clean})")
+        if self.tokens_line:
+            parts.append(f"📊 {self.tokens_line}")
         if self.total_premium_requests:
             parts.append(f"💰 {self.total_premium_requests} premium request(s)")
         if self.session_time_seconds:
@@ -66,18 +69,36 @@ def _parse_time(value: str) -> int:
 
 
 def _parse_stats(output: str) -> dict:
-    """Parse CLI session stats from non-silent output."""
+    """Parse CLI session stats from non-silent output.
+
+    Handles both old and new CLI formats:
+      Old: Total usage est: 3 Premium requests / API time spent: 6m 29s / ...
+      New: Requests 1 Premium (15m 44s) / Tokens ↑ 5.5m • ↓ 34.0k • ...
+    """
     stats: dict = {"premium_requests": 0, "api_time": 0, "session_time": 0, "models": {}}
 
     for line in output.splitlines():
         line = line.strip()
 
+        # Premium requests — old: "Total usage est: 3 Premium"
+        #                    new: "Requests 1 Premium (15m 44s)"
         if m := re.match(r"(?:Total usage est:|Requests)\s+(\d+)\s+Premium", line):
             stats["premium_requests"] = int(m.group(1))
+            # New format embeds session time in parentheses on the same line
+            if t := re.search(r"\((\d+m\s*\d*s?)\)", line):
+                stats["session_time"] = _parse_time(t.group(1))
+
+        # Old format only
         elif m := re.match(r"API time spent:\s+(.+)", line):
             stats["api_time"] = _parse_time(m.group(1))
         elif m := re.match(r"Total session time:\s+(.+)", line):
             stats["session_time"] = _parse_time(m.group(1))
+
+        # Tokens — new: "Tokens ↑ 5.5m • ↓ 34.0k • 5.3m (cached) • 19.9k (reasoning)"
+        elif m := re.match(r"Tokens\s+(.+)", line):
+            stats["tokens_line"] = m.group(1).strip()
+
+        # Model usage — old: "gpt-5.4  5.5m in, 34.0k out ..."
         elif m := re.match(r"^\s*(\S+)\s+([\d.]+[km]?\s+in,\s+[\d.]+[km]?\s+out.*)", line):
             model_name = m.group(1)
             if model_name not in ("Total", "Breakdown"):
@@ -247,6 +268,7 @@ async def run_copilot(
         api_time_seconds=stats["api_time"],
         session_time_seconds=stats["session_time"],
         models=stats["models"],
+        tokens_line=stats.get("tokens_line", ""),
         session_transcript=transcript,
         session_id=parsed_session_id,
     )

--- a/stacks/agents/app/implement.py
+++ b/stacks/agents/app/implement.py
@@ -57,6 +57,7 @@ def _format_stage_stats(
     api_time_seconds: int = 0,
     effort: str = "",
     models: dict | None = None,
+    tokens_line: str = "",
 ) -> str:
     """Format a compact stats footer for a lifecycle stage comment."""
     parts = []
@@ -75,6 +76,8 @@ def _format_stage_stats(
         for model_name, detail in models.items():
             clean = re.sub(r"\s*\(Est\..*?\)", "", detail).strip().rstrip(",")
             parts.append(f"🤖 {model_name}: {clean}")
+    elif tokens_line:
+        parts.append(f"📊 {tokens_line}")
     return " · ".join(parts)
 
 
@@ -86,6 +89,7 @@ def _cli_stage_stats(result: CLIResult, effort: str = "") -> str:
         api_time_seconds=result.api_time_seconds,
         effort=effort,
         models=result.models,
+        tokens_line=result.tokens_line,
     )
 
 
@@ -557,6 +561,7 @@ async def implement_issue(
                         api_time_seconds=review_result.get("api_time_seconds", 0),
                         effort=review_result.get("reasoning_effort", ""),
                         models=review_result.get("models"),
+                        tokens_line=review_result.get("tokens_line", ""),
                     )
                     verdict = (
                         "✅ approved" if original_event == "APPROVE" else "📋 changes requested"

--- a/stacks/agents/app/review.py
+++ b/stacks/agents/app/review.py
@@ -410,6 +410,7 @@ async def review_pr(
             "reasoning_effort": reasoning_effort,
             "premium_requests": result.total_premium_requests,
             "models": result.models,
+            "tokens_line": result.tokens_line,
             "original_event": review_data.event,
             "review_threads": _format_review_threads(review_data.comments),
             "session_id": result.session_id,

--- a/stacks/agents/app/tests/test_copilot.py
+++ b/stacks/agents/app/tests/test_copilot.py
@@ -100,6 +100,15 @@ Tokens    ↑ 5.5m • ↓ 34.0k • 5.3m (cached) • 19.9k (reasoning)
 def test_parse_new_cli_format():
     stats = _parse_stats(SAMPLE_OUTPUT_NEW_FORMAT)
     assert stats["premium_requests"] == 1
+    assert stats["session_time"] == 15 * 60 + 44
+    assert stats["tokens_line"] == "↑ 5.5m • ↓ 34.0k • 5.3m (cached) • 19.9k (reasoning)"
+    assert stats["models"] == {}
+
+
+def test_parse_new_format_short_time():
+    stats = _parse_stats("Requests  3 Premium (6m 16s)\n")
+    assert stats["premium_requests"] == 3
+    assert stats["session_time"] == 6 * 60 + 16
 
 
 def test_stats_line_strips_est_premium():

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -52,6 +52,21 @@ class TestFormatStageStats:
     def test_empty_when_no_data(self):
         assert _format_stage_stats() == ""
 
+    def test_tokens_line_when_no_models(self):
+        result = _format_stage_stats(
+            premium_requests=1,
+            tokens_line="↑ 1.1m • ↓ 18.9k • 1.0m (cached)",
+        )
+        assert "📊 ↑ 1.1m • ↓ 18.9k • 1.0m (cached)" in result
+
+    def test_models_preferred_over_tokens_line(self):
+        result = _format_stage_stats(
+            models={"gpt-5.4": "1.2m in, 12k out"},
+            tokens_line="↑ 1.1m • ↓ 18.9k",
+        )
+        assert "🤖 gpt-5.4" in result
+        assert "📊" not in result
+
     def test_cli_stage_stats_from_result(self):
         r = CLIResult(
             output="",
@@ -65,6 +80,18 @@ class TestFormatStageStats:
         assert "⏱️ 5m 0s (API: 3m 0s)" in result
         assert "🧠 high" in result
         assert "gpt-5.4" in result
+
+    def test_cli_stage_stats_new_format(self):
+        r = CLIResult(
+            output="",
+            total_premium_requests=1,
+            session_time_seconds=376,
+            tokens_line="↑ 1.1m • ↓ 18.9k • 1.0m (cached) • 11.7k (reasoning)",
+        )
+        result = _cli_stage_stats(r, effort="high")
+        assert "💰 1 premium" in result
+        assert "⏱️ 6m 16s" in result
+        assert "📊 ↑ 1.1m" in result
 
 
 class TestImplementIssue:


### PR DESCRIPTION
## Problem

PR #82 shows stats as `💰 1 premium · 🧠 high` — missing elapsed time (⏱️) and token usage (🤖/📊). 

The Copilot CLI changed its stats output format and we only fixed the premium requests regex, not the time/model lines:

| Field | Old format | New format |
|-------|-----------|------------|
| Premium | `Total usage est: 3 Premium` | `Requests 1 Premium (15m 44s)` |
| Time | `Total session time: 15m 44s` | Embedded in Requests line above |
| API time | `API time spent: 6m 29s` | Gone |
| Tokens | `gpt-5.4  5.5m in, 34.0k out` | `Tokens ↑ 5.5m • ↓ 34.0k • 5.3m (cached)` |

## Changes

- `_parse_stats()`: extract `session_time` from parenthesized time on the Requests line, capture `tokens_line` from new Tokens line
- `CLIResult`: added `tokens_line` field
- `_format_stage_stats()`: shows 📊 tokens_line when old-format model breakdown isn't available
- `review_pr()`: passes `tokens_line` through result dict

**Expected output after fix:**
```
💰 1 premium · ⏱️ 6m 16s · 🧠 high · 📊 ↑ 1.1m • ↓ 18.9k • 1.0m (cached) • 11.7k (reasoning)
```

150 tests pass (4 new).