### PR TITLE
refactor: flatten nesting, eliminate duplication, extract helpers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,8 @@ Single-node homelab on a Beelink mini-PC (Ubuntu 24.04, 16 GB RAM) running conta
 - **Source code is the single source of truth** — don't duplicate information that lives in code (schemas, constants, examples). Reference the source file instead. If it can go stale, it shouldn't be written twice.
 - When fixing a bug or adding a pattern, audit for the same class of issue across the codebase. Don't fix one instance — grep for the pattern and fix all of them in one pass.
 - **One way to do things.** Before adding code, find how the codebase already handles the same operation. Either use the existing approach or improve it — don't add a competing one.
+- **Flat control flow** — use early returns and guard clauses instead of deep nesting. If a function has more than one level of try/catch, extract the inner error handling into a helper.
+- **DRY error handling** — when the same try/catch-and-log pattern appears in multiple places, extract a shared helper. Don't copy-paste error recovery blocks.
 
 ## Repo Layout
 

--- a/.github/skills/refactor/SKILL.md
+++ b/.github/skills/refactor/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: refactor
+description: Code cleanup and refactoring skill. Use when deliberately improving code quality — flattening nesting, eliminating duplication, extracting helpers, or simplifying tests.
+allowed-tools: shell
+user-invocable: true
+---
+
+# Refactoring Skill
+
+You are performing a deliberate cleanup pass. Unlike feature work (bot-implement), your goal is structural improvement — not adding behavior.
+
+## When to use
+
+- Nesting depth > 3 levels that can be flattened with early returns or extraction
+- Duplicated code blocks (3+ copies of the same pattern)
+- Test files with repeated boilerplate that should be in conftest.py
+- Functions doing too many things that should be split
+- Dead code, unused imports, stale comments
+
+## Principles
+
+- **Behavior stays the same.** Every refactoring must pass the existing tests without modification to assertions. Test *structure* can change (e.g., moving mocks to conftest), but test *contracts* must not.
+- **Flat control flow.** Prefer early returns and guard clauses over nested if/else. Extract deeply nested blocks into named functions.
+- **DRY error handling.** If the same try/except/log pattern appears 3+ times, extract a helper.
+- **One pass, not one file.** When you find a pattern to fix, grep for all instances across the codebase. Fix them all in one commit.
+- **Measure the improvement.** Before and after: count lines, nesting depth, number of duplicate blocks. Include the delta in the PR description.
+
+## Process
+
+1. **Audit first.** Read the files in scope and identify specific patterns to improve. Don't start editing until you have a list.
+2. **Validate baseline.** Run `mise run ci` before any changes. All tests must pass.
+3. **Make changes.** Work through the list methodically.
+4. **Validate again.** Run `mise run ci` after changes. Zero regressions.
+5. **Commit and PR.** Use `refactor:` conventional commit prefix. Include before/after metrics.
+
+## What NOT to do
+
+- Don't rename things for style preference — only rename if the current name is misleading
+- Don't restructure modules or move files between packages unless the issue specifically asks for it
+- Don't add new abstractions that only have one caller — wait until there are 2+
+- Don't change public API signatures unless the issue explicitly requires it
+- Don't "improve" tests by weakening assertions

--- a/stacks/agents/app/implement/orchestrator.py
+++ b/stacks/agents/app/implement/orchestrator.py
@@ -9,12 +9,12 @@ from services.copilot import CLIResult, TaskError, run_copilot
 from services.git import cleanup_branch_worktree, create_branch_worktree
 from services.github import (
     close_issue,
-    comment_on_issue,
     find_pr_by_branch,
     get_issue,
     get_token,
+    safe_comment,
 )
-from stats import STATUS_EMOJI, format_stage_stats
+from stats import STATUS_EMOJI, cli_stage_stats
 from trust import is_trusted_content_author
 
 logger = logging.getLogger(__name__)
@@ -59,6 +59,76 @@ def _is_stale_pr(pr_data: GitHubPullRequest, run_start: datetime) -> bool:
             return True
 
     return False
