### PR TITLE
fix: trigger bot review after implement

### DIFF
--- a/.github/skills/bot-implement/SKILL.md
+++ b/.github/skills/bot-implement/SKILL.md
@@ -15,9 +15,9 @@ You are implementing a GitHub issue. The issue details are provided in the promp
 2. Explore the codebase to understand the relevant code and conventions
 3. Make the necessary changes — follow existing patterns
 4. Run `mise run ci` to validate everything (lint, typecheck, test, compose). Fix any failures before finishing.
-5. Self-review against the checklist below
+5. Sanity-check the implementation against the checklist below
 6. Commit, push, and create a draft PR
-7. Self-review the PR, fix issues (up to 2 rounds), then mark ready and merge
+7. Wait for CI, mark ready, and merge
 
 ## Git Workflow
 
@@ -27,9 +27,9 @@ You start in a worktree on the `agent/issue-{N}` branch, set up by the orchestra
 2. **Push** — `git push origin agent/issue-{N}`. Force-push is fine on agent branches.
 3. **Create draft PR** — `gh pr create --draft --title "..." --body "Closes #N\n\n..."`. Always link the issue with `Closes #N` in the body.
 4. **Wait for CI** — `gh pr checks --watch` until all checks pass. Fix failures before proceeding.
-5. **Self-review** — review your own diff critically. Look for the issues in the checklist below. Fix anything you find and push again.
-6. **Mark ready** — `gh pr ready` when CI passes and you're satisfied with the code.
-7. **Merge** — `gh pr merge --squash --auto` to squash-merge after all checks pass.
+5. **Mark ready** — `gh pr ready` when CI passes and you're satisfied with the code.
+6. **Merge** — `gh pr merge --squash --auto` to squash-merge after all checks pass.
+7. **Independent review** — after a successful implement run, the API monitor comments `/review` on the PR to trigger the fresh advisory review worker. Do not spend premium requests reviewing your own PR from the same CLI session.
 
 ## Rules
 
@@ -48,9 +48,9 @@ You start in a worktree on the `agent/issue-{N}` branch, set up by the orchestra
 - **Never access or modify `docs/private/`** — these are encrypted files you cannot read
 - **If an issue includes out-of-scope work** (e.g., workflow edits), implement everything you can and list the remaining items under a "Human follow-up" heading in the PR description. Do not attempt to modify restricted files.
 
-## Self-Review Checklist
+## Implementation Checklist
 
-Before creating the PR, self-review against these questions:
+Before creating the PR, sanity-check these questions:
 
 - **Error handling:** If a multi-step operation produces state that matters (metrics, audit logs, side effects), ensure that state is captured regardless of which step fails.
 - **New types or patterns:** If you introduce a new exception class, status value, or convention, grep for all call sites using the old version and migrate them.
@@ -62,7 +62,7 @@ Before creating the PR, self-review against these questions:
 
 - **`mise run ci` includes type-checking (`ty`).** `ty` does not support `# type: ignore` comments. Use typed dataclasses or exceptions instead of monkey-patching.
 - **Docker service names don't resolve across separate compose stacks.** Use Tailscale IPs (`100.x.x.x`) or `host.docker.internal`.
-- **GitHub API rejects APPROVE and REQUEST_CHANGES on your own PRs.** Self-reviews must use `COMMENT` event or `gh pr review --comment`.
+- **Independent review is post-implement.** The API monitor triggers it by commenting `/review` on the PR after a successful implement result, and it may arrive after merge.
 
 ## Responding to Review Feedback
 

--- a/.github/skills/write-issue/SKILL.md
+++ b/.github/skills/write-issue/SKILL.md
@@ -22,7 +22,7 @@ Not: "The fix loop needs improvement."
 
 Observable, testable success criteria. If the agent can't verify it with `mise run ci` or by checking behavior, it's not concrete enough.
 
