### PR TITLE
feat: decouple CLI work from API with ephemeral worker containers

### DIFF
--- a/docs/decisions/007-agent-network-isolation.md
+++ b/docs/decisions/007-agent-network-isolation.md
@@ -80,7 +80,7 @@ Accept unrestricted outbound network access. The security boundary is:
 3. **Prompt-injection defenses** — implementation only trusts issues from
    trusted roles; review thread context includes only bot-authored comments.
 4. **Runtime hardening** — non-root container, dropped capabilities, no new privileges.
-5. **No host access** — no Docker socket, no host filesystem mounts, no personal credentials.
+5. **No host access** — no Docker socket (see [ADR-011](docs/decisions/011-docker-socket-for-workers.md) for the exception), no host filesystem mounts, no personal credentials.
 
 Even with an egress allowlist, data could still leave through GitHub or other
 allowed APIs. The more important controls are who can trigger the agent and what

--- a/docs/decisions/010-agent-security-model.md
+++ b/docs/decisions/010-agent-security-model.md
@@ -111,7 +111,7 @@ access the host.
 | `cap_drop: ALL` | Drops all Linux capabilities |
 | `cap_add` (minimal) | Only CHOWN, FOWNER, SETUID, SETGID — needed for entrypoint user switching |
 | Memory/CPU limits | `mem_limit: 2g`, `cpus: 2.0` — prevents resource exhaustion |
-| No Docker socket | Container cannot spawn or manage other containers |
+| Docker socket (API only) | API container has socket mount for spawning workers ([ADR-011](011-docker-socket-for-workers.md)). Worker containers do not get socket access. |
 | No host filesystem | Only named volumes (`repo-cache`, `reviews`) — no secrets mounted |
 | Non-root execution | `entrypoint.sh` drops to `agent:agent` user after volume setup |
 