+
+
+def _build_result(
+    pr_data: GitHubPullRequest | None,
+    elapsed: float,
+    premium_requests: int,
+    cli_result: CLIResult,
+    repo: str,
+) -> TaskResult:
+    """Build a TaskResult from PR state after CLI completes."""
+    if not pr_data:
+        return TaskResult(
+            status="failed",
+            error="CLI did not create a PR",
+            repo=repo,
+            elapsed_seconds=elapsed,
+            premium_requests=premium_requests,
+            api_time_seconds=cli_result.api_time_seconds,
+            models=cli_result.models,
+            tokens_line=cli_result.tokens_line,
+            session_id=cli_result.session_id,
+        )
+
+    merged = pr_data.merged_at is not None or pr_data.merged
+
+    if merged:
+        return TaskResult(
+            status="complete",
+            merged=True,
+            pr_number=pr_data.number,
+            pr_url=pr_data.html_url,
+            repo=repo,
+            elapsed_seconds=elapsed,
+            premium_requests=premium_requests,
+            api_time_seconds=cli_result.api_time_seconds,
+            models=cli_result.models,
+            tokens_line=cli_result.tokens_line,
+            session_id=cli_result.session_id,
+        )
+
+    if pr_data.auto_merge is not None:
+        return TaskResult(
+            status="complete",
+            merged=False,
+            auto_merge=True,
+            pr_number=pr_data.number,
+            pr_url=pr_data.html_url,
+            repo=repo,
+            elapsed_seconds=elapsed,
+            premium_requests=premium_requests,
+            api_time_seconds=cli_result.api_time_seconds,
+            models=cli_result.models,
+            tokens_line=cli_result.tokens_line,
+            session_id=cli_result.session_id,
+        )
+
+    return TaskResult(
+        status="partial",
+        merged=False,
+        error="CLI created PR but did not merge — needs manual attention",
+        pr_number=pr_data.number,
+        pr_url=pr_data.html_url,
+        repo=repo,
+        elapsed_seconds=elapsed,
+        premium_requests=premium_requests,
+        api_time_seconds=cli_result.api_time_seconds,
+        models=cli_result.models,
+        tokens_line=cli_result.tokens_line,
+        session_id=cli_result.session_id,
+    )
 
 
 async def implement_issue(
@@ -115,7 +185,6 @@ async def implement_issue(
         )
         total_premium_requests += cli_result.total_premium_requests
 
-        # Check what the CLI accomplished
         pr_data = await find_pr_by_branch(repo, branch_name)
 
         if pr_data and _is_stale_pr(pr_data, start_wall):
@@ -129,84 +198,18 @@ async def implement_issue(
             pr_data = None
 
         elapsed = _monotonic() - start
-        if pr_data:
-            pr_number = pr_data.number
-            pr_url = pr_data.html_url
-            merged = pr_data.merged_at is not None or pr_data.merged
-            auto_merge = pr_data.auto_merge is not None
+        result = _build_result(pr_data, elapsed, total_premium_requests, cli_result, repo)
 
-            if merged:
-                try:
-                    await close_issue(repo, issue_number)
-                except Exception:
-                    logger.warning(
-                        "Failed to close issue %s#%d after merged PR #%d",
-                        repo,
-                        issue_number,
-                        pr_number,
-                        exc_info=True,
-                    )
-
-                result = TaskResult(
-                    status="complete",
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    merged=True,
-                    repo=repo,
-                    elapsed_seconds=elapsed,
-                    premium_requests=total_premium_requests,
-                    api_time_seconds=cli_result.api_time_seconds,
-                    models=cli_result.models,
-                    tokens_line=cli_result.tokens_line,
-                    session_id=cli_result.session_id,
+        if result.merged:
+            try:
+                await close_issue(repo, issue_number)
+            except Exception:
+                logger.warning(
+                    "Failed to close issue %s#%d after merged PR",
+                    repo,
+                    issue_number,
+                    exc_info=True,
                 )
-            elif auto_merge:
-                # Auto-merge enabled — CLI did its job, GitHub will merge
-                # when CI passes and auto-close the issue via "Closes #N"
-                result = TaskResult(
-                    status="complete",
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    merged=False,
-                    auto_merge=True,
-                    repo=repo,
-                    elapsed_seconds=elapsed,
-                    premium_requests=total_premium_requests,
-                    api_time_seconds=cli_result.api_time_seconds,
-                    models=cli_result.models,
-                    tokens_line=cli_result.tokens_line,
-                    session_id=cli_result.session_id,
-                )
-            else:
-                result = TaskResult(
-                    status="partial",
-                    pr_number=pr_number,
-                    pr_url=pr_url,
-                    merged=False,
-                    error="CLI created PR but did not merge — needs manual attention",
-                    repo=repo,
-                    elapsed_seconds=elapsed,
-                    premium_requests=total_premium_requests,
-                    api_time_seconds=cli_result.api_time_seconds,
-                    models=cli_result.models,
-                    tokens_line=cli_result.tokens_line,
-                    session_id=cli_result.session_id,
-                )
-        else:
-            result = TaskResult(
-                status="failed",
-                pr_number=None,
-                pr_url=None,
-                merged=False,
-                error="CLI did not create a PR",
-                repo=repo,
-                elapsed_seconds=elapsed,
-                premium_requests=total_premium_requests,
-                api_time_seconds=cli_result.api_time_seconds,
-                models=cli_result.models,
-                tokens_line=cli_result.tokens_line,
-                session_id=cli_result.session_id,
-            )
 
         return result
 
@@ -217,28 +220,11 @@ async def implement_issue(
 
     finally:
         if result and result.pr_number is not None:
-            try:
-                stats = format_stage_stats(
-                    premium_requests=total_premium_requests,
-                    elapsed_seconds=_monotonic() - start,
-                    api_time_seconds=cli_result.api_time_seconds if cli_result else 0,
-                    effort=reasoning_effort,
-                    models=cli_result.models if cli_result else None,
-                    tokens_line=cli_result.tokens_line if cli_result else "",
-                )
-                status = result.status
-                emoji = STATUS_EMOJI.get(status, "❓")
-                await comment_on_issue(
-                    repo,
-                    result.pr_number,
-                    f"{emoji} **Implementation {status}**\n{stats}",
-                )
-            except Exception:
-                logger.warning(
-                    "Failed to post implementation %s stats comment on %s#%s",
-                    result.status,
-                    repo,
-                    result.pr_number,
-                    exc_info=True,
-                )
+            stats = cli_stage_stats(cli_result, effort=reasoning_effort) if cli_result else ""
+            emoji = STATUS_EMOJI.get(result.status, "❓")
+            await safe_comment(
+                repo,
+                result.pr_number,
+                f"{emoji} **Implementation {result.status}**\n{stats}",
+            )
         await cleanup_branch_worktree(branch_name)

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -242,6 +242,43 @@ def _spawn_monitor(container_id: str, *, task_type: str, number: int, start: flo
     _monitor_tasks[monitor_key] = task
 
 
+async def _dispatch_worker(
+    *,
+    task_type: str,
+    repo: str,
+    number: int,
+    github_token: str,
+    model: str,
+    effort: str,
+) -> str:
+    """Spawn a worker container and start its monitor. Returns the container ID."""
+    image = await get_own_image()
+    env = {
+        "TASK_TYPE": task_type,
+        "REPO": repo,
+        "NUMBER": str(number),
+        "GH_TOKEN": github_token,
+        "COPILOT_GITHUB_TOKEN": os.environ.get("COPILOT_GITHUB_TOKEN", ""),
+        "LOG_FORMAT": _worker_log_format(),
+        "MODEL": model,
+        "REASONING_EFFORT": effort,
+    }
+
+    start = time.monotonic()
+    TASK_IN_PROGRESS.labels(task_type=task_type).inc()
+
+    container_id = await spawn_worker(
+        task_type=task_type,
+        image=image,
+        env=env,
+        number=number,
+        volumes=["repo-cache:/repo.git", "reviews:/reviews"],
+    )
+
+    _spawn_monitor(container_id, task_type=task_type, number=number, start=start)
+    return container_id
+
+
 # --- Review endpoints ---
 
 
@@ -254,33 +291,15 @@ async def handle_review(req: ReviewRequest):
             content={"error": f"Actor '{req.triggered_by}' is not allowed"},
         )
     set_token(req.github_token)
-    model = req.model or MODEL
-    effort = req.reasoning_effort or REASONING_EFFORT
 
-    image = await get_own_image()
-    env = {
-        "TASK_TYPE": "review",
-        "REPO": req.repo,
-        "NUMBER": str(req.pr_number),
-        "GH_TOKEN": req.github_token,
-        "COPILOT_GITHUB_TOKEN": os.environ.get("COPILOT_GITHUB_TOKEN", ""),
-        "LOG_FORMAT": _worker_log_format(),
-        "MODEL": model,
-        "REASONING_EFFORT": effort,
-    }
-
-    start = time.monotonic()
-    TASK_IN_PROGRESS.labels(task_type="review").inc()
-
-    container_id = await spawn_worker(
+    await _dispatch_worker(
         task_type="review",
-        image=image,
-        env=env,
+        repo=req.repo,
         number=req.pr_number,
-        volumes=["repo-cache:/repo.git", "reviews:/reviews"],
+        github_token=req.github_token,
+        model=req.model or MODEL,
+        effort=req.reasoning_effort or REASONING_EFFORT,
     )
-
-    _spawn_monitor(container_id, task_type="review", number=req.pr_number, start=start)
     return {"status": "accepted", "pr_number": req.pr_number}
 
 
@@ -305,40 +324,21 @@ async def handle_implement(req: ImplementRequest):
             content={"error": f"Actor '{req.triggered_by}' is not allowed"},
         )
     set_token(req.github_token)
-    model = req.model or MODEL
-    effort = req.reasoning_effort or REASONING_EFFORT
 
-    # Check for duplicate via running container
     if await is_worker_running("implement", req.issue_number):
         return JSONResponse(
             status_code=409,
             content={"status": "already_in_progress", "issue_number": req.issue_number},
         )
 
-    image = await get_own_image()
-    env = {
-        "TASK_TYPE": "implement",
-        "REPO": req.repo,
-        "NUMBER": str(req.issue_number),
-        "GH_TOKEN": req.github_token,
-        "COPILOT_GITHUB_TOKEN": os.environ.get("COPILOT_GITHUB_TOKEN", ""),
-        "LOG_FORMAT": _worker_log_format(),
-        "MODEL": model,
-        "REASONING_EFFORT": effort,
-    }
-
-    start = time.monotonic()
-    TASK_IN_PROGRESS.labels(task_type="implement").inc()
-
-    container_id = await spawn_worker(
+    await _dispatch_worker(
         task_type="implement",
-        image=image,
-        env=env,
+        repo=req.repo,
         number=req.issue_number,
-        volumes=["repo-cache:/repo.git", "reviews:/reviews"],
+        github_token=req.github_token,
+        model=req.model or MODEL,
+        effort=req.reasoning_effort or REASONING_EFFORT,
     )
-
-    _spawn_monitor(container_id, task_type="implement", number=req.issue_number, start=start)
     return {"status": "accepted", "issue_number": req.issue_number}
 
 

--- a/stacks/agents/app/services/copilot.py
+++ b/stacks/agents/app/services/copilot.py
@@ -208,25 +208,17 @@ async def run_copilot(
         session_id or "none",
     )
 
+    kwargs: dict[str, object] = {
+        "cwd": worktree_path,
+        "stdin": asyncio.subprocess.DEVNULL,
+        "stdout": asyncio.subprocess.PIPE,
+        "stderr": asyncio.subprocess.PIPE,
+        "env": env,
+    }
     if os.name == "posix":
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=worktree_path,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-            start_new_session=True,
-        )
-    else:
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=worktree_path,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-        )
+        kwargs["start_new_session"] = True
+
+    proc = await asyncio.create_subprocess_exec(*cmd, **kwargs)  # ty: ignore[invalid-argument-type]
 
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []

--- a/stacks/agents/app/services/git.py
+++ b/stacks/agents/app/services/git.py
@@ -147,36 +147,40 @@ async def _acquire_in_process_repo_lock() -> None:
         raise
 
 
+async def _acquire_file_lock_cancellation_safe() -> int:
+    """Acquire the cross-container file lock, handling cancellation safely.
+
+    Uses asyncio.shield so a cancellation during acquisition still finishes
+    the lock handshake, then releases if we were cancelled.
+    """
+    file_lock_task = asyncio.create_task(
+        asyncio.to_thread(_acquire_repo_file_lock, REPO_LOCK_TIMEOUT_SECONDS)
+    )
+    try:
+        return await asyncio.shield(file_lock_task)
+    except TimeoutError as err:
+        raise RuntimeError(_repo_lock_timeout_message()) from err
+    except asyncio.CancelledError:
+        # The file lock acquisition may still be in progress — wait for it
+        # to finish so we can release it cleanly.
+        try:
+            fd = await file_lock_task
+        except Exception:
+            logger.warning(
+                "Failed to finish repo lock acquisition during cancellation cleanup",
+                exc_info=True,
+            )
+            raise
+        await asyncio.shield(asyncio.to_thread(_release_repo_file_lock, fd))
+        raise
+
+
 @contextlib.asynccontextmanager
 async def _hold_repo_lock() -> AsyncIterator[None]:
     """Serialize shared bare-clone mutations across tasks and containers."""
     await _acquire_in_process_repo_lock()
     try:
-        file_lock_task = asyncio.create_task(
-            asyncio.to_thread(_acquire_repo_file_lock, REPO_LOCK_TIMEOUT_SECONDS)
-        )
-        try:
-            fd = await asyncio.shield(file_lock_task)
-        except TimeoutError as err:
-            raise RuntimeError(_repo_lock_timeout_message()) from err
-        except asyncio.CancelledError:
-            try:
-                fd = await file_lock_task
-            except Exception:
-                logger.warning(
-                    "Failed to finish repo lock acquisition during cancellation cleanup",
-                    exc_info=True,
-                )
-            else:
-                try:
-                    await asyncio.shield(asyncio.to_thread(_release_repo_file_lock, fd))
-                except Exception:
-                    logger.warning(
-                        "Failed to release repo lock during cancellation cleanup",
-                        exc_info=True,
-                    )
-            raise
-
+        fd = await _acquire_file_lock_cancellation_safe()
         try:
             yield
         finally:

--- a/stacks/agents/app/services/git.py
+++ b/stacks/agents/app/services/git.py
@@ -171,7 +171,13 @@ async def _acquire_file_lock_cancellation_safe() -> int:
                 exc_info=True,
             )
             raise
-        await asyncio.shield(asyncio.to_thread(_release_repo_file_lock, fd))
+        try:
+            await asyncio.shield(asyncio.to_thread(_release_repo_file_lock, fd))
+        except Exception:
+            logger.warning(
+                "Failed to release repo lock during cancellation cleanup",
+                exc_info=True,
+            )
         raise
 
 

--- a/stacks/agents/app/services/github.py
+++ b/stacks/agents/app/services/github.py
@@ -1,7 +1,10 @@
 """GitHub API — token management and REST helpers."""
 
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from contextvars import ContextVar
+from typing import Any
 
 import httpx
 from pydantic import TypeAdapter
@@ -51,38 +54,40 @@ def bot_email() -> str:
     return f"{_BOT_USER_ID}+{bot_login()}@users.noreply.github.com"
 
 
-# ── Issue / PR read ────────────────────────────────────────
+# ── Authenticated client ───────────────────────────────────
 
 
-async def get_issue(repo: str, issue_number: int) -> GitHubIssue:
-    """Fetch issue details (title, body, labels)."""
+@asynccontextmanager
+async def _client() -> AsyncIterator[httpx.AsyncClient]:
+    """Yield an httpx client with GitHub auth headers."""
     token = await get_token()
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
     }
+    async with httpx.AsyncClient(timeout=30, headers=headers) as client:
+        yield client
 
-    async with httpx.AsyncClient(timeout=30) as client:
-        resp = await client.get(
-            f"https://api.github.com/repos/{repo}/issues/{issue_number}",
-            headers=headers,
-        )
+
+_API = "https://api.github.com"
+
+
+# ── Issue / PR read ────────────────────────────────────────
+
+
+async def get_issue(repo: str, issue_number: int) -> GitHubIssue:
+    """Fetch issue details (title, body, labels)."""
+    async with _client() as client:
+        resp = await client.get(f"{_API}/repos/{repo}/issues/{issue_number}")
         resp.raise_for_status()
         return GitHubIssue.model_validate(resp.json())
 
 
 async def close_issue(repo: str, issue_number: int) -> None:
     """Close an issue as completed."""
-    token = await get_token()
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-    }
-
-    async with httpx.AsyncClient(timeout=30) as client:
+    async with _client() as client:
         resp = await client.patch(
-            f"https://api.github.com/repos/{repo}/issues/{issue_number}",
-            headers=headers,
+            f"{_API}/repos/{repo}/issues/{issue_number}",
             json={"state": "closed", "state_reason": "completed"},
         )
         if resp.status_code != 200:
@@ -93,34 +98,18 @@ async def close_issue(repo: str, issue_number: int) -> None:
 
 async def get_pr(repo: str, pr_number: int) -> GitHubPullRequest:
     """Fetch PR details (head branch, base, state)."""
-    token = await get_token()
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-    }
-
-    async with httpx.AsyncClient(timeout=30) as client:
-        resp = await client.get(
-            f"https://api.github.com/repos/{repo}/pulls/{pr_number}",
-            headers=headers,
-        )
+    async with _client() as client:
+        resp = await client.get(f"{_API}/repos/{repo}/pulls/{pr_number}")
         resp.raise_for_status()
         return GitHubPullRequest.model_validate(resp.json())
 
 
 async def find_pr_by_branch(repo: str, branch: str) -> GitHubPullRequest | None:
     """Find the most recently updated PR for a branch (any state)."""
-    token = await get_token()
     owner = repo.split("/")[0]
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-    }
-
-    async with httpx.AsyncClient(timeout=30) as client:
+    async with _client() as client:
         resp = await client.get(
-            f"https://api.github.com/repos/{repo}/pulls",
-            headers=headers,
+            f"{_API}/repos/{repo}/pulls",
             params={
                 "head": f"{owner}:{branch}",
                 "state": "all",
@@ -139,16 +128,9 @@ async def find_pr_by_branch(repo: str, branch: str) -> GitHubPullRequest | None:
 
 async def comment_on_issue(repo: str, issue_number: int, body: str) -> int:
     """Post a comment on an issue or PR and return the comment ID."""
-    token = await get_token()
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-    }
-
-    async with httpx.AsyncClient(timeout=30) as client:
+    async with _client() as client:
         resp = await client.post(
-            f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments",
-            headers=headers,
+            f"{_API}/repos/{repo}/issues/{issue_number}/comments",
             json={"body": body},
         )
         if resp.status_code not in (200, 201):
@@ -159,18 +141,25 @@ async def comment_on_issue(repo: str, issue_number: int, body: str) -> int:
         return comment.id
 
 
+async def safe_comment(repo: str, issue_number: int, body: str, **log_ctx: Any) -> None:
+    """Post a comment, logging a warning on failure instead of raising."""
+    try:
+        await comment_on_issue(repo, issue_number, body)
+    except Exception:
+        logger.warning(
+            "Failed to post comment on %s#%d",
+            repo,
+            issue_number,
+            exc_info=True,
+            extra=log_ctx,
+        )
+
+
 async def update_comment(repo: str, comment_id: int, body: str) -> None:
     """Edit an existing issue or PR comment."""
-    token = await get_token()
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-    }
-
-    async with httpx.AsyncClient(timeout=30) as client:
+    async with _client() as client:
         resp = await client.patch(
-            f"https://api.github.com/repos/{repo}/issues/comments/{comment_id}",
-            headers=headers,
+            f"{_API}/repos/{repo}/issues/comments/{comment_id}",
             json={"body": body},
         )
         if resp.status_code != 200:
@@ -183,20 +172,14 @@ async def find_issue_comment_by_body_prefix(
     repo: str, issue_number: int, body_prefix: str
 ) -> int | None:
     """Find the latest bot-authored issue/PR comment whose body starts with a prefix."""
-    token = await get_token()
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-    }
     login = bot_login()
     comments: list[GitHubIssueComment] = []
     page = 1
 
-    async with httpx.AsyncClient(timeout=30) as client:
+    async with _client() as client:
         while True:
             resp = await client.get(
-                f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments",
-                headers=headers,
+                f"{_API}/repos/{repo}/issues/{issue_number}/comments",
                 params={"per_page": 100, "page": page},
             )
             resp.raise_for_status()

--- a/stacks/agents/app/tests/conftest.py
+++ b/stacks/agents/app/tests/conftest.py
@@ -1,0 +1,71 @@
+"""Shared test fixtures and constants."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from models import GitHubIssue
+from services.copilot import CLIResult
+
+MOCK_ISSUE = GitHubIssue.model_validate(
+    {
+        "title": "Add foo feature",
+        "body": "We need foo.",
+        "user": {"login": "ColinCee"},
+    }
+)
+
+MOCK_CLI_RESULT = CLIResult(
+    output="done",
+    total_premium_requests=5,
+    session_id="sess-123",
+    session_time_seconds=120,
+    api_time_seconds=60,
+    models={"gpt-5.4": "883.6k in, 17.7k out, 788.5k cached"},
+    tokens_line="↑ 883.6k • ↓ 17.7k • 788.5k (cached)",
+)
+
+IMPLEMENT_ENV = {
+    "TASK_TYPE": "implement",
+    "REPO": "user/repo",
+    "NUMBER": "10",
+    "GH_TOKEN": "ghs_test",
+}
+
+REVIEW_ENV = {
+    "TASK_TYPE": "review",
+    "REPO": "user/repo",
+    "NUMBER": "42",
+    "GH_TOKEN": "ghs_test",
+}
+
+
+@pytest.fixture()
+def make_mock_process():
+    """Factory fixture returning mock subprocess objects for copilot tests."""
+
+    def _factory(stdout_text: str = "", returncode: int = 0):
+        proc = AsyncMock()
+        proc.returncode = returncode
+
+        stdout_lines = (stdout_text + "\n").encode().split(b"\n") if stdout_text else [b""]
+        stdout_stream = AsyncMock()
+        stdout_stream.at_eof = lambda: len(stdout_lines) == 0
+
+        async def read_stdout():
+            if stdout_lines:
+                return stdout_lines.pop(0) + b"\n"
+            return b""
+
+        stdout_stream.readline = read_stdout
+
+        stderr_stream = AsyncMock()
+        stderr_stream.at_eof = lambda: True
+        stderr_stream.readline = AsyncMock(return_value=b"")
+
+        proc.stdout = stdout_stream
+        proc.stderr = stderr_stream
+        proc.wait = AsyncMock()
+        return proc
+
+    return _factory

--- a/stacks/agents/app/tests/test_copilot.py
+++ b/stacks/agents/app/tests/test_copilot.py
@@ -172,35 +172,10 @@ class TestRedactSecrets:
 
 
 class TestRunCopilot:
-    def _make_mock_process(self, stdout_text: str = "", returncode: int = 0):
-        """Create a mock subprocess that yields stdout_text line by line."""
-        proc = AsyncMock()
-        proc.returncode = returncode
-
-        stdout_lines = (stdout_text + "\n").encode().split(b"\n") if stdout_text else [b""]
-        stdout_stream = AsyncMock()
-        stdout_stream.at_eof = lambda: len(stdout_lines) == 0
-
-        async def read_stdout():
-            if stdout_lines:
-                return stdout_lines.pop(0) + b"\n"
-            return b""
-
-        stdout_stream.readline = read_stdout
-
-        stderr_stream = AsyncMock()
-        stderr_stream.at_eof = lambda: True
-        stderr_stream.readline = AsyncMock(return_value=b"")
-
-        proc.stdout = stdout_stream
-        proc.stderr = stderr_stream
-        proc.wait = AsyncMock()
-        return proc
-
     @patch("services.copilot.asyncio.create_subprocess_exec")
-    def test_share_flag_in_command(self, mock_exec: AsyncMock, tmp_path: Path):
+    def test_share_flag_in_command(self, mock_exec: AsyncMock, tmp_path: Path, make_mock_process):
         """Verifies --share flag is passed to the CLI."""
-        proc = self._make_mock_process("done")
+        proc = make_mock_process("done")
         mock_exec.return_value = proc
 
         asyncio.run(run_copilot(tmp_path, "test prompt"))
@@ -212,13 +187,15 @@ class TestRunCopilot:
         assert mock_exec.call_args.kwargs["start_new_session"] is True
 
     @patch("services.copilot.asyncio.create_subprocess_exec")
-    def test_reads_transcript_when_present(self, mock_exec: AsyncMock, tmp_path: Path):
+    def test_reads_transcript_when_present(
+        self, mock_exec: AsyncMock, tmp_path: Path, make_mock_process
+    ):
         """Verifies session transcript is read from the --share output file."""
         transcript_content = "# Session\n\n## Turn 1\n\nUser: test prompt\n"
         transcript_path = tmp_path / ".copilot-session.md"
         transcript_path.write_text(transcript_content)
 
-        proc = self._make_mock_process("done")
+        proc = make_mock_process("done")
         mock_exec.return_value = proc
 
         result = asyncio.run(run_copilot(tmp_path, "test prompt"))
@@ -226,9 +203,11 @@ class TestRunCopilot:
         assert result.session_transcript == transcript_content
 
     @patch("services.copilot.asyncio.create_subprocess_exec")
-    def test_transcript_none_when_file_missing(self, mock_exec: AsyncMock, tmp_path: Path):
+    def test_transcript_none_when_file_missing(
+        self, mock_exec: AsyncMock, tmp_path: Path, make_mock_process
+    ):
         """Transcript is None when --share file doesn't exist."""