-> A single `/implement` call owns the full lifecycle: implement → self-review → fix (up to 2 rounds) → mark ready → merge. The CLI session handles all git operations, PR creation, and review.
+> A single `/implement` call owns the full lifecycle: implement → create/merge PR. After the worker completes with a PR number, the API monitor comments `/review` on the PR to trigger an independent advisory review.
 
 Not: "Make the implement flow better."
 

--- a/docs/runbooks/isolated-review-agent.md
+++ b/docs/runbooks/isolated-review-agent.md
@@ -95,7 +95,10 @@ mise run deploy:agents
 
 1. Add the `agent` label to the issue or comment `/implement`.
 2. The agent creates `agent/issue-<N>`, and the CLI handles the full lifecycle:
-   implement → self-review → fix (up to 2 rounds) → mark ready → merge.
+   implement → create PR → wait for CI → mark ready → merge.
+3. After a successful implement result includes a PR number, the API monitor
+   comments `/review` on the PR to trigger the independent advisory review
+   worker.
 
 ## 6. Verify
 
@@ -166,11 +169,12 @@ docker exec $AGENT cat /reviews/agent-issue-<N>/.copilot-session.md
 
 ## 8. Operational Gotchas
 
-- **`/review` is manual-only.** The workflow does not auto-review on PR open,
-  synchronize, or ready-for-review.
-- **Self-review is informational.** When the bot reviews its own PR, GitHub
-  forces the review to be a `COMMENT`, so thread-resolution behavior differs
-  from a normal human review.
+- **`/review` remains a manual escape hatch.** Humans can still comment it on
+  any PR, and successful implement runs now comment `/review` automatically on
+  their own PRs.
+- **Independent review is advisory.** It runs in a fresh worker session and may
+  land after merge; findings inform the next iteration rather than blocking the
+  current one.
 - **Agent branches are disposable state.** Reruns can reuse the same
   `agent/issue-*` branch name; pushes are force-updated intentionally.
 - **Worktree cleanup is deferred.** Crash-orphaned worktrees can linger until

--- a/stacks/agents/app/implement/orchestrator.py
+++ b/stacks/agents/app/implement/orchestrator.py
@@ -71,7 +71,7 @@ async def implement_issue(
 ) -> dict:
     """Implement a GitHub issue: set up worktree → CLI handles everything → check result.
 
-    The CLI owns the full lifecycle: commit, push, create PR, self-review, fix,
+    The CLI owns the full lifecycle: commit, push, create PR, wait for CI,
     mark ready, and merge. The orchestrator only validates trust, sets up the
     environment, and collects stats.
     """