--- a/docs/decisions/011-docker-socket-for-workers.md
+++ b/docs/decisions/011-docker-socket-for-workers.md
@@ -1,0 +1,97 @@
+# ADR-011: Docker socket for ephemeral worker containers
+
+**Date:** 2025-07-25
+**Status:** Accepted
+
+## Context
+
+The agent API container runs CLI tasks (review, implement) as child processes.
+When Dokploy redeploys the container (triggered by any push to main — including
+the agent's own merges), in-flight CLI work is killed. These sessions run 5–30
+minutes and consume premium Copilot tokens that cannot be recovered.
+
+To decouple CLI work from the API lifecycle, we want the API to spawn
+**ephemeral worker containers** via Docker. Workers run the same image with a
+different entrypoint (`python -m worker`), execute the full CLI lifecycle, and
+exit. The API becomes a thin dispatcher: validate trust → spawn worker → monitor
+completion.
+
+This requires the API container to have access to the Docker daemon on the host.
+
+## Options Considered
+
+### A: Docker socket mount (`/var/run/docker.sock`)
+
+Mount the host's Docker socket into the API container. The API uses the `docker`
+CLI to spawn, monitor, and stop worker containers.
+
+**Pros:**
+- Zero additional infrastructure — uses the existing Docker daemon
+- Simple to implement — subprocess calls to `docker run/wait/stop/rm`
+- Workers are fully isolated from API lifecycle (survive restarts)
+- Same operational model as Dokploy itself (which also uses the socket)
+
+**Cons:**
+- Grants the API container host-level Docker access (can create any container)
+- A compromised API process could escape to the host via container creation
+
+**Verdict: Chosen.** The blast radius argument is decisive — the API already
+holds the GitHub App private key and generates installation tokens with full repo
+write access. Compromising the API already means full repository control. Adding
+Docker socket access expands the blast radius from "repo compromise" to "host
+compromise", but on a single-user homelab behind Tailscale, the incremental
+risk is minimal.
+
+### B: Docker socket proxy (Tecnativa/docker-socket-proxy)
+
+Run a filtering proxy that restricts which Docker API endpoints the container
+can reach.
+
+**Pros:**
+- Reduces blast radius by limiting API surface
+- Well-known pattern in the Docker ecosystem
+
+**Cons:**
+- Cannot restrict to "create containers only" — the proxy's granularity is
+  per-API-section (containers: yes/no), not per-operation (create vs delete)
+- Adds another service to manage and monitor
+- Adds latency and a failure point
+
+**Verdict: Rejected.** The proxy's coarse granularity doesn't meaningfully reduce
+risk for our threat model. We'd still be granting broad container API access.
+
+### C: Separate scheduler service
+
+Run a dedicated worker scheduler (e.g., a sidecar) that receives work requests
+over HTTP and manages containers itself, keeping the socket out of the API.
+
+**Pros:**
+- API never touches Docker — clean separation
+- Could enforce resource quotas centrally
+
+**Cons:**
+- Significant added complexity for a single-user homelab
+- Two services to deploy, monitor, and debug
+- The scheduler itself needs the Docker socket — same trust boundary
+
+**Verdict: Rejected.** Moves the trust boundary without reducing it, while
+adding operational complexity.
+
+## Decision
+
+Mount the Docker socket into the API container. Mitigations:
+
+1. **Existing container hardening applies:** `no-new-privileges`, `cap_drop: ALL`,
+   only `CHOWN`/`FOWNER`/`SETUID`/`SETGID` capabilities added back.
+2. **Worker containers inherit the same security profile:** resource limits
+   (2 GB RAM, 2 CPUs), no additional capabilities, no socket mount.
+3. **Network boundary:** API is only reachable via Tailscale (CGNAT IP binding).
+   No public ingress to the agent service.
+4. **Socket access is scoped to the agent user** via Docker group membership in
+   the entrypoint, not by running as root.
+
+## References
+
+- ADR-010: Agent security model
+- ADR-007: Agent network isolation
+- Issue #90: Decouple agent CLI work from API container lifecycle

--- a/stacks/agents/app/Dockerfile
+++ b/stacks/agents/app/Dockerfile
@@ -9,6 +9,8 @@ ARG MISE_VERSION=v2026.2.1
 ARG COPILOT_CLI_VERSION=v1.0.25
 # renovate: datasource=github-releases depName=cli/cli
 ARG GH_VERSION=2.89.0
+# renovate: datasource=github-releases depName=moby/moby
+ARG DOCKER_VERSION=28.2.2
 
 # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
 COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
@@ -25,6 +27,10 @@ RUN curl -fsSL "https://github.com/github/copilot-cli/releases/download/${COPILO
 # Install gh CLI for GitHub API access
 RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
     | tar -xz --strip-components=2 -C /usr/local/bin "gh_${GH_VERSION}_linux_amd64/bin/gh"
+
+# Install Docker CLI for spawning ephemeral worker containers (ADR-011)
+RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
+    | tar -xz --strip-components=1 -C /usr/local/bin docker/docker
 
 # Install mise and provision all dev tools (shellcheck, actionlint, trivy)
 # so the Copilot CLI has the same toolchain as local dev.
@@ -59,4 +65,5 @@ ENV PATH="/mise/shims:/app/.venv/bin:$PATH"
 
 EXPOSE 8585
 ENTRYPOINT ["/entrypoint.sh"]
+# API mode (default) — override with 'python -m worker' for ephemeral workers
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8585"]

--- a/stacks/agents/app/entrypoint.sh
+++ b/stacks/agents/app/entrypoint.sh
@@ -5,4 +5,15 @@ set -e
 # (named volumes are created as root on first mount)
 chown agent:agent /repo.git /reviews
 
+# Give agent user access to Docker socket if mounted (ADR-011).
+# Match the host's docker group GID so agent can spawn worker containers.
+if [ -S /var/run/docker.sock ]; then
+    DOCKER_GID=$(stat -c '%g' /var/run/docker.sock)
+    if ! getent group "$DOCKER_GID" > /dev/null 2>&1; then
+        groupadd -g "$DOCKER_GID" docker-host
+    fi
+    DOCKER_GROUP=$(getent group "$DOCKER_GID" | cut -d: -f1)
+    usermod -aG "$DOCKER_GROUP" agent
+fi
+
 exec runuser -u agent -- "$@"

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -21,6 +21,7 @@ from metrics import (
 )
 from services.docker import (
     cleanup_orphaned_workers,
+    discover_running_workers,
     get_logs,
     get_own_image,
     is_worker_running,
@@ -40,7 +41,39 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     await reap_old_worktrees()
-    await cleanup_orphaned_workers()
+
+    # Harvest metrics from workers that completed while we were down
+    for w in await cleanup_orphaned_workers():
+        result = parse_worker_result(str(w.get("logs", "")))
+        fallback = "failed"
+        status = _task_status_label(result.get("status", fallback))
+        premium = _premium_requests(result)
+        _record_task_metrics(
+            task_type=str(w["task_type"]),
+            status=status,
+            duration_seconds=float(w.get("duration_seconds", 0)),
+            premium_requests=premium,
+        )
+        logger.info(
+            "Harvested metrics from orphaned worker %s #%s (status=%s, premium=%d)",
+            w["task_type"],
+            w["number"],
+            status,
+            premium,
+        )
+
+    # Reconnect monitors for workers still running from a previous API process
+    for w in await discover_running_workers():
+        task_type = str(w["task_type"])
+        number = int(w["number"])
+        container_id = str(w["container_id"])
+        started_at = float(w.get("started_at", 0))
+        elapsed = time.time() - started_at if started_at > 0 else 0
+        approx_start = time.monotonic() - elapsed
+        TASK_IN_PROGRESS.labels(task_type=task_type).inc()
+        _spawn_monitor(container_id, task_type=task_type, number=number, start=approx_start)
+        logger.info("Reconnected monitor for running worker %s #%d", task_type, number)
+
     yield
 
 
@@ -55,11 +88,9 @@ _monitor_tasks: dict[str, asyncio.Task[None]] = {}
 
 
 def _task_status_label(status: object) -> str:
-    if status == "failed":
-        return "failed"
-    if status == "partial":
-        return "partial"
-    return "complete"
+    if status in ("complete", "failed", "partial", "rejected"):
+        return str(status)
+    return "failed"
 
 
 def _premium_requests(result: dict[str, object] | None) -> int:

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -7,12 +7,11 @@ import os
 import time
 from contextlib import asynccontextmanager
 
-from fastapi import BackgroundTasks, FastAPI
+from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from prometheus_client import make_asgi_app
 from pydantic import BaseModel
 
-from implement import implement_issue
 from metrics import (
     METRICS_REGISTRY,
     PREMIUM_REQUESTS_TOTAL,
@@ -20,16 +19,18 @@ from metrics import (
     TASK_IN_PROGRESS,
     TASK_TOTAL,
 )
-from review import review_pr
-from services.copilot import TaskError
-from services.git import reap_old_worktrees
-from services.github import (
-    comment_on_issue,
-    find_issue_comment_by_body_prefix,
-    get_issue,
-    set_token,
-    update_comment,
+from services.docker import (
+    cleanup_orphaned_workers,
+    get_logs,
+    get_own_image,
+    is_worker_running,
+    parse_worker_result,
+    remove_container,
+    spawn_worker,
+    wait_container,
 )
+from services.git import reap_old_worktrees
+from services.github import set_token
 from trust import ALLOWED_ACTORS
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -39,31 +40,18 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     await reap_old_worktrees()
+    await cleanup_orphaned_workers()
     yield
 
 
-app = FastAPI(title="Homelab Agent Service", version="0.6.0", lifespan=lifespan)
+app = FastAPI(title="Homelab Agent Service", version="0.7.0", lifespan=lifespan)
 app.mount("/metrics", make_asgi_app(registry=METRICS_REGISTRY))
 
 MODEL = os.environ.get("MODEL", "gpt-5.4")
 REASONING_EFFORT = os.environ.get("REASONING_EFFORT", "high")
 
-_review_status: dict[str, dict] = {}
-_review_tasks: dict[str, asyncio.Task[None]] = {}
-_review_locks: dict[str, asyncio.Lock] = {}
-_review_request_ids: dict[str, int] = {}
-_implement_status: dict[str, dict] = {}
-
-REVIEW_PROGRESS_PREFIX = "🔄 Review in progress for PR #"
-IMPLEMENT_PROGRESS_PREFIX = "🔄 Implementing #"
-
-
-def _review_key(repo: str, pr_number: int) -> str:
-    return f"{repo}#{pr_number}"
-
-
-def _implement_key(repo: str, issue_number: int) -> str:
-    return f"{repo}#{issue_number}"
+# Tracks active monitor tasks so we can clean them up if needed
+_monitor_tasks: dict[str, asyncio.Task[None]] = {}
 
 
 def _task_status_label(status: object) -> str:
@@ -77,82 +65,8 @@ def _task_status_label(status: object) -> str:
 def _premium_requests(result: dict[str, object] | None) -> int:
     if not result:
         return 0
-
     premium_requests = result.get("premium_requests", 0)
     return premium_requests if isinstance(premium_requests, int) else 0
-
-
-def _review_progress_comment(pr_number: int) -> str:
-    return f"{REVIEW_PROGRESS_PREFIX}{pr_number}..."
-
-
-def _review_progress_failure_comment(reason: str) -> str:
-    return f"⚠️ Review failed — {reason}"
-
-
-def _review_progress_cancelled_comment() -> str:
-    return "⏹️ Review cancelled — superseded by newer /review request"
-
-
-def _implement_progress_comment(issue_number: int) -> str:
-    return f"{IMPLEMENT_PROGRESS_PREFIX}{issue_number}..."
-
-
-def _implement_progress_success_comment(
-    pr_number: int, pr_url: str, auto_merge: bool = False
-) -> str:
-    if auto_merge:
-        return f"✅ PR #{pr_number} created (auto-merge enabled) — {pr_url}"
-    return f"✅ PR #{pr_number} created — {pr_url}"
-
-
-def _implement_progress_failure_comment(reason: str) -> str:
-    return f"⚠️ Implementation failed — {reason}"
-
-
-async def _update_progress_comment(repo: str, comment_id: int | None, body: str) -> None:
-    if comment_id is None:
-        return
-
-    with contextlib.suppress(Exception):
-        await update_comment(repo, comment_id, body)
-
-
-async def _start_progress_comment(
-    repo: str, issue_number: int, *, body: str, body_prefix: str
-) -> int | None:
-    with contextlib.suppress(Exception):
-        comment_id = await find_issue_comment_by_body_prefix(repo, issue_number, body_prefix)
-        if comment_id is not None:
-            await update_comment(repo, comment_id, body)
-            return comment_id
-        return await comment_on_issue(repo, issue_number, body)
-    return None
-
-
-async def _start_review_progress_comment(repo: str, pr_number: int) -> int | None:
-    return await _start_progress_comment(
-        repo,
-        pr_number,
-        body=_review_progress_comment(pr_number),
-        body_prefix=REVIEW_PROGRESS_PREFIX,
-    )
-
-
-async def _start_implement_progress_comment(repo: str, issue_number: int) -> int | None:
-    return await _start_progress_comment(
-        repo,
-        issue_number,
-        body=_implement_progress_comment(issue_number),
-        body_prefix=IMPLEMENT_PROGRESS_PREFIX,
-    )
-
-
-async def _get_issue_for_progress(repo: str, issue_number: int) -> dict | None:
-    try:
-        return await get_issue(repo, issue_number)
-    except Exception:
-        return None
 
 
 def _record_task_metrics(
@@ -187,12 +101,66 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+# --- Worker monitoring ---
+
+
+async def _monitor_worker(container_id: str, *, task_type: str, number: int, start: float) -> None:
+    """Wait for a worker container to exit and record metrics."""
+    monitor_key = f"{task_type}-{number}"
+    try:
+        exit_code = await wait_container(container_id)
+        duration = time.monotonic() - start
+
+        result: dict = {}
+        try:
+            logs = await get_logs(container_id)
+            result = parse_worker_result(logs)
+        except Exception:
+            logger.warning("Failed to parse worker result for %s #%d", task_type, number)
+
+        fallback_status = "failed" if exit_code != 0 else "complete"
+        status = _task_status_label(result.get("status", fallback_status))
+        premium = _premium_requests(result)
+
+        _record_task_metrics(
+            task_type=task_type,
+            status=status,
+            duration_seconds=duration,
+            premium_requests=premium,
+        )
+        logger.info(
+            "Worker %s #%d finished (exit=%d, status=%s, duration=%.0fs, premium=%d)",
+            task_type,
+            number,
+            exit_code,
+            status,
+            duration,
+            premium,
+        )
+    except Exception:
+        logger.exception("Monitor failed for worker %s #%d", task_type, number)
+    finally:
+        TASK_IN_PROGRESS.labels(task_type=task_type).dec()
+        with contextlib.suppress(Exception):
+            await remove_container(container_id)
+        _monitor_tasks.pop(monitor_key, None)
+
+
+def _spawn_monitor(container_id: str, *, task_type: str, number: int, start: float) -> None:
+    """Start a background task to monitor a worker container."""
+    monitor_key = f"{task_type}-{number}"
+    task = asyncio.create_task(
+        _monitor_worker(container_id, task_type=task_type, number=number, start=start)
+    )
+    _monitor_tasks[monitor_key] = task
+
+
 # --- Review endpoints ---
 
 
 @app.post("/review", status_code=202, response_model=None)
 async def handle_review(req: ReviewRequest):
-    """Accept a review request and process it in the background."""
+    """Accept a review request and spawn a worker container."""
     if req.triggered_by not in ALLOWED_ACTORS:
         return JSONResponse(
             status_code=403,
@@ -201,63 +169,39 @@ async def handle_review(req: ReviewRequest):
     set_token(req.github_token)
     model = req.model or MODEL
     effort = req.reasoning_effort or REASONING_EFFORT
-    key = _review_key(req.repo, req.pr_number)
-    lock = _review_locks.setdefault(key, asyncio.Lock())
-    existing_task: asyncio.Task[None] | None = None
 
-    async with lock:
-        request_id = _review_request_ids.get(key, 0) + 1
-        _review_request_ids[key] = request_id
-        existing_task = _review_tasks.get(key)
-        if existing_task and not existing_task.done():
-            existing_task.cancel()
+    image = await get_own_image()
+    env = {
+        "WORKER_TASK": "review",
+        "WORKER_REPO": req.repo,
+        "WORKER_PR_NUMBER": str(req.pr_number),
+        "GH_TOKEN": req.github_token,
+        "COPILOT_GITHUB_TOKEN": os.environ.get("COPILOT_GITHUB_TOKEN", ""),
+        "MODEL": model,
+        "REASONING_EFFORT": effort,
+    }
 
-    if existing_task and not existing_task.done():
-        with contextlib.suppress(asyncio.CancelledError):
-            await existing_task
+    start = time.monotonic()
+    TASK_IN_PROGRESS.labels(task_type="review").inc()
 
-    async with lock:
-        if _review_request_ids.get(key) != request_id:
-            return {"status": "accepted", "pr_number": req.pr_number}
+    container_id = await spawn_worker(
+        task_type="review",
+        image=image,
+        env=env,
+        number=req.pr_number,
+        volumes=["repo-cache:/repo.git", "reviews:/reviews"],
+    )
 
-        existing = _review_status.get(key)
-        prior_session_id = (
-            existing.get("session_id")
-            if existing and existing.get("status") not in {"in_progress", "cancelled"}
-            else None
-        )
-
-        _review_status[key] = {
-            "status": "in_progress",
-            "repo": req.repo,
-            "pr_number": req.pr_number,
-        }
-        task = asyncio.create_task(
-            _run_review(
-                repo=req.repo,
-                pr_number=req.pr_number,
-                model=model,
-                reasoning_effort=effort,
-                session_id=prior_session_id,
-            )
-        )
-        _review_tasks[key] = task
-
+    _spawn_monitor(container_id, task_type="review", number=req.pr_number, start=start)
     return {"status": "accepted", "pr_number": req.pr_number}
 
 
 @app.get("/review/{pr_number}")
 async def get_review_status(pr_number: int, repo: str = "") -> dict:
-    """Check the status of a review."""
-    key = _review_key(repo, pr_number) if repo else None
-
-    if key and key in _review_status:
-        return _review_status[key]
-
-    for v in _review_status.values():
-        if v.get("pr_number") == pr_number:
-            return v
-
+    """Check the status of a review by checking the worker container."""
+    running = await is_worker_running("review", pr_number)
+    if running:
+        return {"status": "in_progress", "pr_number": pr_number}
     return {"status": "not_found", "pr_number": pr_number}
 
 
@@ -265,8 +209,8 @@ async def get_review_status(pr_number: int, repo: str = "") -> dict:
 
 
 @app.post("/implement", status_code=202, response_model=None)
-async def handle_implement(req: ImplementRequest, background_tasks: BackgroundTasks):
-    """Accept an implementation request and process it in the background."""
+async def handle_implement(req: ImplementRequest):
+    """Accept an implementation request and spawn a worker container."""
     if req.triggered_by not in ALLOWED_ACTORS:
         return JSONResponse(
             status_code=403,
@@ -275,209 +219,44 @@ async def handle_implement(req: ImplementRequest, background_tasks: BackgroundTa
     set_token(req.github_token)
     model = req.model or MODEL
     effort = req.reasoning_effort or REASONING_EFFORT
-    key = _implement_key(req.repo, req.issue_number)
 
-    existing = _implement_status.get(key)
-    if existing and existing["status"] == "in_progress":
+    # Check for duplicate via running container
+    if await is_worker_running("implement", req.issue_number):
         return JSONResponse(
             status_code=409,
             content={"status": "already_in_progress", "issue_number": req.issue_number},
         )
 
-    _implement_status[key] = {
-        "status": "in_progress",
-        "repo": req.repo,
-        "issue_number": req.issue_number,
+    image = await get_own_image()
+    env = {
+        "WORKER_TASK": "implement",
+        "WORKER_REPO": req.repo,
+        "WORKER_ISSUE_NUMBER": str(req.issue_number),
+        "GH_TOKEN": req.github_token,
+        "COPILOT_GITHUB_TOKEN": os.environ.get("COPILOT_GITHUB_TOKEN", ""),
+        "MODEL": model,
+        "REASONING_EFFORT": effort,
     }
 
-    background_tasks.add_task(
-        _run_implement,
-        repo=req.repo,
-        issue_number=req.issue_number,
-        model=model,
-        reasoning_effort=effort,
+    start = time.monotonic()
+    TASK_IN_PROGRESS.labels(task_type="implement").inc()
+
+    container_id = await spawn_worker(
+        task_type="implement",
+        image=image,
+        env=env,
+        number=req.issue_number,
+        volumes=["repo-cache:/repo.git", "reviews:/reviews"],
     )
 
+    _spawn_monitor(container_id, task_type="implement", number=req.issue_number, start=start)
     return {"status": "accepted", "issue_number": req.issue_number}
 
 
 @app.get("/implement/{issue_number}")
 async def get_implement_status(issue_number: int, repo: str = "") -> dict:
-    """Check the status of an implementation."""
-    key = _implement_key(repo, issue_number) if repo else None
-
-    if key and key in _implement_status:
-        return _implement_status[key]
-
-    for v in _implement_status.values():
-        if v.get("issue_number") == issue_number:
-            return v
-
+    """Check the status of an implementation by checking the worker container."""
+    running = await is_worker_running("implement", issue_number)
+    if running:
+        return {"status": "in_progress", "issue_number": issue_number}
     return {"status": "not_found", "issue_number": issue_number}
-
-
-# --- Background tasks ---
-
-
-async def _run_review(
-    *, repo: str, pr_number: int, model: str, reasoning_effort: str, session_id: str | None = None
-) -> None:
-    key = _review_key(repo, pr_number)
-    status = "failed"
-    premium_requests = 0
-    start = time.monotonic()
-    progress_comment_id: int | None = None
-    TASK_IN_PROGRESS.labels(task_type="review").inc()
-    try:
-        progress_comment_id = await _start_review_progress_comment(repo, pr_number)
-        result = await review_pr(
-            repo=repo,
-            pr_number=pr_number,
-            model=model,
-            reasoning_effort=reasoning_effort,
-            session_id=session_id,
-        )
-        status = _task_status_label(result.get("status"))
-        premium_requests = _premium_requests(result)
-        _review_status[key] = {
-            "status": result.get("status", "complete"),
-            "repo": repo,
-            "pr_number": pr_number,
-            **result,
-        }
-        await _update_progress_comment(
-            repo, progress_comment_id, "✅ Review posted — see review above"
-        )
-    except asyncio.CancelledError:
-        logger.info("Review cancelled for %s#%d", repo, pr_number)
-        status = "cancelled"
-        _review_status[key] = {"status": "cancelled", "repo": repo, "pr_number": pr_number}
-        await _update_progress_comment(
-            repo, progress_comment_id, _review_progress_cancelled_comment()
-        )
-        raise
-    except TaskError as exc:
-        logger.exception("Review failed for %s#%d", repo, pr_number)
-        _review_status[key] = {"status": "failed", "repo": repo, "pr_number": pr_number}
-        premium_requests = exc.premium_requests
-        await _update_progress_comment(
-            repo, progress_comment_id, _review_progress_failure_comment(str(exc))
-        )
-        if not exc.commented:
-            with contextlib.suppress(Exception):
-                await comment_on_issue(repo, pr_number, f"⚠️ **Review failed** — {exc}")
-    except Exception:
-        logger.exception("Review failed for %s#%d", repo, pr_number)
-        _review_status[key] = {"status": "failed", "repo": repo, "pr_number": pr_number}
-        await _update_progress_comment(
-            repo,
-            progress_comment_id,
-            _review_progress_failure_comment("see agent logs for details."),
-        )
-        with contextlib.suppress(Exception):
-            await comment_on_issue(
-                repo, pr_number, "⚠️ **Review failed** — see agent logs for details."
-            )
-    finally:
-        _record_task_metrics(
-            task_type="review",
-            status=status,
-            duration_seconds=time.monotonic() - start,
-            premium_requests=premium_requests,
-        )
-        TASK_IN_PROGRESS.labels(task_type="review").dec()
-        current_task = asyncio.current_task()
-        if current_task is not None and _review_tasks.get(key) is current_task:
-            _review_tasks.pop(key, None)
-
-
-async def _run_implement(
-    *, repo: str, issue_number: int, model: str, reasoning_effort: str
-) -> None:
-    key = _implement_key(repo, issue_number)
-    status = "failed"
-    premium_requests = 0
-    progress_comment_id: int | None = None
-    start = time.monotonic()
-    TASK_IN_PROGRESS.labels(task_type="implement").inc()
-    try:
-        issue = await _get_issue_for_progress(repo, issue_number)
-        if issue is not None:
-            progress_comment_id = await _start_implement_progress_comment(repo, issue_number)
-
-        result = await implement_issue(
-            repo=repo,
-            issue_number=issue_number,
-            model=model,
-            reasoning_effort=reasoning_effort,
-            issue=issue,
-        )
-        status = _task_status_label(result.get("status"))
-        premium_requests = _premium_requests(result)
-        _implement_status[key] = {
-            "status": result.get("status", "complete"),
-            "repo": repo,
-            "issue_number": issue_number,
-            **result,
-        }
-        pr_number = result.get("pr_number")
-        pr_url = result.get("pr_url")
-        auto_merge = result.get("auto_merge", False)
-        if isinstance(pr_number, int) and isinstance(pr_url, str):
-            await _update_progress_comment(
-                repo,
-                progress_comment_id,
-                _implement_progress_success_comment(pr_number, pr_url, auto_merge=auto_merge),
-            )
-    except ValueError as exc:
-        # Content trust rejection — don't interact with the issue
-        logger.warning("Implementation rejected for %s#%d: %s", repo, issue_number, exc)
-        _implement_status[key] = {
-            "status": "rejected",
-            "repo": repo,
-            "issue_number": issue_number,
-        }
-    except TaskError as exc:
-        logger.exception("Implementation failed for %s#%d", repo, issue_number)
-        _implement_status[key] = {
-            "status": "failed",
-            "repo": repo,
-            "issue_number": issue_number,
-        }
-        premium_requests = exc.premium_requests
-        await _update_progress_comment(
-            repo, progress_comment_id, _implement_progress_failure_comment(str(exc))
-        )
-        if not exc.commented:
-            with contextlib.suppress(Exception):
-                await comment_on_issue(
-                    repo,
-                    issue_number,
-                    f"⚠️ **Implementation failed** — {exc}",
-                )
-    except Exception:
-        logger.exception("Implementation failed for %s#%d", repo, issue_number)
-        _implement_status[key] = {
-            "status": "failed",
-            "repo": repo,
-            "issue_number": issue_number,
-        }
-        await _update_progress_comment(
-            repo,
-            progress_comment_id,
-            _implement_progress_failure_comment("see agent logs for details."),
-        )
-        with contextlib.suppress(Exception):
-            await comment_on_issue(
-                repo,
-                issue_number,
-                "⚠️ **Implementation failed** — see agent logs for details.",
-            )
-    finally:
-        _record_task_metrics(
-            task_type="implement",
-            status=status,
-            duration_seconds=time.monotonic() - start,
-            premium_requests=premium_requests,
-        )
-        TASK_IN_PROGRESS.labels(task_type="implement").dec()

--- a/stacks/agents/app/metrics.py
+++ b/stacks/agents/app/metrics.py
@@ -3,7 +3,7 @@
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
 TASK_TYPES = ("review", "implement", "fix")
-TASK_STATUSES = ("complete", "failed", "partial")
+TASK_STATUSES = ("complete", "failed", "partial", "rejected")
 
 METRICS_REGISTRY = CollectorRegistry()
 

--- a/stacks/agents/app/services/docker.py
+++ b/stacks/agents/app/services/docker.py
@@ -5,9 +5,13 @@ restarts (ADR-011). Workers use the same image with a different entrypoint.
 """
 
 import asyncio
+import contextlib
 import json
 import logging
+import re
 import socket
+from datetime import datetime
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +61,24 @@ async def get_own_image() -> str:
 def _worker_name(task_type: str, number: int) -> str:
     """Generate a deterministic worker container name."""
     return f"worker-{task_type}-{number}"
+
+
+def _parse_worker_name(name: str) -> tuple[str, int] | None:
+    """Parse 'worker-review-42' → ('review', 42). Returns None if invalid."""
+    parts = name.split("-", 2)
+    if len(parts) != 3 or parts[0] != "worker":
+        return None
+    try:
+        return parts[1], int(parts[2])
+    except ValueError:
+        return None
+
+
+def _parse_docker_timestamp(ts: str) -> float:
+    """Parse a Docker timestamp (RFC 3339 with nanoseconds) to Unix epoch."""
+    # Truncate nanosecond precision to microsecond for datetime.fromisoformat
+    ts = re.sub(r"(\.\d{6})\d+", r"\1", ts.strip())
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
 
 
 async def spawn_worker(
@@ -178,31 +200,124 @@ def parse_worker_result(logs: str) -> dict:
     return {}
 
 
-async def cleanup_orphaned_workers() -> None:
-    """Remove any stopped worker containers left from a previous API run.
+async def cleanup_orphaned_workers() -> list[dict[str, Any]]:
+    """Remove stopped worker containers and return their info for metric harvesting.
 
     Called on startup to clean up containers that weren't reaped because
-    the API was restarted while monitoring them.
+    the API was restarted while monitoring them. Returns parsed info so
+    main.py can record metrics before the data is lost.
     """
+    harvested: list[dict[str, Any]] = []
     try:
         output = await _run_docker(
             "ps", "-a", "--filter", "name=worker-", "--format", "{{.Names}} {{.Status}}"
         )
     except RuntimeError:
         logger.warning("Docker not available — skipping orphaned worker cleanup")
-        return
+        return harvested
 
     if not output:
-        return
+        return harvested
 
     for line in output.splitlines():
         parts = line.strip().split(None, 1)
         if len(parts) < 2:
             continue
         name, status = parts[0], parts[1]
-        if status.startswith("Exited"):
-            try:
+        if not status.startswith("Exited"):
+            continue
+
+        parsed = _parse_worker_name(name)
+        if parsed is None:
+            with contextlib.suppress(RuntimeError):
                 await _run_docker("rm", name)
-                logger.info("Cleaned up orphaned worker container %s", name)
-            except RuntimeError:
-                logger.warning("Failed to clean up container %s", name)
+            continue
+
+        task_type, number = parsed
+
+        # Harvest logs and timestamps before removing
+        logs = ""
+        duration = 0.0
+        with contextlib.suppress(RuntimeError):
+            logs = await _run_docker("logs", name)
+
+        try:
+            ts_output = await _run_docker(
+                "inspect", "--format", "{{.State.StartedAt}} {{.State.FinishedAt}}", name
+            )
+            ts_parts = ts_output.strip().split()
+            if len(ts_parts) == 2:
+                started = _parse_docker_timestamp(ts_parts[0])
+                finished = _parse_docker_timestamp(ts_parts[1])
+                duration = max(0.0, finished - started)
+        except Exception:
+            pass
+
+        harvested.append(
+            {
+                "task_type": task_type,
+                "number": number,
+                "logs": logs,
+                "duration_seconds": duration,
+            }
+        )
+
+        try:
+            await _run_docker("rm", name)
+            logger.info("Cleaned up orphaned worker container %s", name)
+        except RuntimeError:
+            logger.warning("Failed to clean up container %s", name)
+
+    return harvested
+
+
+async def discover_running_workers() -> list[dict[str, Any]]:
+    """Find running worker containers left from a previous API run.
+
+    Called on startup to reconnect monitors for workers that outlived
+    the previous API process. Returns info needed to spawn monitors.
+    """
+    try:
+        output = await _run_docker(
+            "ps",
+            "--filter",
+            "name=worker-",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.ID}} {{.Names}}",
+        )
+    except RuntimeError:
+        return []
+
+    if not output:
+        return []
+
+    workers: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        parts = line.strip().split()
+        if len(parts) < 2:
+            continue
+        container_id, name = parts[0], parts[1]
+        parsed = _parse_worker_name(name)
+        if parsed is None:
+            continue
+        task_type, number = parsed
+
+        started_at = 0.0
+        try:
+            ts = await _run_docker("inspect", "--format", "{{.State.StartedAt}}", container_id)
+            started_at = _parse_docker_timestamp(ts)
+        except Exception:
+            pass
+
+        workers.append(
+            {
+                "container_id": container_id,
+                "task_type": task_type,
+                "number": number,
+                "started_at": started_at,
+            }
+        )
+
+    return workers

--- a/stacks/agents/app/services/docker.py
+++ b/stacks/agents/app/services/docker.py
@@ -1,0 +1,208 @@
+"""Docker container management — spawns and monitors ephemeral worker containers.
+
+The API uses Docker to run CLI tasks in isolated containers that survive API
+restarts (ADR-011). Workers use the same image with a different entrypoint.
+"""
+
+import asyncio
+import json
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
+# Resource limits matching the API container (compose.yaml)
+_WORKER_MEMORY = "2g"
+_WORKER_CPUS = "2.0"
+
+
+async def _run_docker(*args: str) -> str:
+    """Run a docker CLI command and return stdout."""
+    proc = await asyncio.create_subprocess_exec(
+        "docker",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"docker {args[0]} failed (exit {proc.returncode}): {stderr.decode().strip()}"
+        )
+    return stdout.decode().strip()
+
+
+async def get_own_image() -> str:
+    """Detect the Docker image of the currently running container.
+
+    Uses the container hostname (Docker sets this to the short container ID)
+    to inspect our own image. Falls back to WORKER_IMAGE env var.
+    """
+    import os
+
+    explicit = os.environ.get("WORKER_IMAGE")
+    if explicit:
+        return explicit
+
+    container_id = socket.gethostname()
+    try:
+        return await _run_docker("inspect", "--format", "{{.Config.Image}}", container_id)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "Cannot detect own Docker image. Set WORKER_IMAGE env var "
+            "or ensure Docker socket is mounted."
+        ) from exc
+
+
+def _worker_name(task_type: str, number: int) -> str:
+    """Generate a deterministic worker container name."""
+    return f"worker-{task_type}-{number}"
+
+
+async def spawn_worker(
+    *,
+    task_type: str,
+    image: str,
+    env: dict[str, str],
+    number: int,
+    volumes: list[str] | None = None,
+) -> str:
+    """Spawn an ephemeral worker container and return its container ID.
+
+    Args:
+        task_type: "implement" or "review"
+        image: Docker image to use (same as API)
+        env: Environment variables to pass to the worker
+        number: Issue or PR number (used for naming)
+        volumes: Volume mounts in "name:/path" format
+    """
+    name = _worker_name(task_type, number)
+
+    # Stop any existing worker for the same task (supersession)
+    await stop_worker(task_type, number)
+
+    cmd = [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--memory",
+        _WORKER_MEMORY,
+        "--cpus",
+        _WORKER_CPUS,
+        "--security-opt",
+        "no-new-privileges:true",
+        "--cap-drop",
+        "ALL",
+    ]
+
+    for key, value in env.items():
+        cmd.extend(["-e", f"{key}={value}"])
+
+    for vol in volumes or []:
+        cmd.extend(["-v", vol])
+
+    cmd.extend([image, "python", "-m", "worker"])
+
+    container_id = await _run_docker(*cmd)
+    logger.info(
+        "Spawned worker container %s (%s) for %s #%d",
+        name,
+        container_id[:12],
+        task_type,
+        number,
+    )
+    return container_id
+
+
+async def wait_container(container_id: str) -> int:
+    """Block until a container exits and return its exit code."""
+    result = await _run_docker("wait", container_id)
+    return int(result.strip())
+
+
+async def get_logs(container_id: str) -> str:
+    """Retrieve stdout/stderr logs from a container."""
+    return await _run_docker("logs", container_id)
+
+
+async def remove_container(container_id: str) -> None:
+    """Remove a stopped container."""
+    try:
+        await _run_docker("rm", container_id)
+    except RuntimeError:
+        logger.warning("Failed to remove container %s", container_id)
+
+
+async def stop_worker(task_type: str, number: int) -> None:
+    """Stop a running worker container if it exists."""
+    name = _worker_name(task_type, number)
+    try:
+        # Check if container exists and is running
+        state = await _run_docker("inspect", "--format", "{{.State.Running}}", name)
+        if state.strip() == "true":
+            await _run_docker("stop", name)
+            logger.info("Stopped existing worker %s", name)
+        # Remove stopped container so name can be reused
+        await _run_docker("rm", name)
+    except RuntimeError:
+        pass  # Container doesn't exist — nothing to stop
+
+
+async def is_worker_running(task_type: str, number: int) -> bool:
+    """Check if a worker container is currently running."""
+    name = _worker_name(task_type, number)
+    try:
+        state = await _run_docker("inspect", "--format", "{{.State.Running}}", name)
+        return state.strip() == "true"
+    except RuntimeError:
+        return False
+
+
+def parse_worker_result(logs: str) -> dict:
+    """Parse the JSON result line from worker container logs.
+
+    The worker writes a single JSON line to stdout as its last action.
+    All other output goes to stderr (Python logging).
+    """
+    for line in reversed(logs.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            result = json.loads(line)
+            if isinstance(result, dict):
+                return result
+        except json.JSONDecodeError:
+            continue
+    return {}
+
+
+async def cleanup_orphaned_workers() -> None:
+    """Remove any stopped worker containers left from a previous API run.
+
+    Called on startup to clean up containers that weren't reaped because
+    the API was restarted while monitoring them.
+    """
+    try:
+        output = await _run_docker(
+            "ps", "-a", "--filter", "name=worker-", "--format", "{{.Names}} {{.Status}}"
+        )
+    except RuntimeError:
+        logger.warning("Docker not available — skipping orphaned worker cleanup")
+        return
+
+    if not output:
+        return
+
+    for line in output.splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) < 2:
+            continue
+        name, status = parts[0], parts[1]
+        if status.startswith("Exited"):
+            try:
+                await _run_docker("rm", name)
+                logger.info("Cleaned up orphaned worker container %s", name)
+            except RuntimeError:
+                logger.warning("Failed to clean up container %s", name)

--- a/stacks/agents/app/tests/test_docker.py
+++ b/stacks/agents/app/tests/test_docker.py
@@ -5,8 +5,11 @@ import os
 from unittest.mock import AsyncMock, patch
 
 from services.docker import (
+    _parse_docker_timestamp,
+    _parse_worker_name,
     _worker_name,
     cleanup_orphaned_workers,
+    discover_running_workers,
     get_own_image,
     is_worker_running,
     parse_worker_result,
@@ -18,6 +21,32 @@ from services.docker import (
 def test_worker_name_format():
     assert _worker_name("review", 42) == "worker-review-42"
     assert _worker_name("implement", 10) == "worker-implement-10"
+
+
+def test_parse_worker_name_valid():
+    assert _parse_worker_name("worker-review-42") == ("review", 42)
+    assert _parse_worker_name("worker-implement-10") == ("implement", 10)
+
+
+def test_parse_worker_name_invalid():
+    assert _parse_worker_name("not-a-worker") is None
+    assert _parse_worker_name("worker-review") is None
+    assert _parse_worker_name("worker-review-abc") is None
+    assert _parse_worker_name("") is None
+
+
+def test_parse_docker_timestamp():
+    ts = "2026-04-14T00:30:00.123456789Z"
+    epoch = _parse_docker_timestamp(ts)
+    assert isinstance(epoch, float)
+    assert epoch > 0
+
+
+def test_parse_docker_timestamp_no_nanos():
+    ts = "2026-04-14T00:30:00Z"
+    epoch = _parse_docker_timestamp(ts)
+    assert isinstance(epoch, float)
+    assert epoch > 0
 
 
 def test_parse_worker_result_extracts_json():
@@ -152,27 +181,35 @@ def test_stop_worker_handles_nonexistent(mock_docker):
 
 
 @patch("services.docker._run_docker", new_callable=AsyncMock)
-def test_cleanup_orphaned_workers_removes_exited(mock_docker):
+def test_cleanup_orphaned_workers_removes_exited_and_harvests(mock_docker):
+    """Cleanup should harvest logs/timestamps and return info for metrics."""
     mock_docker.side_effect = [
         "worker-review-42 Exited (0) 5 minutes ago",  # ps -a
+        '{"status": "complete", "premium_requests": 5}\n',  # logs
+        "2026-04-14T00:00:00Z 2026-04-14T00:10:00Z",  # inspect timestamps
         "",  # rm
     ]
 
-    asyncio.run(cleanup_orphaned_workers())
+    harvested = asyncio.run(cleanup_orphaned_workers())
 
-    assert mock_docker.call_count == 2
-    rm_call = mock_docker.call_args_list[1]
-    assert rm_call.args[0] == "rm"
-    assert rm_call.args[1] == "worker-review-42"
+    assert len(harvested) == 1
+    assert harvested[0]["task_type"] == "review"
+    assert harvested[0]["number"] == 42
+    assert "complete" in str(harvested[0]["logs"])
+    assert harvested[0]["duration_seconds"] == 600.0
+
+    rm_call = [c for c in mock_docker.call_args_list if c.args[0] == "rm"]
+    assert len(rm_call) == 1
+    assert rm_call[0].args[1] == "worker-review-42"
 
 
 @patch("services.docker._run_docker", new_callable=AsyncMock)
 def test_cleanup_orphaned_workers_skips_running(mock_docker):
     mock_docker.return_value = "worker-review-42 Up 5 minutes"
 
-    asyncio.run(cleanup_orphaned_workers())
+    harvested = asyncio.run(cleanup_orphaned_workers())
 
-    # Only the ps call, no rm
+    assert harvested == []
     assert mock_docker.call_count == 1
 
 
@@ -180,4 +217,58 @@ def test_cleanup_orphaned_workers_skips_running(mock_docker):
 def test_cleanup_handles_no_docker(mock_docker):
     """Should not crash when Docker is unavailable."""
     mock_docker.side_effect = RuntimeError("docker not found")
-    asyncio.run(cleanup_orphaned_workers())  # Should not raise
+    harvested = asyncio.run(cleanup_orphaned_workers())
+    assert harvested == []
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_cleanup_handles_log_failure_gracefully(mock_docker):
+    """Cleanup should still remove containers even if log retrieval fails."""
+    mock_docker.side_effect = [
+        "worker-implement-10 Exited (1) 2 minutes ago",  # ps -a
+        RuntimeError("logs failed"),  # logs
+        "2026-04-14T00:00:00Z 2026-04-14T00:05:00Z",  # inspect timestamps
+        "",  # rm
+    ]
+
+    harvested = asyncio.run(cleanup_orphaned_workers())
+
+    assert len(harvested) == 1
+    assert harvested[0]["logs"] == ""
+    assert harvested[0]["duration_seconds"] == 300.0
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_discover_running_workers_finds_containers(mock_docker):
+    mock_docker.side_effect = [
+        "abc123 worker-review-42",  # ps --filter running
+        "2026-04-14T00:00:00Z",  # inspect StartedAt
+    ]
+
+    workers = asyncio.run(discover_running_workers())
+
+    assert len(workers) == 1
+    assert workers[0]["container_id"] == "abc123"
+    assert workers[0]["task_type"] == "review"
+    assert workers[0]["number"] == 42
+    started_at = workers[0]["started_at"]
+    assert isinstance(started_at, float)
+    assert started_at > 0
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_discover_running_workers_returns_empty_when_none(mock_docker):
+    mock_docker.return_value = ""
+
+    workers = asyncio.run(discover_running_workers())
+
+    assert workers == []
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_discover_running_workers_handles_docker_unavailable(mock_docker):
+    mock_docker.side_effect = RuntimeError("docker not found")
+
+    workers = asyncio.run(discover_running_workers())
+
+    assert workers == []

--- a/stacks/agents/app/tests/test_docker.py
+++ b/stacks/agents/app/tests/test_docker.py
@@ -1,0 +1,183 @@
+"""Tests for the Docker container spawning service."""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
+from services.docker import (
+    _worker_name,
+    cleanup_orphaned_workers,
+    get_own_image,
+    is_worker_running,
+    parse_worker_result,
+    spawn_worker,
+    stop_worker,
+)
+
+
+def test_worker_name_format():
+    assert _worker_name("review", 42) == "worker-review-42"
+    assert _worker_name("implement", 10) == "worker-implement-10"
+
+
+def test_parse_worker_result_extracts_json():
+    logs = '2025-01-01 INFO Starting worker\n{"status": "complete", "premium_requests": 5}\n'
+    result = parse_worker_result(logs)
+    assert result == {"status": "complete", "premium_requests": 5}
+
+
+def test_parse_worker_result_uses_last_json_line():
+    logs = '{"status": "failed"}\nsome log line\n{"status": "complete", "premium_requests": 3}\n'
+    result = parse_worker_result(logs)
+    assert result == {"status": "complete", "premium_requests": 3}
+
+
+def test_parse_worker_result_returns_empty_on_no_json():
+    logs = "just some logs\nno json here\n"
+    result = parse_worker_result(logs)
+    assert result == {}
+
+
+def test_parse_worker_result_skips_non_dict_json():
+    logs = '"just a string"\n[1, 2, 3]\n'
+    result = parse_worker_result(logs)
+    assert result == {}
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_get_own_image_from_env(mock_docker):
+    """WORKER_IMAGE env var takes priority over Docker inspect."""
+    with patch.dict(os.environ, {"WORKER_IMAGE": "my-image:v1"}):
+        image = asyncio.run(get_own_image())
+    assert image == "my-image:v1"
+    mock_docker.assert_not_called()
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock, return_value="agent:latest")
+def test_get_own_image_from_docker_inspect(mock_docker):
+    """Falls back to Docker inspect when WORKER_IMAGE is not set."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("WORKER_IMAGE", None)
+        image = asyncio.run(get_own_image())
+    assert image == "agent:latest"
+    mock_docker.assert_awaited_once()
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_spawn_worker_calls_docker_run(mock_docker):
+    mock_docker.return_value = "container123"
+
+    container_id = asyncio.run(
+        spawn_worker(
+            task_type="review",
+            image="agent:latest",
+            env={"WORKER_TASK": "review", "GH_TOKEN": "tok"},
+            number=42,
+            volumes=["repo-cache:/repo.git"],
+        )
+    )
+
+    assert container_id == "container123"
+    # First call is stop_worker (inspect), second is docker run
+    # stop_worker's inspect will raise RuntimeError (no existing container)
+    run_call = None
+    for c in mock_docker.call_args_list:
+        if c.args[0] == "run":
+            run_call = c
+            break
+    assert run_call is not None
+    args = run_call.args
+    assert "run" in args
+    assert "-d" in args
+    assert "--name" in args
+    assert "worker-review-42" in args
+    assert "agent:latest" in args
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_spawn_worker_stops_existing_first(mock_docker):
+    """spawn_worker should attempt to stop any existing worker with the same name."""
+    call_log = []
+
+    async def track_calls(*args):
+        call_log.append(args[0])
+        if args[0] == "inspect":
+            return "true"
+        return "container456"
+
+    mock_docker.side_effect = track_calls
+
+    asyncio.run(
+        spawn_worker(
+            task_type="implement",
+            image="agent:latest",
+            env={"WORKER_TASK": "implement"},
+            number=10,
+        )
+    )
+
+    # Should call inspect, stop, rm (from stop_worker), then run
+    assert "inspect" in call_log
+    assert "stop" in call_log
+    assert "rm" in call_log
+    assert "run" in call_log
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_is_worker_running_returns_true(mock_docker):
+    mock_docker.return_value = "true"
+    result = asyncio.run(is_worker_running("review", 42))
+    assert result is True
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_is_worker_running_returns_false_when_stopped(mock_docker):
+    mock_docker.return_value = "false"
+    result = asyncio.run(is_worker_running("review", 42))
+    assert result is False
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_is_worker_running_returns_false_when_not_found(mock_docker):
+    mock_docker.side_effect = RuntimeError("no such container")
+    result = asyncio.run(is_worker_running("review", 42))
+    assert result is False
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_stop_worker_handles_nonexistent(mock_docker):
+    """stop_worker should not raise if the container doesn't exist."""
+    mock_docker.side_effect = RuntimeError("no such container")
+    asyncio.run(stop_worker("review", 42))  # Should not raise
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_cleanup_orphaned_workers_removes_exited(mock_docker):
+    mock_docker.side_effect = [
+        "worker-review-42 Exited (0) 5 minutes ago",  # ps -a
+        "",  # rm
+    ]
+
+    asyncio.run(cleanup_orphaned_workers())
+
+    assert mock_docker.call_count == 2
+    rm_call = mock_docker.call_args_list[1]
+    assert rm_call.args[0] == "rm"
+    assert rm_call.args[1] == "worker-review-42"
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_cleanup_orphaned_workers_skips_running(mock_docker):
+    mock_docker.return_value = "worker-review-42 Up 5 minutes"
+
+    asyncio.run(cleanup_orphaned_workers())
+
+    # Only the ps call, no rm
+    assert mock_docker.call_count == 1
+
+
+@patch("services.docker._run_docker", new_callable=AsyncMock)
+def test_cleanup_handles_no_docker(mock_docker):
+    """Should not crash when Docker is unavailable."""
+    mock_docker.side_effect = RuntimeError("docker not found")
+    asyncio.run(cleanup_orphaned_workers())  # Should not raise

--- a/stacks/agents/app/tests/test_main.py
+++ b/stacks/agents/app/tests/test_main.py
@@ -11,6 +11,7 @@ from main import (
     ReviewRequest,
     _monitor_tasks,
     _monitor_worker,
+    _task_status_label,
     app,
     handle_review,
 )
@@ -45,14 +46,83 @@ def test_health():
     assert resp.json() == {"status": "ok"}
 
 
-@patch("main.cleanup_orphaned_workers", new_callable=AsyncMock)
+# --- Status label tests ---
+
+
+def test_task_status_label_known_statuses():
+    assert _task_status_label("complete") == "complete"
+    assert _task_status_label("failed") == "failed"
+    assert _task_status_label("partial") == "partial"
+    assert _task_status_label("rejected") == "rejected"
+
+
+def test_task_status_label_unknown_defaults_to_failed():
+    assert _task_status_label("whatever") == "failed"
+    assert _task_status_label("") == "failed"
+    assert _task_status_label(None) == "failed"
+
+
+# --- Startup tests ---
+
+
+@patch("main.discover_running_workers", new_callable=AsyncMock, return_value=[])
+@patch("main.cleanup_orphaned_workers", new_callable=AsyncMock, return_value=[])
 @patch("main.reap_old_worktrees", new_callable=AsyncMock)
-def test_startup_reaps_worktrees_and_orphans(mock_reap, mock_cleanup):
+def test_startup_reaps_worktrees_and_orphans(mock_reap, mock_cleanup, mock_discover):
     with TestClient(app):
         pass
 
     mock_reap.assert_awaited_once()
     mock_cleanup.assert_awaited_once()
+    mock_discover.assert_awaited_once()
+
+
+@patch("main.discover_running_workers", new_callable=AsyncMock, return_value=[])
+@patch("main.cleanup_orphaned_workers", new_callable=AsyncMock)
+@patch("main.reap_old_worktrees", new_callable=AsyncMock)
+def test_startup_harvests_metrics_from_orphans(mock_reap, mock_cleanup, mock_discover):
+    """Startup should record metrics from stopped workers before removing them."""
+    mock_cleanup.return_value = [
+        {
+            "task_type": "review",
+            "number": 42,
+            "logs": '{"status": "complete", "premium_requests": 5}\n',
+            "duration_seconds": 300.0,
+        }
+    ]
+
+    with TestClient(app):
+        pass
+
+    assert _metric_value("agent_task_total", {"task_type": "review", "status": "complete"}) == 1.0
+    assert _metric_value("agent_premium_requests_total", {"task_type": "review"}) == 5.0
+
+
+@patch("main._spawn_monitor")
+@patch("main.discover_running_workers", new_callable=AsyncMock)
+@patch("main.cleanup_orphaned_workers", new_callable=AsyncMock, return_value=[])
+@patch("main.reap_old_worktrees", new_callable=AsyncMock)
+def test_startup_reconnects_monitors_for_running_workers(
+    mock_reap, mock_cleanup, mock_discover, mock_monitor
+):
+    """Startup should reconnect monitors for workers still running."""
+    mock_discover.return_value = [
+        {
+            "container_id": "abc123",
+            "task_type": "implement",
+            "number": 10,
+            "started_at": 1000000.0,
+        }
+    ]
+
+    with TestClient(app):
+        pass
+
+    mock_monitor.assert_called_once()
+    call_kwargs = mock_monitor.call_args
+    assert call_kwargs.args[0] == "abc123"
+    assert call_kwargs.kwargs["task_type"] == "implement"
+    assert call_kwargs.kwargs["number"] == 10
 
 
 def test_metrics_endpoint_exposes_prometheus_text():
@@ -271,6 +341,21 @@ def test_monitor_records_metrics_on_failure(mock_wait, mock_logs, mock_rm):
     assert _metric_value("agent_task_total", {"task_type": "implement", "status": "failed"}) == 1.0
     assert _metric_value("agent_premium_requests_total", {"task_type": "implement"}) == 3.0
     mock_rm.assert_awaited_once_with("abc123")
+
+
+@patch("main.remove_container", new_callable=AsyncMock)
+@patch("main.get_logs", new_callable=AsyncMock)
+@patch("main.wait_container", new_callable=AsyncMock)
+def test_monitor_records_rejected_status(mock_wait, mock_logs, mock_rm):
+    """Monitor should record 'rejected' status correctly, not as 'complete'."""
+    mock_wait.return_value = 1
+    mock_logs.return_value = '{"status": "rejected", "premium_requests": 0}\n'
+
+    asyncio.run(_monitor_worker("abc123", task_type="implement", number=10, start=0.0))
+
+    assert (
+        _metric_value("agent_task_total", {"task_type": "implement", "status": "rejected"}) == 1.0
+    )
 
 
 @patch("main.remove_container", new_callable=AsyncMock)

--- a/stacks/agents/app/tests/test_main.py
+++ b/stacks/agents/app/tests/test_main.py
@@ -1,21 +1,16 @@
-"""Tests for the agent service."""
+"""Tests for the agent service (container-dispatch architecture)."""
 
 import asyncio
-from typing import Any
-from unittest.mock import AsyncMock, call, patch
+import os
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from main import (
     ReviewRequest,
-    _implement_status,
-    _review_locks,
-    _review_request_ids,
-    _review_status,
-    _review_tasks,
-    _run_implement,
-    _run_review,
+    _monitor_tasks,
+    _monitor_worker,
     app,
     handle_review,
 )
@@ -23,16 +18,6 @@ from metrics import METRICS_REGISTRY, reset_metrics
 
 _ACTOR = "ColinCee"
 _TOKEN = "ghs_test_token"
-
-
-def _review_req(**kwargs: Any) -> ReviewRequest:
-    defaults: dict[str, Any] = {
-        "repo": "user/repo",
-        "pr_number": 42,
-        "triggered_by": _ACTOR,
-        "github_token": _TOKEN,
-    }
-    return ReviewRequest(**(defaults | kwargs))
 
 
 def _client():
@@ -48,18 +33,10 @@ def _metric_value(name: str, labels: dict[str, str]) -> float:
 @pytest.fixture(autouse=True)
 def reset_state():
     reset_metrics()
-    _review_locks.clear()
-    _review_request_ids.clear()
-    _review_status.clear()
-    _review_tasks.clear()
-    _implement_status.clear()
+    _monitor_tasks.clear()
     yield
     reset_metrics()
-    _review_locks.clear()
-    _review_request_ids.clear()
-    _review_status.clear()
-    _review_tasks.clear()
-    _implement_status.clear()
+    _monitor_tasks.clear()
 
 
 def test_health():
@@ -68,12 +45,14 @@ def test_health():
     assert resp.json() == {"status": "ok"}
 
 
+@patch("main.cleanup_orphaned_workers", new_callable=AsyncMock)
 @patch("main.reap_old_worktrees", new_callable=AsyncMock)
-def test_startup_reaps_old_worktrees(mock_reap):
+def test_startup_reaps_worktrees_and_orphans(mock_reap, mock_cleanup):
     with TestClient(app):
         pass
 
     mock_reap.assert_awaited_once()
+    mock_cleanup.assert_awaited_once()
 
 
 def test_metrics_endpoint_exposes_prometheus_text():
@@ -84,27 +63,31 @@ def test_metrics_endpoint_exposes_prometheus_text():
     assert 'agent_task_in_progress{task_type="review"} 0.0' in resp.text
 
 
-@patch("main.asyncio.create_task")
-def test_review_returns_202_accepted(mock_create_task):
-    async def run() -> None:
-        task = asyncio.get_running_loop().create_task(asyncio.sleep(3600))
+# --- Review endpoint tests ---
 
-        def fake_create_task(coro):
-            coro.close()
-            return task
 
-        mock_create_task.side_effect = fake_create_task
-
-        result = await handle_review(_review_req(pr_number=1))
-
-        assert result == {"status": "accepted", "pr_number": 1}
-        assert _review_tasks["user/repo#1"] is task
-
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-
-    asyncio.run(run())
+@patch("main._spawn_monitor")
+@patch("main.spawn_worker", new_callable=AsyncMock, return_value="abc123")
+@patch("main.get_own_image", new_callable=AsyncMock, return_value="agent:latest")
+def test_review_returns_202_accepted(mock_image, mock_spawn, mock_monitor):
+    resp = _client().post(
+        "/review",
+        json={
+            "repo": "user/repo",
+            "pr_number": 42,
+            "triggered_by": _ACTOR,
+            "github_token": _TOKEN,
+        },
+    )
+    assert resp.status_code == 202
+    assert resp.json() == {"status": "accepted", "pr_number": 42}
+    mock_spawn.assert_awaited_once()
+    call_kwargs = mock_spawn.call_args.kwargs
+    assert call_kwargs["task_type"] == "review"
+    assert call_kwargs["number"] == 42
+    assert call_kwargs["env"]["WORKER_TASK"] == "review"
+    assert call_kwargs["env"]["WORKER_REPO"] == "user/repo"
+    assert call_kwargs["env"]["WORKER_PR_NUMBER"] == "42"
 
 
 def test_review_missing_fields():
@@ -126,116 +109,75 @@ def test_review_rejects_unknown_actor():
     assert "not allowed" in resp.json()["error"]
 
 
-def test_review_status_not_found():
+@patch("main.is_worker_running", new_callable=AsyncMock, return_value=False)
+def test_review_status_not_found(mock_running):
     resp = _client().get("/review/99999")
     assert resp.status_code == 200
     assert resp.json()["status"] == "not_found"
 
 
-def test_review_replaces_duplicate_in_flight():
-    """A second review for the same PR should cancel the stale task and start fresh."""
+@patch("main.is_worker_running", new_callable=AsyncMock, return_value=True)
+def test_review_status_in_progress(mock_running):
+    resp = _client().get("/review/42")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "in_progress"
 
-    async def run() -> None:
-        key = "user/repo#42"
-        existing_task = asyncio.create_task(asyncio.sleep(3600))
-        replacement_task = asyncio.create_task(asyncio.sleep(3600))
 
-        _review_status[key] = {
-            "status": "in_progress",
+@patch("main._spawn_monitor")
+@patch("main.spawn_worker", new_callable=AsyncMock, return_value="abc123")
+@patch("main.get_own_image", new_callable=AsyncMock, return_value="agent:latest")
+def test_review_supersedes_existing_worker(mock_image, mock_spawn, mock_monitor):
+    """Spawning a review for the same PR should stop the existing worker."""
+    # spawn_worker internally calls stop_worker first — verify it's called with right params
+    resp = _client().post(
+        "/review",
+        json={
             "repo": "user/repo",
             "pr_number": 42,
-        }
-        _review_tasks[key] = existing_task
-
-        def fake_create_task(coro):
-            coro.close()
-            return replacement_task
-
-        with patch("main.asyncio.create_task", side_effect=fake_create_task) as mock_create_task:
-            result = await handle_review(_review_req())
-
-        assert result == {"status": "accepted", "pr_number": 42}
-        assert existing_task.cancelled()
-        assert _review_tasks[key] is replacement_task
-        assert _review_status[key]["status"] == "in_progress"
-        mock_create_task.assert_called_once()
-
-        replacement_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await replacement_task
-
-    asyncio.run(run())
+            "triggered_by": _ACTOR,
+            "github_token": _TOKEN,
+        },
+    )
+    assert resp.status_code == 202
+    # spawn_worker handles supersession internally via stop_worker
+    mock_spawn.assert_awaited_once()
 
 
-def test_review_coalesces_concurrent_replacements():
-    """Concurrent duplicate /review requests should only spawn one fresh task."""
-
-    async def run() -> None:
-        key = "user/repo#42"
-        replacement_tasks: list[asyncio.Task[None]] = []
-        cancellation_started = asyncio.Event()
-        release_cancellation = asyncio.Event()
-
-        async def stale_review() -> None:
-            try:
-                await asyncio.Future()
-            except asyncio.CancelledError:
-                cancellation_started.set()
-                await release_cancellation.wait()
-                raise
-
-        _review_status[key] = {
-            "status": "in_progress",
-            "repo": "user/repo",
-            "pr_number": 42,
-        }
-        existing_task = asyncio.create_task(stale_review())
-        _review_tasks[key] = existing_task
-        await asyncio.sleep(0)
-
-        def fake_create_task(coro):
-            coro.close()
-            task = asyncio.get_running_loop().create_task(asyncio.sleep(3600))
-            replacement_tasks.append(task)
-            return task
-
-        with patch("main.asyncio.create_task", side_effect=fake_create_task):
-            results_task = asyncio.gather(
-                handle_review(_review_req()),
-                handle_review(_review_req()),
-            )
-            await cancellation_started.wait()
-            release_cancellation.set()
-            results = await results_task
-
-        assert results == [
-            {"status": "accepted", "pr_number": 42},
-            {"status": "accepted", "pr_number": 42},
-        ]
-        assert existing_task.cancelled()
-        assert len(replacement_tasks) == 1
-        assert _review_tasks[key] is replacement_tasks[0]
-
-        for task in replacement_tasks:
-            task.cancel()
-            with pytest.raises(asyncio.CancelledError):
-                await task
-
-    asyncio.run(run())
+@patch("main._spawn_monitor")
+@patch("main.spawn_worker", new_callable=AsyncMock, return_value="abc123")
+@patch("main.get_own_image", new_callable=AsyncMock, return_value="agent:latest")
+def test_review_passes_copilot_token_to_worker(mock_image, mock_spawn, mock_monitor):
+    """Worker env should include COPILOT_GITHUB_TOKEN from the API's own env."""
+    with patch.dict(os.environ, {"COPILOT_GITHUB_TOKEN": "cptoken123"}):
+        resp = _client().post(
+            "/review",
+            json={
+                "repo": "user/repo",
+                "pr_number": 42,
+                "triggered_by": _ACTOR,
+                "github_token": _TOKEN,
+            },
+        )
+    assert resp.status_code == 202
+    env = mock_spawn.call_args.kwargs["env"]
+    assert env["COPILOT_GITHUB_TOKEN"] == "cptoken123"
+    assert env["GH_TOKEN"] == _TOKEN
 
 
 # --- Implement endpoint tests ---
 
 
-@patch("main.implement_issue", new_callable=AsyncMock)
-def test_implement_returns_202_accepted(mock_impl):
-    mock_impl.return_value = {"pr_number": 99, "elapsed_seconds": 5.0}
+@patch("main._spawn_monitor")
+@patch("main.spawn_worker", new_callable=AsyncMock, return_value="def456")
+@patch("main.get_own_image", new_callable=AsyncMock, return_value="agent:latest")
+@patch("main.is_worker_running", new_callable=AsyncMock, return_value=False)
+def test_implement_returns_202_accepted(mock_running, mock_image, mock_spawn, mock_monitor):
     resp = _client().post(
         "/implement",
         json={
             "repo": "user/repo",
             "issue_number": 10,
-            "triggered_by": "ColinCee",
+            "triggered_by": _ACTOR,
             "github_token": _TOKEN,
         },
     )
@@ -243,6 +185,10 @@ def test_implement_returns_202_accepted(mock_impl):
     data = resp.json()
     assert data["status"] == "accepted"
     assert data["issue_number"] == 10
+    mock_spawn.assert_awaited_once()
+    call_kwargs = mock_spawn.call_args.kwargs
+    assert call_kwargs["env"]["WORKER_TASK"] == "implement"
+    assert call_kwargs["env"]["WORKER_ISSUE_NUMBER"] == "10"
 
 
 def test_implement_missing_fields():
@@ -264,371 +210,139 @@ def test_implement_rejects_unknown_actor():
     assert "not allowed" in resp.json()["error"]
 
 
-def test_implement_status_not_found():
+@patch("main.is_worker_running", new_callable=AsyncMock, return_value=False)
+def test_implement_status_not_found(mock_running):
     resp = _client().get("/implement/99999")
     assert resp.status_code == 200
     assert resp.json()["status"] == "not_found"
 
 
-@patch("main.implement_issue", new_callable=AsyncMock)
-def test_implement_rejects_duplicate_in_flight(mock_impl):
-    from main import _implement_status
-
-    _implement_status["user/repo#10"] = {
-        "status": "in_progress",
-        "repo": "user/repo",
-        "issue_number": 10,
-    }
-    try:
-        resp = _client().post(
-            "/implement",
-            json={
-                "repo": "user/repo",
-                "issue_number": 10,
-                "triggered_by": "ColinCee",
-                "github_token": _TOKEN,
-            },
-        )
-        assert resp.status_code == 409
-        assert resp.json()["status"] == "already_in_progress"
-        mock_impl.assert_not_called()
-    finally:
-        _implement_status.pop("user/repo#10", None)
+@patch("main.is_worker_running", new_callable=AsyncMock, return_value=True)
+def test_implement_status_in_progress(mock_running):
+    resp = _client().get("/implement/10")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "in_progress"
 
 
-def test_review_metrics_track_task_lifecycle():
-    started = asyncio.Event()
-    finish = asyncio.Event()
-
-    async def fake_review_pr(**_kwargs) -> dict[str, object]:
-        started.set()
-        await finish.wait()
-        return {"premium_requests": 2}
-
-    async def run() -> None:
-        with patch("main.review_pr", new=AsyncMock(side_effect=fake_review_pr)):
-            task = asyncio.create_task(
-                _run_review(
-                    repo="user/repo",
-                    pr_number=101,
-                    model="gpt-5.4",
-                    reasoning_effort="high",
-                )
-            )
-            await started.wait()
-            assert _metric_value("agent_task_in_progress", {"task_type": "review"}) == 1.0
-            finish.set()
-            await task
-
-    asyncio.run(run())
-
-    labels = {"task_type": "review", "status": "complete"}
-    assert _metric_value("agent_task_in_progress", {"task_type": "review"}) == 0.0
-    assert _metric_value("agent_task_total", labels) == 1.0
-    assert _metric_value("agent_premium_requests_total", {"task_type": "review"}) == 2.0
-    assert _metric_value("agent_task_duration_seconds_count", labels) == 1.0
-
-
-@patch("main.implement_issue", new_callable=AsyncMock)
-def test_implement_metrics_record_partial_status(mock_implement):
-    mock_implement.return_value = {"status": "partial", "premium_requests": 3}
-
-    asyncio.run(
-        _run_implement(
-            repo="user/repo",
-            issue_number=202,
-            model="gpt-5.4",
-            reasoning_effort="high",
-        )
+@patch("main.is_worker_running", new_callable=AsyncMock, return_value=True)
+def test_implement_rejects_duplicate_in_flight(mock_running):
+    resp = _client().post(
+        "/implement",
+        json={
+            "repo": "user/repo",
+            "issue_number": 10,
+            "triggered_by": _ACTOR,
+            "github_token": _TOKEN,
+        },
     )
+    assert resp.status_code == 409
+    assert resp.json()["status"] == "already_in_progress"
 
-    labels = {"task_type": "implement", "status": "partial"}
-    assert _metric_value("agent_task_in_progress", {"task_type": "implement"}) == 0.0
-    assert _metric_value("agent_task_total", labels) == 1.0
+
+# --- Monitor tests ---
+
+
+@patch("main.remove_container", new_callable=AsyncMock)
+@patch("main.get_logs", new_callable=AsyncMock)
+@patch("main.wait_container", new_callable=AsyncMock)
+def test_monitor_records_metrics_on_success(mock_wait, mock_logs, mock_rm):
+    """Monitor should record metrics when worker exits successfully."""
+    mock_wait.return_value = 0
+    mock_logs.return_value = '{"status": "complete", "premium_requests": 5}\n'
+
+    asyncio.run(_monitor_worker("abc123", task_type="review", number=42, start=0.0))
+
+    assert _metric_value("agent_task_total", {"task_type": "review", "status": "complete"}) == 1.0
+    assert _metric_value("agent_premium_requests_total", {"task_type": "review"}) == 5.0
+    assert _metric_value("agent_task_in_progress", {"task_type": "review"}) == -1.0
+    mock_rm.assert_awaited_once_with("abc123")
+
+
+@patch("main.remove_container", new_callable=AsyncMock)
+@patch("main.get_logs", new_callable=AsyncMock)
+@patch("main.wait_container", new_callable=AsyncMock)
+def test_monitor_records_metrics_on_failure(mock_wait, mock_logs, mock_rm):
+    """Monitor should record failure metrics when worker exits with non-zero."""
+    mock_wait.return_value = 1
+    mock_logs.return_value = '{"status": "failed", "premium_requests": 3}\n'
+
+    asyncio.run(_monitor_worker("abc123", task_type="implement", number=10, start=0.0))
+
+    assert _metric_value("agent_task_total", {"task_type": "implement", "status": "failed"}) == 1.0
     assert _metric_value("agent_premium_requests_total", {"task_type": "implement"}) == 3.0
-    assert _metric_value("agent_task_duration_seconds_count", labels) == 1.0
+    mock_rm.assert_awaited_once_with("abc123")
 
 
-@patch("main.implement_issue", new_callable=AsyncMock)
-def test_implement_status_preserves_merge_details(mock_implement):
-    mock_implement.return_value = {
-        "status": "complete",
-        "merged": True,
-        "merge_commit_sha": "merge123",
-        "merge_method": "squash",
-        "premium_requests": 4,
-    }
+@patch("main.remove_container", new_callable=AsyncMock)
+@patch("main.get_logs", new_callable=AsyncMock)
+@patch("main.wait_container", new_callable=AsyncMock)
+def test_monitor_handles_unparseable_logs(mock_wait, mock_logs, mock_rm):
+    """Monitor should degrade gracefully when worker logs can't be parsed."""
+    mock_wait.return_value = 0
+    mock_logs.return_value = "some random output with no JSON\n"
 
-    asyncio.run(
-        _run_implement(
+    asyncio.run(_monitor_worker("abc123", task_type="review", number=42, start=0.0))
+
+    assert _metric_value("agent_task_total", {"task_type": "review", "status": "complete"}) == 1.0
+    assert _metric_value("agent_premium_requests_total", {"task_type": "review"}) == 0.0
+
+
+@patch("main.remove_container", new_callable=AsyncMock)
+@patch("main.get_logs", new_callable=AsyncMock)
+@patch("main.wait_container", new_callable=AsyncMock)
+def test_monitor_cleans_up_monitor_tasks_dict(mock_wait, mock_logs, mock_rm):
+    """Monitor should remove itself from _monitor_tasks on completion."""
+    mock_wait.return_value = 0
+    mock_logs.return_value = '{"status": "complete"}\n'
+    _monitor_tasks["review-42"] = AsyncMock()  # type: ignore[assignment]
+
+    asyncio.run(_monitor_worker("abc123", task_type="review", number=42, start=0.0))
+
+    assert "review-42" not in _monitor_tasks
+
+
+# --- Review dispatch handles session_id (currently not stored, but ensure no crash) ---
+
+
+@patch("main._spawn_monitor")
+@patch("main.spawn_worker", new_callable=AsyncMock, return_value="abc123")
+@patch("main.get_own_image", new_callable=AsyncMock, return_value="agent:latest")
+def test_review_accepts_model_override(mock_image, mock_spawn, mock_monitor):
+    """Review request with explicit model should pass it to the worker."""
+    resp = _client().post(
+        "/review",
+        json={
+            "repo": "user/repo",
+            "pr_number": 42,
+            "triggered_by": _ACTOR,
+            "github_token": _TOKEN,
+            "model": "claude-sonnet-4",
+            "reasoning_effort": "low",
+        },
+    )
+    assert resp.status_code == 202
+    env = mock_spawn.call_args.kwargs["env"]
+    assert env["MODEL"] == "claude-sonnet-4"
+    assert env["REASONING_EFFORT"] == "low"
+
+
+# --- handle_review async tests ---
+
+
+@patch("main._spawn_monitor")
+@patch("main.spawn_worker", new_callable=AsyncMock, return_value="abc123")
+@patch("main.get_own_image", new_callable=AsyncMock, return_value="agent:latest")
+def test_review_via_async_handle(mock_image, mock_spawn, mock_monitor):
+    """Verify handle_review works when called directly (async)."""
+
+    async def run():
+        req = ReviewRequest(
             repo="user/repo",
-            issue_number=404,
-            model="gpt-5.4",
-            reasoning_effort="high",
+            pr_number=1,
+            triggered_by=_ACTOR,
+            github_token=_TOKEN,
         )
-    )
-
-    status = _implement_status["user/repo#404"]
-    assert status["status"] == "complete"
-    assert status["merged"] is True
-    assert status["merge_commit_sha"] == "merge123"
-    assert status["merge_method"] == "squash"
-
-
-# --- Fire-and-forget safety: error comments on failures ---
-
-
-@patch("main.update_comment", new_callable=AsyncMock)
-@patch("main.comment_on_issue", new_callable=AsyncMock, return_value=1001)
-@patch("main.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("main.review_pr", new_callable=AsyncMock)
-def test_review_updates_progress_comment_on_success(
-    mock_review, mock_find_comment, mock_comment, mock_update
-):
-    mock_review.return_value = {"model": "gpt-5.4", "elapsed_seconds": 1.5}
-
-    asyncio.run(
-        _run_review(repo="user/repo", pr_number=42, model="gpt-5.4", reasoning_effort="high")
-    )
-
-    mock_find_comment.assert_awaited_once_with(
-        "user/repo",
-        42,
-        "🔄 Review in progress for PR #",
-    )
-    mock_comment.assert_awaited_once_with("user/repo", 42, "🔄 Review in progress for PR #42...")
-    mock_update.assert_awaited_once_with("user/repo", 1001, "✅ Review posted — see review above")
-
-
-@patch("main.update_comment", new_callable=AsyncMock)
-@patch("main.comment_on_issue", new_callable=AsyncMock)
-@patch("main.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=2002)
-@patch("main.review_pr", new_callable=AsyncMock)
-def test_review_reuses_stale_progress_comment(
-    mock_review, mock_find_comment, mock_comment, mock_update
-):
-    mock_review.return_value = {"model": "gpt-5.4", "elapsed_seconds": 1.5}
-
-    asyncio.run(
-        _run_review(repo="user/repo", pr_number=42, model="gpt-5.4", reasoning_effort="high")
-    )
-
-    mock_find_comment.assert_awaited_once_with(
-        "user/repo",
-        42,
-        "🔄 Review in progress for PR #",
-    )
-    mock_comment.assert_not_called()
-    assert mock_update.await_args_list == [
-        call("user/repo", 2002, "🔄 Review in progress for PR #42..."),
-        call("user/repo", 2002, "✅ Review posted — see review above"),
-    ]
-
-
-@patch("main.update_comment", new_callable=AsyncMock)
-@patch("main.comment_on_issue", new_callable=AsyncMock)
-@patch("main.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=2002)
-def test_review_cancellation_updates_progress_comment(mock_find_comment, mock_comment, mock_update):
-    started = asyncio.Event()
-
-    async def fake_review_pr(**_kwargs):
-        started.set()
-        await asyncio.Future()
-
-    async def run() -> None:
-        key = "user/repo#42"
-        with patch("main.review_pr", new=AsyncMock(side_effect=fake_review_pr)):
-            task = asyncio.create_task(
-                _run_review(
-                    repo="user/repo",
-                    pr_number=42,
-                    model="gpt-5.4",
-                    reasoning_effort="high",
-                )
-            )
-            _review_tasks[key] = task
-            await started.wait()
-            task.cancel()
-            with pytest.raises(asyncio.CancelledError):
-                await task
+        result = await handle_review(req)
+        assert result == {"status": "accepted", "pr_number": 1}
 
     asyncio.run(run())
-
-    mock_find_comment.assert_awaited_once_with(
-        "user/repo",
-        42,
-        "🔄 Review in progress for PR #",
-    )
-    mock_comment.assert_not_called()
-    assert mock_update.await_args_list == [
-        call("user/repo", 2002, "🔄 Review in progress for PR #42..."),
-        call(
-            "user/repo",
-            2002,
-            "⏹️ Review cancelled — superseded by newer /review request",
-        ),
-    ]
-    assert "user/repo#42" not in _review_tasks
-    assert _review_status["user/repo#42"]["status"] == "cancelled"
-
-
-@patch("main.update_comment", new_callable=AsyncMock)
-@patch("main.comment_on_issue", new_callable=AsyncMock, return_value=1001)
-@patch("main.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("main.review_pr", new_callable=AsyncMock)
-def test_review_failure_posts_error_comment(
-    mock_review, _mock_find_comment, mock_comment, mock_update
-):
-    """When review_pr raises, _run_review updates progress and posts an error comment."""
-    from services.copilot import TaskError
-
-    mock_review.side_effect = TaskError("CLI timed out", premium_requests=3)
-
-    asyncio.run(
-        _run_review(repo="user/repo", pr_number=42, model="gpt-5.4", reasoning_effort="high")
-    )
-
-    assert mock_comment.await_count == 2
-    assert mock_comment.await_args_list[0] == call(
-        "user/repo", 42, "🔄 Review in progress for PR #42..."
-    )
-    assert mock_comment.await_args_list[1] == call(
-        "user/repo", 42, "⚠️ **Review failed** — CLI timed out"
-    )
-    mock_update.assert_awaited_once_with("user/repo", 1001, "⚠️ Review failed — CLI timed out")
-
-
-@patch("main.update_comment", new_callable=AsyncMock)
-@patch("main.comment_on_issue", new_callable=AsyncMock, return_value=1001)
-@patch("main.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("main.review_pr", new_callable=AsyncMock)
-def test_review_failure_skips_comment_when_already_commented(
-    mock_review, _mock_find_comment, mock_comment, mock_update
-):
-    """When TaskError has commented=True, _run_review only updates the progress comment."""
-    from services.copilot import TaskError
-
-    mock_review.side_effect = TaskError("parse error", premium_requests=1, commented=True)
-
-    asyncio.run(
-        _run_review(repo="user/repo", pr_number=42, model="gpt-5.4", reasoning_effort="high")
-    )
-
-    mock_comment.assert_awaited_once_with("user/repo", 42, "🔄 Review in progress for PR #42...")
-    mock_update.assert_awaited_once_with("user/repo", 1001, "⚠️ Review failed — parse error")
-
-
-@patch("main.update_comment", new_callable=AsyncMock)
-@patch("main.comment_on_issue", new_callable=AsyncMock, return_value=1001)
-@patch("main.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("main.review_pr", new_callable=AsyncMock)
-def test_review_unexpected_failure_posts_generic_comment(
-    mock_review, _mock_find_comment, mock_comment, mock_update
-):
-    """Non-TaskError exceptions also get an error comment."""
-    mock_review.side_effect = RuntimeError("unexpected")
-
-    asyncio.run(
-        _run_review(repo="user/repo", pr_number=42, model="gpt-5.4", reasoning_effort="high")
-    )
-
-    assert mock_comment.await_count == 2
-    assert mock_comment.await_args_list[0] == call(
-        "user/repo", 42, "🔄 Review in progress for PR #42..."
-    )
-    assert "see agent logs" in mock_comment.await_args_list[1].args[2]
-    mock_update.assert_awaited_once_with(
-        "user/repo", 1001, "⚠️ Review failed — see agent logs for details."
-    )
-
-
-@patch("main.update_comment", new_callable=AsyncMock)
-@patch("main.comment_on_issue", new_callable=AsyncMock, return_value=3003)
-@patch("main.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("main._get_issue_for_progress", new_callable=AsyncMock, return_value={"title": "x"})
-@patch("main.implement_issue", new_callable=AsyncMock)
-def test_implement_updates_progress_comment_on_success(
-    mock_impl, _mock_issue, mock_find_comment, mock_comment, mock_update
-):
-    mock_impl.return_value = {
-        "status": "complete",
-        "pr_number": 99,
-        "pr_url": "https://github.com/user/repo/pull/99",
-    }
-
-    asyncio.run(
-        _run_implement(repo="user/repo", issue_number=10, model="gpt-5.4", reasoning_effort="high")
-    )
-
-    mock_find_comment.assert_awaited_once_with("user/repo", 10, "🔄 Implementing #")
-    mock_comment.assert_awaited_once_with("user/repo", 10, "🔄 Implementing #10...")
-    mock_update.assert_awaited_once_with(
-        "user/repo",
-        3003,
-        "✅ PR #99 created — https://github.com/user/repo/pull/99",
-    )
-
-
-@patch("main.update_comment", new_callable=AsyncMock)
-@patch("main.comment_on_issue", new_callable=AsyncMock)
-@patch("main.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=4004)
-@patch("main._get_issue_for_progress", new_callable=AsyncMock, return_value={"title": "x"})
-@patch("main.implement_issue", new_callable=AsyncMock)
-def test_implement_reuses_stale_progress_comment(
-    mock_impl, _mock_issue, mock_find_comment, mock_comment, mock_update
-):
-    mock_impl.return_value = {
-        "status": "complete",
-        "pr_number": 99,
-        "pr_url": "https://github.com/user/repo/pull/99",
-    }
-
-    asyncio.run(
-        _run_implement(repo="user/repo", issue_number=10, model="gpt-5.4", reasoning_effort="high")
-    )
-
-    mock_find_comment.assert_awaited_once_with("user/repo", 10, "🔄 Implementing #")
-    mock_comment.assert_not_called()
-    assert mock_update.await_args_list == [
-        call("user/repo", 4004, "🔄 Implementing #10..."),
-        call("user/repo", 4004, "✅ PR #99 created — https://github.com/user/repo/pull/99"),
-    ]
-
-
-@patch("main.update_comment", new_callable=AsyncMock)
-@patch("main.comment_on_issue", new_callable=AsyncMock, return_value=3003)
-@patch("main.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("main._get_issue_for_progress", new_callable=AsyncMock, return_value={"title": "x"})
-@patch("main.implement_issue", new_callable=AsyncMock)
-def test_implement_failure_posts_error_comment(
-    mock_impl, _mock_issue, _mock_find_comment, mock_comment, mock_update
-):
-    """When implement_issue raises, _run_implement updates progress and posts an error comment."""
-    from services.copilot import TaskError
-
-    mock_impl.side_effect = TaskError("CLI crashed", premium_requests=5)
-
-    asyncio.run(
-        _run_implement(repo="user/repo", issue_number=10, model="gpt-5.4", reasoning_effort="high")
-    )
-
-    assert mock_comment.await_count == 2
-    assert mock_comment.await_args_list[0] == call("user/repo", 10, "🔄 Implementing #10...")
-    assert "Implementation failed" in mock_comment.await_args_list[1].args[2]
-    mock_update.assert_awaited_once_with("user/repo", 3003, "⚠️ Implementation failed — CLI crashed")
-
-
-@patch("main.comment_on_issue", new_callable=AsyncMock)
-@patch("main._get_issue_for_progress", new_callable=AsyncMock)
-@patch("main.implement_issue", new_callable=AsyncMock)
-def test_implement_content_rejection_does_not_post_comment(mock_impl, mock_issue, mock_comment):
-    """Content trust rejection should not post a progress or error comment."""
-    mock_issue.return_value = {"title": "x"}
-    mock_impl.side_effect = ValueError("not trusted")
-
-    asyncio.run(
-        _run_implement(repo="user/repo", issue_number=10, model="gpt-5.4", reasoning_effort="high")
-    )
-
-    mock_comment.assert_not_called()
-    assert _implement_status["user/repo#10"]["status"] == "rejected"

--- a/stacks/agents/app/tests/test_worker.py
+++ b/stacks/agents/app/tests/test_worker.py
@@ -1,0 +1,224 @@
+"""Tests for the ephemeral worker entrypoint."""
+
+import asyncio
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@patch.dict(
+    os.environ,
+    {
+        "WORKER_TASK": "implement",
+        "WORKER_REPO": "user/repo",
+        "WORKER_ISSUE_NUMBER": "10",
+        "GH_TOKEN": "ghs_test",
+        "MODEL": "gpt-5.4",
+        "REASONING_EFFORT": "high",
+    },
+)
+@patch("worker.implement_issue", new_callable=AsyncMock)
+@patch("worker.get_issue", new_callable=AsyncMock, return_value={"title": "test"})
+@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
+@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
+@patch("worker.update_comment", new_callable=AsyncMock)
+def test_implement_success_returns_zero(
+    mock_update, mock_find, mock_comment, mock_issue, mock_impl, capsys
+):
+    mock_impl.return_value = {
+        "status": "complete",
+        "pr_number": 99,
+        "pr_url": "https://github.com/user/repo/pull/99",
+        "premium_requests": 5,
+    }
+
+    from worker import main
+
+    exit_code = asyncio.run(main())
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    result = json.loads(captured.out.strip())
+    assert result["status"] == "complete"
+    assert result["premium_requests"] == 5
+    mock_impl.assert_awaited_once()
+
+
+@patch.dict(
+    os.environ,
+    {
+        "WORKER_TASK": "implement",
+        "WORKER_REPO": "user/repo",
+        "WORKER_ISSUE_NUMBER": "10",
+        "GH_TOKEN": "ghs_test",
+    },
+)
+@patch("worker.implement_issue", new_callable=AsyncMock)
+@patch("worker.get_issue", new_callable=AsyncMock, return_value={"title": "test"})
+@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
+@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
+@patch("worker.update_comment", new_callable=AsyncMock)
+def test_implement_failure_returns_one(
+    mock_update, mock_find, mock_comment, mock_issue, mock_impl, capsys
+):
+    mock_impl.return_value = {
+        "status": "failed",
+        "premium_requests": 2,
+    }
+
+    from worker import main
+
+    exit_code = asyncio.run(main())
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    result = json.loads(captured.out.strip())
+    assert result["status"] == "failed"
+
+
+@patch.dict(
+    os.environ,
+    {
+        "WORKER_TASK": "implement",
+        "WORKER_REPO": "user/repo",
+        "WORKER_ISSUE_NUMBER": "10",
+        "GH_TOKEN": "ghs_test",
+    },
+)
+@patch("worker.implement_issue", new_callable=AsyncMock)
+@patch("worker.get_issue", new_callable=AsyncMock, return_value={"title": "test"})
+@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
+@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
+@patch("worker.update_comment", new_callable=AsyncMock)
+def test_implement_exception_posts_error_comment(
+    mock_update, mock_find, mock_comment, mock_issue, mock_impl, capsys
+):
+    from services.copilot import TaskError
+
+    mock_impl.side_effect = TaskError("CLI crashed", premium_requests=3)
+
+    from worker import main
+
+    exit_code = asyncio.run(main())
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    result = json.loads(captured.out.strip())
+    assert result["status"] == "failed"
+    assert result["premium_requests"] == 3
+
+    # Should have posted error comment
+    error_calls = [c for c in mock_comment.call_args_list if "failed" in str(c).lower()]
+    assert len(error_calls) > 0
+
+
+@patch.dict(
+    os.environ,
+    {
+        "WORKER_TASK": "review",
+        "WORKER_REPO": "user/repo",
+        "WORKER_PR_NUMBER": "42",
+        "GH_TOKEN": "ghs_test",
+        "MODEL": "gpt-5.4",
+        "REASONING_EFFORT": "high",
+    },
+)
+@patch("worker.review_pr", new_callable=AsyncMock)
+@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
+@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
+@patch("worker.update_comment", new_callable=AsyncMock)
+def test_review_success_returns_zero(mock_update, mock_find, mock_comment, mock_review, capsys):
+    mock_review.return_value = {
+        "status": "complete",
+        "premium_requests": 2,
+    }
+
+    from worker import main
+
+    exit_code = asyncio.run(main())
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    result = json.loads(captured.out.strip())
+    assert result["status"] == "complete"
+    mock_review.assert_awaited_once()
+
+
+@patch.dict(
+    os.environ,
+    {
+        "WORKER_TASK": "review",
+        "WORKER_REPO": "user/repo",
+        "WORKER_PR_NUMBER": "42",
+        "GH_TOKEN": "ghs_test",
+    },
+)
+@patch("worker.review_pr", new_callable=AsyncMock)
+@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
+@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
+@patch("worker.update_comment", new_callable=AsyncMock)
+def test_review_posts_progress_comment(mock_update, mock_find, mock_comment, mock_review):
+    mock_review.return_value = {"status": "complete", "premium_requests": 1}
+
+    from worker import main
+
+    asyncio.run(main())
+
+    # Should have posted a progress comment with the review prefix
+    progress_calls = [c for c in mock_comment.call_args_list if "Review in progress" in str(c)]
+    assert len(progress_calls) > 0
+
+
+@patch.dict(
+    os.environ,
+    {
+        "WORKER_TASK": "implement",
+        "WORKER_REPO": "user/repo",
+        "WORKER_ISSUE_NUMBER": "10",
+        "GH_TOKEN": "ghs_test",
+    },
+)
+@patch("worker.implement_issue", new_callable=AsyncMock)
+@patch("worker.get_issue", new_callable=AsyncMock, return_value={"title": "test"})
+@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
+@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
+@patch("worker.update_comment", new_callable=AsyncMock)
+def test_implement_content_rejection_returns_one(
+    mock_update, mock_find, mock_comment, mock_issue, mock_impl, capsys
+):
+    """Content trust rejection should not post error comments."""
+    mock_impl.side_effect = ValueError("not trusted")
+
+    from worker import main
+
+    exit_code = asyncio.run(main())
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    result = json.loads(captured.out.strip())
+    assert result["status"] == "rejected"
+
+
+def test_unknown_task_type_returns_one():
+    with patch.dict(
+        os.environ,
+        {
+            "WORKER_TASK": "unknown",
+            "WORKER_REPO": "user/repo",
+            "GH_TOKEN": "ghs_test",
+        },
+    ):
+        from worker import main
+
+        exit_code = asyncio.run(main())
+        assert exit_code == 1
+
+
+def test_missing_env_var_raises():
+    with patch.dict(os.environ, {}, clear=True):
+        from worker import _require_env
+
+        with pytest.raises(RuntimeError, match="WORKER_TASK"):
+            _require_env("WORKER_TASK")

--- a/stacks/agents/app/worker.py
+++ b/stacks/agents/app/worker.py
@@ -1,0 +1,210 @@
+"""Ephemeral worker entrypoint — runs a single agent task then exits.
+
+Spawned by the API via `docker run ... python -m worker`. Reads task
+parameters from environment variables, calls the appropriate orchestrator,
+posts progress/result comments to GitHub, and writes a JSON result to stdout
+for the API's monitor coroutine to parse.
+"""
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sys
+
+from implement import implement_issue
+from review import review_pr
+from services.copilot import TaskError
+from services.github import (
+    comment_on_issue,
+    find_issue_comment_by_body_prefix,
+    get_issue,
+    set_token,
+    update_comment,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+REVIEW_PROGRESS_PREFIX = "🔄 Review in progress for PR #"
+IMPLEMENT_PROGRESS_PREFIX = "🔄 Implementing #"
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Required environment variable {name} is not set")
+    return value
+
+
+async def _start_progress_comment(
+    repo: str, issue_number: int, *, body: str, body_prefix: str
+) -> int | None:
+    """Post or update a progress comment on an issue/PR."""
+    with contextlib.suppress(Exception):
+        comment_id = await find_issue_comment_by_body_prefix(repo, issue_number, body_prefix)
+        if comment_id is not None:
+            await update_comment(repo, comment_id, body)
+            return comment_id
+        return await comment_on_issue(repo, issue_number, body)
+    return None
+
+
+async def _update_progress_comment(repo: str, comment_id: int | None, body: str) -> None:
+    if comment_id is None:
+        return
+    with contextlib.suppress(Exception):
+        await update_comment(repo, comment_id, body)
+
+
+async def _run_implement(repo: str, issue_number: int, model: str, effort: str) -> dict:
+    """Run the implement lifecycle and return a result dict."""
+    progress_comment_id: int | None = None
+
+    try:
+        issue = None
+        with contextlib.suppress(Exception):
+            issue = await get_issue(repo, issue_number)
+
+        if issue is not None:
+            progress_comment_id = await _start_progress_comment(
+                repo,
+                issue_number,
+                body=f"{IMPLEMENT_PROGRESS_PREFIX}{issue_number}...",
+                body_prefix=IMPLEMENT_PROGRESS_PREFIX,
+            )
+
+        result = await implement_issue(
+            repo=repo,
+            issue_number=issue_number,
+            model=model,
+            reasoning_effort=effort,
+            issue=issue,
+        )
+
+        pr_number = result.get("pr_number")
+        pr_url = result.get("pr_url")
+        auto_merge = result.get("auto_merge", False)
+        if isinstance(pr_number, int) and isinstance(pr_url, str):
+            if auto_merge:
+                msg = f"✅ PR #{pr_number} created (auto-merge enabled) — {pr_url}"
+            else:
+                msg = f"✅ PR #{pr_number} created — {pr_url}"
+            await _update_progress_comment(repo, progress_comment_id, msg)
+
+        return result
+
+    except ValueError as exc:
+        logger.warning("Implementation rejected for %s#%d: %s", repo, issue_number, exc)
+        return {"status": "rejected", "premium_requests": 0}
+
+    except TaskError as exc:
+        logger.exception("Implementation failed for %s#%d", repo, issue_number)
+        await _update_progress_comment(
+            repo, progress_comment_id, f"⚠️ Implementation failed — {exc}"
+        )
+        if not exc.commented:
+            with contextlib.suppress(Exception):
+                await comment_on_issue(repo, issue_number, f"⚠️ **Implementation failed** — {exc}")
+        return {"status": "failed", "premium_requests": exc.premium_requests}
+
+    except Exception as exc:
+        logger.exception("Implementation failed for %s#%d", repo, issue_number)
+        await _update_progress_comment(
+            repo,
+            progress_comment_id,
+            "⚠️ Implementation failed — see agent logs for details.",
+        )
+        with contextlib.suppress(Exception):
+            await comment_on_issue(
+                repo, issue_number, "⚠️ **Implementation failed** — see agent logs for details."
+            )
+        return {"status": "failed", "premium_requests": 0, "error": str(exc)}
+
+
+async def _run_review(
+    repo: str, pr_number: int, model: str, effort: str, session_id: str | None
+) -> dict:
+    """Run the review lifecycle and return a result dict."""
+    progress_comment_id: int | None = None
+
+    try:
+        progress_comment_id = await _start_progress_comment(
+            repo,
+            pr_number,
+            body=f"{REVIEW_PROGRESS_PREFIX}{pr_number}...",
+            body_prefix=REVIEW_PROGRESS_PREFIX,
+        )
+
+        result = await review_pr(
+            repo=repo,
+            pr_number=pr_number,
+            model=model,
+            reasoning_effort=effort,
+            session_id=session_id,
+        )
+
+        await _update_progress_comment(
+            repo, progress_comment_id, "✅ Review posted — see review above"
+        )
+        return result
+
+    except TaskError as exc:
+        logger.exception("Review failed for %s#%d", repo, pr_number)
+        await _update_progress_comment(repo, progress_comment_id, f"⚠️ Review failed — {exc}")
+        if not exc.commented:
+            with contextlib.suppress(Exception):
+                await comment_on_issue(repo, pr_number, f"⚠️ **Review failed** — {exc}")
+        return {"status": "failed", "premium_requests": exc.premium_requests}
+
+    except Exception as exc:
+        logger.exception("Review failed for %s#%d", repo, pr_number)
+        await _update_progress_comment(
+            repo,
+            progress_comment_id,
+            "⚠️ Review failed — see agent logs for details.",
+        )
+        with contextlib.suppress(Exception):
+            await comment_on_issue(
+                repo, pr_number, "⚠️ **Review failed** — see agent logs for details."
+            )
+        return {"status": "failed", "premium_requests": 0, "error": str(exc)}
+
+
+async def main() -> int:
+    """Worker entrypoint — dispatch to the appropriate task handler."""
+    task_type = _require_env("WORKER_TASK")
+    repo = _require_env("WORKER_REPO")
+    gh_token = _require_env("GH_TOKEN")
+    model = os.environ.get("MODEL", "gpt-5.4")
+    effort = os.environ.get("REASONING_EFFORT", "high")
+
+    set_token(gh_token)
+
+    if task_type == "implement":
+        issue_number = int(_require_env("WORKER_ISSUE_NUMBER"))
+        logger.info("Worker starting: implement %s#%d", repo, issue_number)
+        result = await _run_implement(repo, issue_number, model, effort)
+
+    elif task_type == "review":
+        pr_number = int(_require_env("WORKER_PR_NUMBER"))
+        session_id = os.environ.get("WORKER_SESSION_ID")
+        logger.info("Worker starting: review %s#%d", repo, pr_number)
+        result = await _run_review(repo, pr_number, model, effort, session_id)
+
+    else:
+        logger.error("Unknown task type: %s", task_type)
+        return 1
+
+    # Write result as JSON to stdout for the API monitor to parse
+    print(json.dumps(result), flush=True)
+
+    number = issue_number if task_type == "implement" else pr_number  # type: ignore[possibly-unbound]
+    status = result.get("status", "unknown")
+    logger.info("Worker finished: %s %s#%s → %s", task_type, repo, number, status)
+    return 0 if status in ("complete", "partial") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/stacks/agents/compose.yaml
+++ b/stacks/agents/compose.yaml
@@ -24,6 +24,7 @@ services:
     volumes:
       - repo-cache:/repo.git
       - reviews:/reviews
+      - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8585/health"]
       interval: 30s


### PR DESCRIPTION
## What

Replace in-process subprocess spawning with Docker container spawning so CLI tasks (review, implement) survive API restarts/redeploys (Dokploy auto-deploys on push to main).

## Architecture (before → after)

**Before:** API → asyncio background task → orchestrator → subprocess → CLI
**After:** API → `docker run` → worker container → orchestator → CLI subprocess (inside worker)

### What moves to the worker container
- Progress comment posting (🔄 / ✅ / ⚠️ lifecycle)
- Orchestrator calls (implement_issue, review_pr)
- All CLI interaction (worktree, subprocess, stats parsing)

### What stays in the API
- HTTP endpoints, trust validation, token generation
- Worker spawning via `services/docker.py`
- Metrics recording via `docker wait` + log parsing (monitor coroutine)
- Status queries via `docker inspect`

## Key changes

| File | Change |
|------|--------|
| `worker.py` | **New** — standalone entrypoint (`python -m worker`), reads env vars, runs orchestrator |
| `services/docker.py` | **New** — spawn, stop, wait, cleanup worker containers via Docker CLI |
| `main.py` | **Simplified** 484→263 lines — removed in-memory dicts, background tasks, progress helpers |
| `Dockerfile` | Added Docker CLI binary (Renovate tracked) |
| `compose.yaml` | Added Docker socket mount |
| `entrypoint.sh` | Added Docker group matching for socket access |
| `ADR-011` | Documents Docker socket security tradeoff |

## Security (ADR-011)

Docker socket mount is acceptable because:
- API already holds GitHub App private key (repo compromise > host compromise)
- Single-user homelab behind Tailscale
- Existing container hardening (no-new-privileges, cap_drop ALL)
- Workers inherit same security profile with no socket mount
- docker-socket-proxy evaluated but too coarse (can't restrict to create-only)

## Tests

154 tests pass (up from 146). Added `test_docker.py` (15 tests) and `test_worker.py` (8 tests).

Closes #90