-        proc = self._make_mock_process("done")
+        proc = make_mock_process("done")
         mock_exec.return_value = proc
 
         result = asyncio.run(run_copilot(tmp_path, "test prompt"))
@@ -236,9 +215,9 @@ class TestRunCopilot:
         assert result.session_transcript is None
 
     @patch("services.copilot.asyncio.create_subprocess_exec")
-    def test_resume_flag_in_command(self, mock_exec: AsyncMock, tmp_path: Path):
+    def test_resume_flag_in_command(self, mock_exec: AsyncMock, tmp_path: Path, make_mock_process):
         """When session_id is provided, --resume flag is passed to the CLI."""
-        proc = self._make_mock_process("done")
+        proc = make_mock_process("done")
         mock_exec.return_value = proc
 
         asyncio.run(run_copilot(tmp_path, "fix prompt", session_id="abc-123-def-456"))
@@ -248,9 +227,11 @@ class TestRunCopilot:
         assert resume_args == ["--resume=abc-123-def-456"]
 
     @patch("services.copilot.asyncio.create_subprocess_exec")
-    def test_no_resume_flag_without_session_id(self, mock_exec: AsyncMock, tmp_path: Path):
+    def test_no_resume_flag_without_session_id(
+        self, mock_exec: AsyncMock, tmp_path: Path, make_mock_process
+    ):
         """Without session_id, no --resume flag is passed."""
-        proc = self._make_mock_process("done")
+        proc = make_mock_process("done")
         mock_exec.return_value = proc
 
         asyncio.run(run_copilot(tmp_path, "test prompt"))
@@ -260,9 +241,11 @@ class TestRunCopilot:
         assert resume_args == []
 
     @patch("services.copilot.asyncio.create_subprocess_exec")
-    def test_session_id_parsed_from_output(self, mock_exec: AsyncMock, tmp_path: Path):
+    def test_session_id_parsed_from_output(
+        self, mock_exec: AsyncMock, tmp_path: Path, make_mock_process
+    ):
         """Session ID is extracted from CLI stdout."""
-        proc = self._make_mock_process(
+        proc = make_mock_process(
             "Starting...\nSession ID: `a1b2c3d4-e5f6-7890-abcd-ef1234567890`\nDone."
         )
         mock_exec.return_value = proc

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -3,10 +3,10 @@
 import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import ClassVar
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from conftest import MOCK_CLI_RESULT, MOCK_ISSUE
 
 from implement import implement_issue
 from models import GitHubIssue, GitHubPullRequest
@@ -103,30 +103,12 @@ class TestFormatStageStats:
 class TestImplementIssue:
     """Tests for implement_issue() — thin dispatcher to CLI."""
 
-    MOCK_ISSUE: ClassVar[GitHubIssue] = GitHubIssue.model_validate(
-        {
-            "title": "Add foo feature",
-            "body": "We need foo.",
-            "user": {"login": "ColinCee"},
-        }
-    )
-
-    MOCK_CLI_RESULT = CLIResult(
-        output="done",
-        total_premium_requests=5,
-        session_id="sess-123",
-        session_time_seconds=120,
-        api_time_seconds=60,
-        models={"gpt-5.4": "883.6k in, 17.7k out, 788.5k cached"},
-        tokens_line="↑ 883.6k • ↓ 17.7k • 788.5k (cached)",
-    )
-
     def _base_mocks(self, *, pr_data=None, cli_result=None):
         """Return standard patches for implement_issue tests."""
         return [
             patch(f"{_MOD}._utcnow", return_value=_TEST_START),
             patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
-            patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=self.MOCK_ISSUE),
+            patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=MOCK_ISSUE),
             patch(
                 "implement.orchestrator.create_branch_worktree",
                 new_callable=AsyncMock,
@@ -135,7 +117,7 @@ class TestImplementIssue:
             patch(
                 "implement.orchestrator.run_copilot",
                 new_callable=AsyncMock,
-                return_value=cli_result or self.MOCK_CLI_RESULT,
+                return_value=cli_result or MOCK_CLI_RESULT,
             ),
             patch(
                 "implement.orchestrator.find_pr_by_branch",
@@ -143,7 +125,7 @@ class TestImplementIssue:
                 return_value=pr_data,
             ),
             patch(f"{_MOD}.close_issue", new_callable=AsyncMock),
-            patch(f"{_MOD}.comment_on_issue", new_callable=AsyncMock),
+            patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
             patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
         ]
 
@@ -256,7 +238,7 @@ class TestImplementIssue:
             with (
                 patch(f"{_MOD}._utcnow", return_value=_TEST_START),
                 patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
-                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=self.MOCK_ISSUE),
+                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=MOCK_ISSUE),
                 patch(
                     "implement.orchestrator.create_branch_worktree",
                     new_callable=AsyncMock,
@@ -265,11 +247,11 @@ class TestImplementIssue:
                 patch(
                     "implement.orchestrator.run_copilot",
                     new_callable=AsyncMock,
-                    return_value=self.MOCK_CLI_RESULT,
+                    return_value=MOCK_CLI_RESULT,
                 ) as mock_cli,
                 patch(f"{_MOD}.find_pr_by_branch", new_callable=AsyncMock, return_value=pr_data),
                 patch(f"{_MOD}.close_issue", new_callable=AsyncMock),
-                patch(f"{_MOD}.comment_on_issue", new_callable=AsyncMock),
+                patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
                 patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
             ):
                 await implement_issue(repo="user/repo", issue_number=42)
@@ -291,7 +273,7 @@ class TestImplementIssue:
             with (
                 patch(f"{_MOD}._utcnow", return_value=_TEST_START),
                 patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
-                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=self.MOCK_ISSUE),
+                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=MOCK_ISSUE),
                 patch(
                     "implement.orchestrator.create_branch_worktree",
                     new_callable=AsyncMock,
@@ -300,11 +282,11 @@ class TestImplementIssue:
                 patch(
                     "implement.orchestrator.run_copilot",
                     new_callable=AsyncMock,
-                    return_value=self.MOCK_CLI_RESULT,
+                    return_value=MOCK_CLI_RESULT,
                 ),
                 patch(f"{_MOD}.find_pr_by_branch", new_callable=AsyncMock, return_value=pr_data),
                 patch(f"{_MOD}.close_issue", new_callable=AsyncMock) as mock_close,
-                patch(f"{_MOD}.comment_on_issue", new_callable=AsyncMock),
+                patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
                 patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
             ):
                 await implement_issue(repo="user/repo", issue_number=42)