@@ -130,6 +130,7 @@ async def implement_issue(
 
         elapsed = _monotonic() - start
         common_result = {
+            "repo": repo,
             "elapsed_seconds": elapsed,
             "premium_requests": total_premium_requests,
             "api_time_seconds": cli_result.api_time_seconds,

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -31,7 +31,7 @@ from services.docker import (
     wait_container,
 )
 from services.git import reap_old_worktrees
-from services.github import set_token
+from services.github import comment_on_issue, set_token
 from trust import ALLOWED_ACTORS
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -109,6 +109,29 @@ def _record_task_metrics(
         PREMIUM_REQUESTS_TOTAL.labels(task_type=task_type).inc(premium_requests)
 
 
+async def _trigger_independent_review(
+    *, task_type: str, status: str, number: int, result: dict[str, object]
+) -> None:
+    """Post `/review` on successful implement PRs to trigger the fresh review worker."""
+    if task_type != "implement" or status != "complete":
+        return
+
+    pr_number = result.get("pr_number")
+    if not isinstance(pr_number, int):
+        return
+
+    repo = result.get("repo")
+    if not isinstance(repo, str) or not repo:
+        logger.warning(
+            "Implement worker #%d completed without repo in result; skipping /review trigger",
+            number,
+        )
+        return
+
+    await comment_on_issue(repo, pr_number, "/review")
+    logger.info("Posted /review comment on %s#%d after implement completion", repo, pr_number)
+
+
 class ReviewRequest(BaseModel):
     repo: str
     pr_number: int
@@ -142,7 +165,7 @@ async def _monitor_worker(container_id: str, *, task_type: str, number: int, sta
         exit_code = await wait_container(container_id)
         duration = time.monotonic() - start
 
-        result: dict = {}
+        result: dict[str, object] = {}
         try:
             logs = await get_logs(container_id)
             logger.info("Worker %s #%d raw output:\n%s", task_type, number, logs[-3000:])
@@ -171,6 +194,15 @@ async def _monitor_worker(container_id: str, *, task_type: str, number: int, sta
             premium,
             f", error={error}" if error else "",
         )
+        try:
+            await _trigger_independent_review(
+                task_type=task_type,
+                status=status,
+                number=number,
+                result=result,
+            )
+        except Exception:
+            logger.exception("Failed to post /review comment for implement #%d", number)
     except Exception:
         logger.exception("Monitor failed for worker %s #%d", task_type, number)
     finally:

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -168,6 +168,7 @@ class TestImplementIssue:
         result = self._run(mocks)
         assert result["status"] == "complete"
         assert result["merged"] is True
+        assert result["repo"] == "user/repo"
         assert result["pr_number"] == 99
         assert result["premium_requests"] == 5
         assert result["api_time_seconds"] == 60
@@ -211,6 +212,7 @@ class TestImplementIssue:
         mocks = self._base_mocks(pr_data=None)
         result = self._run(mocks)
         assert result["status"] == "failed"
+        assert result["repo"] == "user/repo"
         assert result["pr_number"] is None
         assert "did not create a PR" in result["error"]
 

--- a/stacks/agents/app/tests/test_main.py
+++ b/stacks/agents/app/tests/test_main.py
@@ -328,6 +328,43 @@ def test_monitor_records_metrics_on_success(mock_wait, mock_logs, mock_rm):
     mock_rm.assert_awaited_once_with("abc123")
 
 
+@patch("main.comment_on_issue", new_callable=AsyncMock)
+@patch("main.remove_container", new_callable=AsyncMock)
+@patch("main.get_logs", new_callable=AsyncMock)
+@patch("main.wait_container", new_callable=AsyncMock)
+def test_monitor_posts_review_comment_after_successful_implement(
+    mock_wait, mock_logs, mock_rm, mock_comment
+):
+    """Successful implement runs should trigger a fresh review via PR comment."""
+    mock_wait.return_value = 0
+    mock_logs.return_value = (
+        '{"status": "complete", "repo": "user/repo", "pr_number": 99, "premium_requests": 2}\n'
+    )
+
+    asyncio.run(_monitor_worker("abc123", task_type="implement", number=10, start=0.0))
+
+    mock_comment.assert_awaited_once_with("user/repo", 99, "/review")
+    assert (
+        _metric_value("agent_task_total", {"task_type": "implement", "status": "complete"}) == 1.0
+    )
+
+
+@patch("main.comment_on_issue", new_callable=AsyncMock)
+@patch("main.remove_container", new_callable=AsyncMock)
+@patch("main.get_logs", new_callable=AsyncMock)
+@patch("main.wait_container", new_callable=AsyncMock)
+def test_monitor_skips_review_comment_when_implement_result_has_no_repo(
+    mock_wait, mock_logs, mock_rm, mock_comment
+):
+    """The monitor should not crash or comment if the implement result lacks a repo."""
+    mock_wait.return_value = 0
+    mock_logs.return_value = '{"status": "complete", "pr_number": 99}\n'
+
+    asyncio.run(_monitor_worker("abc123", task_type="implement", number=10, start=0.0))
+
+    mock_comment.assert_not_awaited()
+
+
 @patch("main.remove_container", new_callable=AsyncMock)
 @patch("main.get_logs", new_callable=AsyncMock)
 @patch("main.wait_container", new_callable=AsyncMock)


### PR DESCRIPTION
Closes #105

## Summary
- auto-comment `/review` on successful implement completions when the worker result includes a PR number
- carry the repo name through implement results so the API monitor can target the PR after parsing worker logs
- remove stale self-review guidance and refresh the lifecycle docs for independent advisory review