@@ -326,7 +308,7 @@ class TestImplementIssue:
             with (
                 patch(f"{_MOD}._utcnow", return_value=_TEST_START),
                 patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
-                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=self.MOCK_ISSUE),
+                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=MOCK_ISSUE),
                 patch(
                     "implement.orchestrator.create_branch_worktree",
                     new_callable=AsyncMock,
@@ -335,11 +317,11 @@ class TestImplementIssue:
                 patch(
                     "implement.orchestrator.run_copilot",
                     new_callable=AsyncMock,
-                    return_value=self.MOCK_CLI_RESULT,
+                    return_value=MOCK_CLI_RESULT,
                 ),
                 patch(f"{_MOD}.find_pr_by_branch", new_callable=AsyncMock, return_value=pr_data),
                 patch(f"{_MOD}.close_issue", new_callable=AsyncMock) as mock_close,
-                patch(f"{_MOD}.comment_on_issue", new_callable=AsyncMock),
+                patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
                 patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
             ):
                 await implement_issue(repo="user/repo", issue_number=42)
@@ -358,7 +340,7 @@ class TestImplementIssue:
                 patch(
                     "implement.orchestrator.get_issue",
                     new_callable=AsyncMock,
-                    return_value=self.MOCK_ISSUE,
+                    return_value=MOCK_ISSUE,
                 ),
                 patch(
                     "implement.orchestrator.create_branch_worktree",
@@ -403,7 +385,7 @@ class TestImplementIssue:
             with (
                 patch(f"{_MOD}._utcnow", return_value=_TEST_START),
                 patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
-                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=self.MOCK_ISSUE),
+                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=MOCK_ISSUE),
                 patch(
                     "implement.orchestrator.create_branch_worktree",
                     new_callable=AsyncMock,
@@ -412,11 +394,11 @@ class TestImplementIssue:
                 patch(
                     "implement.orchestrator.run_copilot",
                     new_callable=AsyncMock,
-                    return_value=self.MOCK_CLI_RESULT,
+                    return_value=MOCK_CLI_RESULT,
                 ),
                 patch(f"{_MOD}.find_pr_by_branch", new_callable=AsyncMock, return_value=pr_data),
                 patch(f"{_MOD}.close_issue", new_callable=AsyncMock),
-                patch(f"{_MOD}.comment_on_issue", new_callable=AsyncMock) as mock_comment,
+                patch(f"{_MOD}.safe_comment", new_callable=AsyncMock) as mock_comment,
                 patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
             ):
                 await implement_issue(repo="user/repo", issue_number=42)
@@ -451,7 +433,7 @@ class TestImplementIssue:
             with (
                 patch(f"{_MOD}._utcnow", return_value=_TEST_START),
                 patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
-                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=self.MOCK_ISSUE),
+                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=MOCK_ISSUE),
                 patch(
                     "implement.orchestrator.create_branch_worktree",
                     new_callable=AsyncMock,
@@ -464,7 +446,7 @@ class TestImplementIssue:
                 ),
                 patch(f"{_MOD}.find_pr_by_branch", new_callable=AsyncMock, return_value=pr_data),
                 patch(f"{_MOD}.close_issue", new_callable=AsyncMock),
-                patch(f"{_MOD}.comment_on_issue", new_callable=AsyncMock) as mock_comment,
+                patch(f"{_MOD}.safe_comment", new_callable=AsyncMock) as mock_comment,
                 patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
             ):
                 await implement_issue(repo="user/repo", issue_number=42)
@@ -513,7 +495,7 @@ class TestImplementIssue:
                 patch(
                     "implement.orchestrator.get_issue",
                     new_callable=AsyncMock,
-                    return_value=self.MOCK_ISSUE,
+                    return_value=MOCK_ISSUE,
                 ),
                 patch(
                     "implement.orchestrator.create_branch_worktree",

--- a/stacks/agents/app/tests/test_worker.py
+++ b/stacks/agents/app/tests/test_worker.py
@@ -2,48 +2,74 @@
 
 import asyncio
 import os
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, patch
+
+from conftest import IMPLEMENT_ENV, REVIEW_ENV
 
 from models import GitHubIssue, TaskResult
 
 
-@patch.dict(
-    os.environ,
-    {
-        "TASK_TYPE": "implement",
-        "REPO": "user/repo",
-        "NUMBER": "10",
-        "GH_TOKEN": "ghs_test",
-        "MODEL": "gpt-5.4",
-        "REASONING_EFFORT": "high",
-    },
-)
-@patch("worker.implement_issue", new_callable=AsyncMock)
-@patch("worker.get_issue", new_callable=AsyncMock, return_value=GitHubIssue(title="test"))
-@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
-@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("worker.update_comment", new_callable=AsyncMock)
-def test_implement_success_returns_zero(
-    mock_update, mock_find, mock_comment, mock_issue, mock_impl, capsys
-):
-    mock_impl.return_value = TaskResult(
-        status="complete",
-        pr_number=99,
-        pr_url="https://github.com/user/repo/pull/99",
-        premium_requests=5,
-        api_time_seconds=60,
-        models={"gpt-5.4": "883.6k in, 17.7k out, 788.5k cached"},
-        tokens_line="↑ 883.6k • ↓ 17.7k • 788.5k (cached)",
-        session_id="sess-123",
+def _implement_patches(mock_impl: AsyncMock):
+    """Return context managers for implement worker tests."""
+    return [
+        patch("worker.implement_issue", mock_impl),
+        patch("worker.get_issue", new_callable=AsyncMock, return_value=GitHubIssue(title="test")),
+        patch("worker.safe_comment", new_callable=AsyncMock),
+        patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100),
+        patch(
+            "worker.find_issue_comment_by_body_prefix",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("worker.update_comment", new_callable=AsyncMock),
+    ]
+
+
+def _review_patches(mock_review: AsyncMock):
+    """Return context managers for review worker tests."""
+    return [
+        patch("worker.review_pr", mock_review),
+        patch("worker.safe_comment", new_callable=AsyncMock),
+        patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100),
+        patch(
+            "worker.find_issue_comment_by_body_prefix",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("worker.update_comment", new_callable=AsyncMock),
+    ]
+
+
+def _enter_patches(stack: ExitStack, patches, env: dict[str, str]):
+    """Enter env dict patch + all mock patches on an ExitStack."""
+    stack.enter_context(patch.dict(os.environ, env))
+    for p in patches:
+        stack.enter_context(p)
+
+
+def test_implement_success_returns_zero(capsys):
+    mock_impl = AsyncMock(
+        return_value=TaskResult(
+            status="complete",
+            pr_number=99,
+            pr_url="https://github.com/user/repo/pull/99",
+            premium_requests=5,
+            api_time_seconds=60,
+            models={"gpt-5.4": "883.6k in, 17.7k out, 788.5k cached"},
+            tokens_line="↑ 883.6k • ↓ 17.7k • 788.5k (cached)",
+            session_id="sess-123",
+        )
     )
+    env = {**IMPLEMENT_ENV, "MODEL": "gpt-5.4", "REASONING_EFFORT": "high"}
+    with ExitStack() as stack:
+        _enter_patches(stack, _implement_patches(mock_impl), env)
+        from worker import main
 
-    from worker import main
-
-    exit_code = asyncio.run(main())
+        exit_code = asyncio.run(main())
 
     assert exit_code == 0
-    captured = capsys.readouterr()
-    result = TaskResult.model_validate_json(captured.out.strip())
+    result = TaskResult.model_validate_json(capsys.readouterr().out.strip())
     assert result.status == "complete"
     assert result.premium_requests == 5
     assert result.api_time_seconds == 60
@@ -53,165 +79,107 @@ def test_implement_success_returns_zero(
     mock_impl.assert_awaited_once()
 
 
-@patch.dict(
-    os.environ,
-    {
-        "TASK_TYPE": "implement",
-        "REPO": "user/repo",
-        "NUMBER": "10",
-        "GH_TOKEN": "ghs_test",
-    },
-)
-@patch("worker.implement_issue", new_callable=AsyncMock)
-@patch("worker.get_issue", new_callable=AsyncMock, return_value=GitHubIssue(title="test"))
-@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
-@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("worker.update_comment", new_callable=AsyncMock)
-def test_implement_failure_returns_one(
-    mock_update, mock_find, mock_comment, mock_issue, mock_impl, capsys
-):
-    mock_impl.return_value = TaskResult(status="failed", premium_requests=2)
+def test_implement_failure_returns_one(capsys):
+    mock_impl = AsyncMock(return_value=TaskResult(status="failed", premium_requests=2))
+    with ExitStack() as stack:
+        _enter_patches(stack, _implement_patches(mock_impl), IMPLEMENT_ENV)
+        from worker import main
 
-    from worker import main
-
-    exit_code = asyncio.run(main())
+        exit_code = asyncio.run(main())
 
     assert exit_code == 1
-    captured = capsys.readouterr()
-    result = TaskResult.model_validate_json(captured.out.strip())
+    result = TaskResult.model_validate_json(capsys.readouterr().out.strip())
     assert result.status == "failed"
 
 
-@patch.dict(
-    os.environ,
-    {
-        "TASK_TYPE": "implement",
-        "REPO": "user/repo",
-        "NUMBER": "10",
-        "GH_TOKEN": "ghs_test",
-    },
-)
-@patch("worker.implement_issue", new_callable=AsyncMock)
-@patch("worker.get_issue", new_callable=AsyncMock, return_value=GitHubIssue(title="test"))
-@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
-@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("worker.update_comment", new_callable=AsyncMock)
-def test_implement_exception_posts_error_comment(
-    mock_update, mock_find, mock_comment, mock_issue, mock_impl, capsys
-):
+def test_implement_exception_posts_error_comment(capsys):
     from services.copilot import TaskError
 
-    mock_impl.side_effect = TaskError("CLI crashed", premium_requests=3)
+    mock_impl = AsyncMock(side_effect=TaskError("CLI crashed", premium_requests=3))
+    safe = AsyncMock()
+    patches = [
+        patch("worker.implement_issue", mock_impl),
+        patch("worker.get_issue", new_callable=AsyncMock, return_value=GitHubIssue(title="test")),
+        patch("worker.safe_comment", safe),
+        patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100),
+        patch(
+            "worker.find_issue_comment_by_body_prefix",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("worker.update_comment", new_callable=AsyncMock),
+    ]
+    with ExitStack() as stack:
+        _enter_patches(stack, patches, IMPLEMENT_ENV)
+        from worker import main
 
-    from worker import main
-
-    exit_code = asyncio.run(main())
+        exit_code = asyncio.run(main())
 
     assert exit_code == 1
-    captured = capsys.readouterr()
-    result = TaskResult.model_validate_json(captured.out.strip())
+    result = TaskResult.model_validate_json(capsys.readouterr().out.strip())
     assert result.status == "failed"
     assert result.premium_requests == 3
 
-    # Should have posted error comment
-    error_calls = [c for c in mock_comment.call_args_list if "failed" in str(c).lower()]
+    error_calls = [c for c in safe.call_args_list if "failed" in str(c).lower()]
     assert len(error_calls) > 0
 
 
-@patch.dict(
-    os.environ,
-    {
-        "TASK_TYPE": "review",
-        "REPO": "user/repo",
-        "NUMBER": "42",
-        "GH_TOKEN": "ghs_test",
-        "MODEL": "gpt-5.4",
-        "REASONING_EFFORT": "high",
-    },
-)
-@patch("worker.review_pr", new_callable=AsyncMock)
-@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
-@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("worker.update_comment", new_callable=AsyncMock)
-def test_review_success_returns_zero(mock_update, mock_find, mock_comment, mock_review, capsys):
-    mock_review.return_value = TaskResult(status="complete", premium_requests=2)
+def test_review_success_returns_zero(capsys):
+    mock_review = AsyncMock(return_value=TaskResult(status="complete", premium_requests=2))
+    env = {**REVIEW_ENV, "MODEL": "gpt-5.4", "REASONING_EFFORT": "high"}
+    with ExitStack() as stack:
+        _enter_patches(stack, _review_patches(mock_review), env)
+        from worker import main
 
-    from worker import main
-
-    exit_code = asyncio.run(main())
+        exit_code = asyncio.run(main())
 
     assert exit_code == 0
-    captured = capsys.readouterr()
-    result = TaskResult.model_validate_json(captured.out.strip())
+    result = TaskResult.model_validate_json(capsys.readouterr().out.strip())
     assert result.status == "complete"
     mock_review.assert_awaited_once()
 
 
-@patch.dict(
-    os.environ,
-    {
-        "TASK_TYPE": "review",
-        "REPO": "user/repo",
-        "NUMBER": "42",
-        "GH_TOKEN": "ghs_test",
-    },
-)
-@patch("worker.review_pr", new_callable=AsyncMock)
-@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
-@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("worker.update_comment", new_callable=AsyncMock)
-def test_review_posts_progress_comment(mock_update, mock_find, mock_comment, mock_review):
-    mock_review.return_value = TaskResult(status="complete", premium_requests=1)
+def test_review_posts_progress_comment():
+    mock_review = AsyncMock(return_value=TaskResult(status="complete", premium_requests=1))
+    comment = AsyncMock(return_value=100)
+    patches = [
+        patch("worker.review_pr", mock_review),
+        patch("worker.safe_comment", new_callable=AsyncMock),
+        patch("worker.comment_on_issue", comment),
+        patch(
+            "worker.find_issue_comment_by_body_prefix",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("worker.update_comment", new_callable=AsyncMock),
+    ]
+    with ExitStack() as stack:
+        _enter_patches(stack, patches, REVIEW_ENV)
+        from worker import main
 
-    from worker import main
+        asyncio.run(main())
 
-    asyncio.run(main())
-
-    # Should have posted a progress comment with the review prefix
-    progress_calls = [c for c in mock_comment.call_args_list if "Review in progress" in str(c)]
+    progress_calls = [c for c in comment.call_args_list if "Review in progress" in str(c)]
     assert len(progress_calls) > 0
 
 
-@patch.dict(
-    os.environ,
-    {
-        "TASK_TYPE": "implement",
-        "REPO": "user/repo",
-        "NUMBER": "10",
-        "GH_TOKEN": "ghs_test",
-    },
-)
-@patch("worker.implement_issue", new_callable=AsyncMock)
-@patch("worker.get_issue", new_callable=AsyncMock, return_value=GitHubIssue(title="test"))
-@patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100)
-@patch("worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None)
-@patch("worker.update_comment", new_callable=AsyncMock)
-def test_implement_content_rejection_returns_one(
-    mock_update, mock_find, mock_comment, mock_issue, mock_impl, capsys
-):
+def test_implement_content_rejection_returns_one(capsys):
     """Content trust rejection should not post error comments."""
-    mock_impl.side_effect = ValueError("not trusted")
+    mock_impl = AsyncMock(side_effect=ValueError("not trusted"))
+    with ExitStack() as stack:
+        _enter_patches(stack, _implement_patches(mock_impl), IMPLEMENT_ENV)
+        from worker import main
 
-    from worker import main
-
-    exit_code = asyncio.run(main())
+        exit_code = asyncio.run(main())
 
     assert exit_code == 1
-    captured = capsys.readouterr()
-    result = TaskResult.model_validate_json(captured.out.strip())
+    result = TaskResult.model_validate_json(capsys.readouterr().out.strip())
     assert result.status == "rejected"
 
 
 def test_unknown_task_type_returns_one():
-    with patch.dict(
-        os.environ,
-        {
-            "TASK_TYPE": "unknown",
-            "REPO": "user/repo",
-            "NUMBER": "1",
-            "GH_TOKEN": "ghs_test",
-        },
-    ):
+    env = {"TASK_TYPE": "unknown", "REPO": "user/repo", "NUMBER": "1", "GH_TOKEN": "ghs_test"}
+    with patch.dict(os.environ, env):
         from worker import main
 
         exit_code = asyncio.run(main())
@@ -227,26 +195,17 @@ def test_missing_env_var_returns_one():
 
 
 def test_worker_supports_legacy_worker_env_aliases(capsys):
-    with (
-        patch.dict(
-            os.environ,
-            {
-                "WORKER_TASK": "review",
-                "WORKER_REPO": "user/repo",
-                "WORKER_PR_NUMBER": "42",
-                "GH_TOKEN": "ghs_test",
-            },
-            clear=True,
-        ),
-        patch(
-            "worker.review_pr", new_callable=AsyncMock, return_value=TaskResult(status="complete")
-        ),
-        patch("worker.comment_on_issue", new_callable=AsyncMock, return_value=100),
-        patch(
-            "worker.find_issue_comment_by_body_prefix", new_callable=AsyncMock, return_value=None
-        ),
-        patch("worker.update_comment", new_callable=AsyncMock),
-    ):
+    mock_review = AsyncMock(return_value=TaskResult(status="complete"))
+    legacy_env = {
+        "WORKER_TASK": "review",
+        "WORKER_REPO": "user/repo",
+        "WORKER_PR_NUMBER": "42",
+        "GH_TOKEN": "ghs_test",
+    }
+    with ExitStack() as stack:
+        stack.enter_context(patch.dict(os.environ, legacy_env, clear=True))
+        for p in _review_patches(mock_review):
+            stack.enter_context(p)
         from worker import main
 
         exit_code = asyncio.run(main())

--- a/stacks/agents/app/worker.py
+++ b/stacks/agents/app/worker.py
@@ -20,6 +20,7 @@ from services.github import (
     comment_on_issue,
     find_issue_comment_by_body_prefix,
     get_issue,
+    safe_comment,
     set_token,
     update_comment,
 )
@@ -117,15 +118,7 @@ async def _run_implement(repo: str, issue_number: int, model: str, effort: str) 
             repo, progress_comment_id, f"⚠️ Implementation failed — {exc}"
         )
         if not exc.commented:
-            try:
-                await comment_on_issue(repo, issue_number, f"⚠️ **Implementation failed** — {exc}")
-            except Exception:
-                logger.warning(
-                    "Failed to post implementation failure comment on %s#%d",
-                    repo,
-                    issue_number,
-                    exc_info=True,
-                )
+            await safe_comment(repo, issue_number, f"⚠️ **Implementation failed** — {exc}")
         return TaskResult(status="failed", premium_requests=exc.premium_requests)
 
     except Exception as exc:
@@ -135,17 +128,9 @@ async def _run_implement(repo: str, issue_number: int, model: str, effort: str) 
             progress_comment_id,
             "⚠️ Implementation failed — see agent logs for details.",
         )
-        try:
-            await comment_on_issue(
-                repo, issue_number, "⚠️ **Implementation failed** — see agent logs for details."
-            )
-        except Exception:
-            logger.warning(
-                "Failed to post implementation failure comment on %s#%d",
-                repo,
-                issue_number,
-                exc_info=True,
-            )
+        await safe_comment(
+            repo, issue_number, "⚠️ **Implementation failed** — see agent logs for details."
+        )
         return TaskResult(status="failed", premium_requests=0, error=str(exc))
 
 
@@ -180,15 +165,7 @@ async def _run_review(
         logger.exception("Review failed for %s#%d", repo, pr_number)
         await _update_progress_comment(repo, progress_comment_id, f"⚠️ Review failed — {exc}")
         if not exc.commented:
-            try:
-                await comment_on_issue(repo, pr_number, f"⚠️ **Review failed** — {exc}")
-            except Exception:
-                logger.warning(
-                    "Failed to post review failure comment on %s#%d",
-                    repo,
-                    pr_number,
-                    exc_info=True,
-                )
+            await safe_comment(repo, pr_number, f"⚠️ **Review failed** — {exc}")
         return TaskResult(status="failed", premium_requests=exc.premium_requests)
 
     except Exception as exc:
@@ -198,17 +175,7 @@ async def _run_review(
             progress_comment_id,
             "⚠️ Review failed — see agent logs for details.",
         )
-        try:
-            await comment_on_issue(
-                repo, pr_number, "⚠️ **Review failed** — see agent logs for details."
-            )
-        except Exception:
-            logger.warning(
-                "Failed to post review failure comment on %s#%d",
-                repo,
-                pr_number,
-                exc_info=True,
-            )
+        await safe_comment(repo, pr_number, "⚠️ **Review failed** — see agent logs for details.")
         return TaskResult(status="failed", premium_requests=0, error=str(exc))
 
 


### PR DESCRIPTION
## Summary

Comprehensive code quality pass across the agent service. Addresses [#126](https://github.com/ColinCee/homelab/issues/126).

### Source changes (-142 lines from existing files)

| File | What changed |
|------|-------------|
| `github.py` | `_client()` context manager + `safe_comment()` replace 7× auth boilerplate |
| `worker.py` | 4 error-path comment blocks → `safe_comment()` one-liners |
| `copilot.py` | Collapsed posix/non-posix subprocess duplication into single call |
| `git.py` | Extracted `_acquire_file_lock_cancellation_safe()`, 5→2 nesting levels |
| `implement/orchestrator.py` | Extracted `_build_result()`, switched to `cli_stage_stats()` |
| `main.py` | Extracted `_dispatch_worker()` from handle_review/handle_implement |

### Test changes

| File | What changed |
|------|-------------|
| `conftest.py` (new) | Shared constants (`MOCK_ISSUE`, `MOCK_CLI_RESULT`, `IMPLEMENT_ENV`, `REVIEW_ENV`) + `make_mock_process` fixture |
| `test_worker.py` | `ExitStack` + patch helpers replace 5× decorator stacks |
| `test_implement.py` | Uses conftest constants, removed ClassVar duplication |
| `test_copilot.py` | Uses `make_mock_process` fixture from conftest |

### Infrastructure

- `copilot-instructions.md`: Added flat control flow + DRY error handling principles
- `.github/skills/refactor/SKILL.md`: New user-invocable refactoring skill

### Metrics

- 195/195 tests pass
- Net -29 lines (with 113 new lines in conftest + refactor skill)
- Net -142 lines from existing files

Closes #126