### PR TITLE
feat: add review-fix loop to implement lifecycle

### DIFF
--- a/.github/skills/bot-implement/SKILL.md
+++ b/.github/skills/bot-implement/SKILL.md
@@ -28,9 +28,7 @@ You start in a worktree on the `agent/issue-{N}` branch, set up by the orchestra
 2. **Push** — `git push origin agent/issue-{N}`. Force-push is fine on agent branches.
 3. **Create draft PR** — `gh pr create --draft --title "..." --body "Closes #N\n\n..."`. Always link the issue with `Closes #N` in the body.
 4. **Wait for CI** — `gh pr checks --watch` until all checks pass. Fix failures before proceeding.
-5. **Mark ready** — `gh pr ready` when CI passes and you're satisfied with the code.
-6. **Merge** — `gh pr merge --squash --auto` to squash-merge after all checks pass.
-7. **Independent review** — after a successful implement run, the API monitor comments `/review` on the PR to trigger the fresh advisory review worker. Do not spend premium requests reviewing your own PR from the same CLI session.
+5. **Stop** — do NOT mark the PR ready or merge it. The orchestrator handles review, merge, and marking the PR ready after automated review passes.
 
 ## Rules
 
@@ -63,7 +61,7 @@ Before creating the PR, sanity-check these questions:
 
 - **`mise run ci` includes type-checking (`ty`).** `ty` does not support `# type: ignore` comments. Use typed dataclasses or exceptions instead of monkey-patching.
 - **Docker service names don't resolve across separate compose stacks.** Use Tailscale IPs (`100.x.x.x`) or `host.docker.internal`.
-- **Independent review is post-implement.** The API monitor triggers it by commenting `/review` on the PR after a successful implement result, and it may arrive after merge.
+- **Do not merge the PR.** The orchestrator runs an automated review-fix loop after your implementation, then handles merge itself. Merging from the CLI session bypasses the review loop.
 
 ## Responding to Review Feedback
 

--- a/stacks/agents/app/implement/orchestrator.py
+++ b/stacks/agents/app/implement/orchestrator.py
@@ -65,9 +65,12 @@ Use the bot-review skill for guidelines on how to review and post your findings.
 
 FIX_PROMPT_TEMPLATE = """\
 Review comments have been posted on PR #{pr_number} in {repo}.
-Read the review threads with `gh pr view {pr_number} --comments`.
 
-For each unresolved thread:
+Here are the unresolved review threads:
+
+{threads_summary}
+
+For each thread:
 - If the comment identifies a real issue: fix the code
 - If the comment is a false positive: reply briefly explaining why, then resolve \
 the thread using `gh api graphql` with the resolveReviewThread mutation
@@ -225,7 +228,13 @@ async def _run_review_fix_loop(
             break
 
         # Check threads after review
-        unresolved = await get_unresolved_review_threads(repo, pr_number)
+        try:
+            unresolved = await get_unresolved_review_threads(repo, pr_number)
+        except Exception:
+            logger.warning(
+                "Failed to fetch review threads after review round %d", round_num, exc_info=True
+            )
+            break
         if not unresolved:
             logger.info("Review round %d: approved (no unresolved threads)", round_num)
             approved = True
@@ -238,7 +247,10 @@ async def _run_review_fix_loop(
         )
 
         # ── Fix step ──
-        fix_prompt = FIX_PROMPT_TEMPLATE.format(pr_number=pr_number, repo=repo)
+        threads_summary = "\n".join(f"- Thread {t.id}: {t.body[:200]}" for t in unresolved)
+        fix_prompt = FIX_PROMPT_TEMPLATE.format(
+            pr_number=pr_number, repo=repo, threads_summary=threads_summary
+        )
         try:
             fix_result = await run_copilot(
                 worktree_path,
@@ -256,7 +268,13 @@ async def _run_review_fix_loop(
             break
 
         # Check threads after fix
-        unresolved = await get_unresolved_review_threads(repo, pr_number)
+        try:
+            unresolved = await get_unresolved_review_threads(repo, pr_number)
+        except Exception:
+            logger.warning(
+                "Failed to fetch review threads after fix round %d", round_num, exc_info=True
+            )
+            break
         if not unresolved:
             logger.info("Fix round %d resolved all threads", round_num)
             approved = True
@@ -290,7 +308,11 @@ async def _try_merge(
         logger.warning("Failed to mark PR #%d ready", pr_number, exc_info=True)
 
     # Fast path: REST API merge
-    merged = await merge_pr(repo, pr_number)
+    try:
+        merged = await merge_pr(repo, pr_number)
+    except Exception:
+        logger.warning("REST merge API call failed for #%d", pr_number, exc_info=True)
+        merged = False
     if merged:
         logger.info("PR #%d merged via REST API", pr_number)
         return True, 0

--- a/stacks/agents/app/implement/orchestrator.py
+++ b/stacks/agents/app/implement/orchestrator.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from datetime import UTC, datetime
+from pathlib import Path
 
 from models import GitHubIssue, GitHubPullRequest, TaskResult
 from services.copilot import CLIResult, TaskError, run_copilot
@@ -12,12 +13,17 @@ from services.github import (
     find_pr_by_branch,
     get_issue,
     get_token,
+    get_unresolved_review_threads,
+    mark_pr_ready,
+    merge_pr,
     safe_comment,
 )
 from stats import STATUS_EMOJI, cli_stage_stats
 from trust import is_trusted_content_author
 
 logger = logging.getLogger(__name__)
+
+MAX_REVIEW_FIX_ROUNDS = 2
 
 
 def _monotonic() -> float:
@@ -35,7 +41,50 @@ Implement the following GitHub issue in {repo}.
 
 {body}
 
+Create a draft PR when your changes are ready. Do NOT merge the PR — \
+the orchestrator handles merge after automated review.
+
 Use the bot-implement skill for guidelines on how to make changes.
+"""
+
+
+REVIEW_PROMPT_TEMPLATE = """\
+Review PR #{pr_number} in {repo}.
+
+This PR implements issue #{issue_number}: {issue_title}
+
+### Issue description
+
+{issue_body}
+
+Read the PR diff with `gh pr diff {pr_number}`. Post your review directly via `gh`.
+
+Use the bot-review skill for guidelines on how to review and post your findings.
+"""
+
+
+FIX_PROMPT_TEMPLATE = """\
+Review comments have been posted on PR #{pr_number} in {repo}.
+Read the review threads with `gh pr view {pr_number} --comments`.
+
+For each unresolved thread:
+- If the comment identifies a real issue: fix the code
+- If the comment is a false positive: reply briefly explaining why, then resolve \
+the thread using `gh api graphql` with the resolveReviewThread mutation
+
+Push your changes when done. Do NOT merge the PR.
+"""
+
+
+MERGE_PROMPT_TEMPLATE = """\
+PR #{pr_number} in {repo} has been approved but could not be merged automatically \
+(likely due to merge conflicts or the branch being out of date).
+
+1. Rebase onto main: `git fetch origin main && git rebase origin/main`
+2. Resolve any conflicts
+3. Push: `git push --force origin {branch}`
+4. Wait for CI: `gh pr checks {pr_number} --watch`
+5. Merge: `gh pr merge {pr_number} --squash`
 """
 
 
@@ -131,6 +180,151 @@ def _build_result(
     )
 
 
+async def _run_review_fix_loop(
+    *,
+    worktree_path: Path,
+    repo: str,
+    pr_number: int,
+    issue_data: GitHubIssue,
+    issue_number: int,
+    implement_session_id: str | None,
+    model: str,
+    reasoning_effort: str,
+    token: str,
+) -> tuple[bool, int]:
+    """Run the review → fix loop. Returns (approved, premium_requests_used)."""
+    total_premium = 0
+    review_session_id: str | None = None
+    approved = False
+
+    for round_num in range(1, MAX_REVIEW_FIX_ROUNDS + 1):
+        # ── Review step ──
+        logger.info("Review round %d for %s#%d", round_num, repo, pr_number)
+        review_prompt = REVIEW_PROMPT_TEMPLATE.format(
+            pr_number=pr_number,
+            repo=repo,
+            issue_number=issue_number,
+            issue_title=issue_data.title,
+            issue_body=issue_data.body or "(no description)",
+        )
+        try:
+            review_result = await run_copilot(
+                worktree_path,
+                review_prompt,
+                model=model,
+                effort=reasoning_effort,
+                session_id=review_session_id,
+                github_token=token,
+            )
+            total_premium += review_result.total_premium_requests
+            review_session_id = review_result.session_id
+        except TaskError as exc:
+            total_premium += exc.premium_requests
+            logger.warning("Review round %d failed: %s", round_num, exc)
+            await safe_comment(repo, pr_number, f"⚠️ Review round {round_num} failed — {exc}")
+            break
+
+        # Check threads after review
+        unresolved = await get_unresolved_review_threads(repo, pr_number)
+        if not unresolved:
+            logger.info("Review round %d: approved (no unresolved threads)", round_num)
+            approved = True
+            break
+
+        logger.info(
+            "Review round %d: %d unresolved thread(s), starting fix",
+            round_num,
+            len(unresolved),
+        )
+
+        # ── Fix step ──
+        fix_prompt = FIX_PROMPT_TEMPLATE.format(pr_number=pr_number, repo=repo)
+        try:
+            fix_result = await run_copilot(
+                worktree_path,
+                fix_prompt,
+                model=model,
+                effort=reasoning_effort,
+                session_id=implement_session_id,
+                github_token=token,
+            )
+            total_premium += fix_result.total_premium_requests
+        except TaskError as exc:
+            total_premium += exc.premium_requests
+            logger.warning("Fix round %d failed: %s", round_num, exc)
+            await safe_comment(repo, pr_number, f"⚠️ Fix round {round_num} failed — {exc}")
+            break
+
+        # Check threads after fix
+        unresolved = await get_unresolved_review_threads(repo, pr_number)
+        if not unresolved:
+            logger.info("Fix round %d resolved all threads", round_num)
+            approved = True
+            break
+
+        logger.info(
+            "Fix round %d: %d thread(s) still unresolved",
+            round_num,
+            len(unresolved),
+        )
+
+    return approved, total_premium
+
+
+async def _try_merge(
+    *,
+    worktree_path: Path,
+    repo: str,
+    pr_number: int,
+    branch_name: str,
+    implement_session_id: str | None,
+    model: str,
+    reasoning_effort: str,
+    token: str,
+) -> tuple[bool, int]:
+    """Attempt to merge a PR. Returns (merged, premium_requests_used)."""
+    # Mark PR ready (it's a draft)
+    try:
+        await mark_pr_ready(repo, pr_number)
+    except Exception:
+        logger.warning("Failed to mark PR #%d ready", pr_number, exc_info=True)
+
+    # Fast path: REST API merge
+    merged = await merge_pr(repo, pr_number)
+    if merged:
+        logger.info("PR #%d merged via REST API", pr_number)
+        return True, 0
+
+    # Fallback: CLI rebase + merge
+    logger.info("REST merge failed for #%d, trying CLI fallback", pr_number)
+    merge_prompt = MERGE_PROMPT_TEMPLATE.format(
+        pr_number=pr_number,
+        repo=repo,
+        branch=branch_name,
+    )
+    try:
+        merge_result = await run_copilot(
+            worktree_path,
+            merge_prompt,
+            model=model,
+            effort=reasoning_effort,
+            session_id=implement_session_id,
+            github_token=token,
+        )
+        premium = merge_result.total_premium_requests
+
+        # Re-check PR state
+        pr_data = await find_pr_by_branch(repo, branch_name)
+        if pr_data and (pr_data.merged_at is not None or pr_data.merged):
+            logger.info("PR #%d merged via CLI fallback", pr_number)
+            return True, premium
+        logger.warning("CLI fallback did not merge PR #%d", pr_number)
+        return False, premium
+    except TaskError as exc:
+        logger.warning("CLI merge fallback failed: %s", exc)
+        return False, exc.premium_requests
+
+
 async def implement_issue(
     *,
     repo: str,
@@ -139,11 +333,10 @@ async def implement_issue(
     reasoning_effort: str = "high",
     issue: GitHubIssue | None = None,
 ) -> TaskResult:
-    """Implement a GitHub issue: set up worktree → CLI handles everything → check result.
+    """Implement a GitHub issue with review-fix loop.
 
-    The CLI owns the full lifecycle: commit, push, create PR, wait for CI,
-    mark ready, and merge. The orchestrator only validates trust, sets up the
-    environment, and collects stats.
+    Lifecycle: implement -> (review -> fix) x N -> merge.
+    Each step is a separate CLI call sharing the same worktree.
     """
     logger.info("Implementing issue %s#%d", repo, issue_number)
     start = _monotonic()
@@ -169,6 +362,7 @@ async def implement_issue(
     try:
         worktree_path = await create_branch_worktree(branch_name, repo_url)
 
+        # ── Step 1: Implement ──
         prompt = IMPLEMENT_PROMPT_TEMPLATE.format(
             repo=repo,
             issue_number=issue_number,
@@ -184,6 +378,7 @@ async def implement_issue(
             github_token=token,
         )
         total_premium_requests += cli_result.total_premium_requests
+        implement_session_id = cli_result.session_id
 
         pr_data = await find_pr_by_branch(repo, branch_name)
 
@@ -196,6 +391,67 @@ async def implement_issue(
                 pr_data.merged_at,
             )
             pr_data = None
+
+        # No PR created → fail early
+        if not pr_data:
+            elapsed = _monotonic() - start
+            result = _build_result(None, elapsed, total_premium_requests, cli_result, repo)
+            return result
+
+        # CLI already merged the PR → skip review loop
+        if pr_data.merged_at is not None or pr_data.merged:
+            logger.info("CLI already merged PR #%d, skipping review loop", pr_data.number)
+            elapsed = _monotonic() - start
+            result = _build_result(pr_data, elapsed, total_premium_requests, cli_result, repo)
+            if result.merged:
+                try:
+                    await close_issue(repo, issue_number)
+                except Exception:
+                    logger.warning(
+                        "Failed to close issue %s#%d after merged PR",
+                        repo,
+                        issue_number,
+                        exc_info=True,
+                    )
+            return result
+
+        # ── Step 2: Review-fix loop ──
+        approved, loop_premium = await _run_review_fix_loop(
+            worktree_path=worktree_path,
+            repo=repo,
+            pr_number=pr_data.number,
+            issue_data=issue_data,
+            issue_number=issue_number,
+            implement_session_id=implement_session_id,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            token=token,
+        )
+        total_premium_requests += loop_premium
+
+        # ── Step 3: Merge or leave open ──
+        if approved:
+            _merged, merge_premium = await _try_merge(
+                worktree_path=worktree_path,
+                repo=repo,
+                pr_number=pr_data.number,
+                branch_name=branch_name,
+                implement_session_id=implement_session_id,
+                model=model,
+                reasoning_effort=reasoning_effort,
+                token=token,
+            )
+            total_premium_requests += merge_premium
+
+            # Re-fetch PR state for final result
+            pr_data = await find_pr_by_branch(repo, branch_name)
+        else:
+            await safe_comment(
+                repo,
+                pr_data.number,
+                f"⚠️ Review-fix loop exhausted ({MAX_REVIEW_FIX_ROUNDS} rounds) "
+                "with unresolved threads — needs human review.",
+            )
 
         elapsed = _monotonic() - start
         result = _build_result(pr_data, elapsed, total_premium_requests, cli_result, repo)

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -32,7 +32,7 @@ from services.docker import (
     wait_container,
 )
 from services.git import reap_old_worktrees
-from services.github import comment_on_issue, set_token
+from services.github import set_token
 from trust import ALLOWED_ACTORS
 
 LOG_FORMAT = resolve_log_format(os.environ.get("LOG_FORMAT"))
@@ -112,31 +112,6 @@ def _record_task_metrics(
         PREMIUM_REQUESTS_TOTAL.labels(task_type=task_type).inc(premium_requests)
 
 
-async def _trigger_independent_review(
-    *, task_type: str, status: str, number: int, result: TaskResult | None
-) -> None:
-    """Post `/review` on successful implement PRs to trigger the fresh review worker."""
-    if task_type != "implement" or status != "complete" or result is None:
-        return
-
-    if result.pr_number is None:
-        return
-
-    if not result.repo:
-        logger.warning(
-            "Implement worker #%d completed without repo in result; skipping /review trigger",
-            number,
-        )
-        return
-
-    await comment_on_issue(result.repo, result.pr_number, "/review")
-    logger.info(
-        "Posted /review comment on %s#%d after implement completion",
-        result.repo,
-        result.pr_number,
-    )
-
-
 class ReviewRequest(BaseModel):
     repo: str
     pr_number: int
@@ -207,15 +182,6 @@ async def _monitor_worker(container_id: str, *, task_type: str, number: int, sta
             premium,
             f", error={error}" if error else "",
         )
-        try:
-            await _trigger_independent_review(
-                task_type=task_type,
-                status=status,
-                number=number,
-                result=result,
-            )
-        except Exception:
-            logger.exception("Failed to post /review comment for implement #%d", number)
     except Exception:
         logger.exception("Monitor failed for worker %s #%d", task_type, number)
     finally:

--- a/stacks/agents/app/models.py
+++ b/stacks/agents/app/models.py
@@ -58,6 +58,15 @@ class GitHubIssueComment(BaseModel):
     user: GitHubUser | None = None
 
 
+class ReviewThread(BaseModel):
+    """A review thread on a PR, from the GraphQL API."""
+
+    id: str
+    is_resolved: bool
+    is_outdated: bool
+    body: str = ""
+
+
 class TaskResult(BaseModel):
     model_config = ConfigDict(extra="ignore")
 

--- a/stacks/agents/app/services/github.py
+++ b/stacks/agents/app/services/github.py
@@ -1,4 +1,4 @@
-"""GitHub API — token management and REST helpers."""
+"""GitHub API — token management, REST helpers, and GraphQL queries."""
 
 import logging
 from collections.abc import AsyncIterator
@@ -9,7 +9,7 @@ from typing import Any
 import httpx
 from pydantic import TypeAdapter
 
-from models import GitHubIssue, GitHubIssueComment, GitHubPullRequest
+from models import GitHubIssue, GitHubIssueComment, GitHubPullRequest, ReviewThread
 
 logger = logging.getLogger(__name__)
 
@@ -200,3 +200,107 @@ async def find_issue_comment_by_body_prefix(
             return comment.id
 
     return None
+
+
+# ── Review threads (GraphQL) ──────────────────────────────
+
+
+_REVIEW_THREADS_QUERY = """
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first: 1) {
+            nodes { body }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_GRAPHQL = "https://api.github.com/graphql"
+
+
+async def get_unresolved_review_threads(repo: str, pr_number: int) -> list[ReviewThread]:
+    """Fetch unresolved, non-outdated review threads on a PR via GraphQL."""
+    owner, name = repo.split("/", 1)
+    async with _client() as client:
+        resp = await client.post(
+            _GRAPHQL,
+            json={
+                "query": _REVIEW_THREADS_QUERY,
+                "variables": {"owner": owner, "repo": name, "pr": pr_number},
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    errors = data.get("errors")
+    if errors:
+        raise RuntimeError(f"GraphQL errors: {errors}")
+
+    pr_data = data.get("data", {}).get("repository", {}).get("pullRequest")
+    if not pr_data:
+        return []
+
+    threads: list[ReviewThread] = []
+    for node in pr_data.get("reviewThreads", {}).get("nodes", []):
+        if node.get("isResolved") or node.get("isOutdated"):
+            continue
+        first_comment = ""
+        comments = node.get("comments", {}).get("nodes", [])
+        if comments:
+            first_comment = comments[0].get("body", "")
+        threads.append(
+            ReviewThread(
+                id=node["id"],
+                is_resolved=False,
+                is_outdated=False,
+                body=first_comment,
+            )
+        )
+    return threads
+
+
+# ── PR merge / ready ──────────────────────────────────────
+
+
+async def merge_pr(repo: str, pr_number: int) -> bool:
+    """Squash-merge a PR. Returns True on success, False if merge is blocked."""
+    async with _client() as client:
+        resp = await client.put(
+            f"{_API}/repos/{repo}/pulls/{pr_number}/merge",
+            json={"merge_method": "squash"},
+        )
+    if resp.status_code == 200:
+        return True
+    if resp.status_code in (405, 409):
+        logger.warning(
+            "Merge blocked for %s#%d: HTTP %d — %s",
+            repo,
+            pr_number,
+            resp.status_code,
+            resp.text,
+        )
+        return False
+    resp.raise_for_status()
+    return False
+
+
+async def mark_pr_ready(repo: str, pr_number: int) -> None:
+    """Mark a draft PR as ready for review."""
+    async with _client() as client:
+        resp = await client.patch(
+            f"{_API}/repos/{repo}/pulls/{pr_number}",
+            json={"draft": False},
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Failed to mark PR #{pr_number} ready on {repo}: HTTP {resp.status_code}"
+            )

--- a/stacks/agents/app/tests/test_github.py
+++ b/stacks/agents/app/tests/test_github.py
@@ -235,3 +235,224 @@ class TestIssueComments:
 
         result = asyncio.run(run())
         assert result == 3
+
+
+class TestGetUnresolvedReviewThreads:
+    def test_returns_unresolved_non_outdated_threads(self):
+        graphql_resp = httpx.Response(
+            200,
+            json={
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [
+                                    {
+                                        "id": "thread-1",
+                                        "isResolved": False,
+                                        "isOutdated": False,
+                                        "comments": {"nodes": [{"body": "Fix this bug"}]},
+                                    },
+                                    {
+                                        "id": "thread-2",
+                                        "isResolved": True,
+                                        "isOutdated": False,
+                                        "comments": {"nodes": [{"body": "Already fixed"}]},
+                                    },
+                                    {
+                                        "id": "thread-3",
+                                        "isResolved": False,
+                                        "isOutdated": True,
+                                        "comments": {"nodes": [{"body": "Old code"}]},
+                                    },
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            request=httpx.Request("POST", "https://api.github.com/graphql"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.post",
+                    new_callable=AsyncMock,
+                    return_value=graphql_resp,
+                ),
+            ):
+                return await github.get_unresolved_review_threads("user/repo", 42)
+
+        threads = asyncio.run(run())
+        assert len(threads) == 1
+        assert threads[0].id == "thread-1"
+        assert threads[0].body == "Fix this bug"
+        assert threads[0].is_resolved is False
+
+    def test_returns_empty_when_no_threads(self):
+        graphql_resp = httpx.Response(
+            200,
+            json={"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}},
+            request=httpx.Request("POST", "https://api.github.com/graphql"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.post",
+                    new_callable=AsyncMock,
+                    return_value=graphql_resp,
+                ),
+            ):
+                return await github.get_unresolved_review_threads("user/repo", 42)
+
+        assert asyncio.run(run()) == []
+
+    def test_returns_empty_when_all_resolved(self):
+        graphql_resp = httpx.Response(
+            200,
+            json={
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [
+                                    {
+                                        "id": "t1",
+                                        "isResolved": True,
+                                        "isOutdated": False,
+                                        "comments": {"nodes": [{"body": "Fixed"}]},
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            request=httpx.Request("POST", "https://api.github.com/graphql"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.post",
+                    new_callable=AsyncMock,
+                    return_value=graphql_resp,
+                ),
+            ):
+                return await github.get_unresolved_review_threads("user/repo", 42)
+
+        assert asyncio.run(run()) == []
+
+
+class TestMergePr:
+    def test_returns_true_on_success(self):
+        merge_resp = httpx.Response(
+            200,
+            json={"merged": True},
+            request=httpx.Request("PUT", "https://api.github.com/merge"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.put",
+                    new_callable=AsyncMock,
+                    return_value=merge_resp,
+                ),
+            ):
+                return await github.merge_pr("user/repo", 42)
+
+        assert asyncio.run(run()) is True
+
+    def test_returns_false_on_conflict(self):
+        merge_resp = httpx.Response(
+            409,
+            json={"message": "Merge conflict"},
+            request=httpx.Request("PUT", "https://api.github.com/merge"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.put",
+                    new_callable=AsyncMock,
+                    return_value=merge_resp,
+                ),
+            ):
+                return await github.merge_pr("user/repo", 42)
+
+        assert asyncio.run(run()) is False
+
+    def test_returns_false_on_method_not_allowed(self):
+        merge_resp = httpx.Response(
+            405,
+            json={"message": "Not allowed"},
+            request=httpx.Request("PUT", "https://api.github.com/merge"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.put",
+                    new_callable=AsyncMock,
+                    return_value=merge_resp,
+                ),
+            ):
+                return await github.merge_pr("user/repo", 42)
+
+        assert asyncio.run(run()) is False
+
+
+class TestMarkPrReady:
+    def test_marks_draft_pr_ready(self):
+        ready_resp = httpx.Response(
+            200,
+            json={"number": 42, "draft": False},
+            request=httpx.Request("PATCH", "https://api.github.com/pulls/42"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.patch",
+                    new_callable=AsyncMock,
+                    return_value=ready_resp,
+                ) as mock_patch,
+            ):
+                await github.mark_pr_ready("user/repo", 42)
+                return mock_patch
+
+        mock_patch = asyncio.run(run())
+        assert mock_patch.await_args.kwargs["json"] == {"draft": False}
+
+    def test_raises_on_failure(self):
+        import pytest
+
+        fail_resp = httpx.Response(
+            422,
+            json={"message": "Validation failed"},
+            request=httpx.Request("PATCH", "https://api.github.com/pulls/42"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.patch",
+                    new_callable=AsyncMock,
+                    return_value=fail_resp,
+                ),
+            ):
+                await github.mark_pr_ready("user/repo", 42)
+
+        with pytest.raises(RuntimeError, match="Failed to mark PR"):
+            asyncio.run(run())

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -9,11 +9,15 @@ import pytest
 from conftest import MOCK_CLI_RESULT, MOCK_ISSUE
 
 from implement import implement_issue
-from models import GitHubIssue, GitHubPullRequest
+from models import GitHubIssue, GitHubPullRequest, ReviewThread
 from services.copilot import CLIResult, TaskError
 from stats import cli_stage_stats, format_stage_stats
 
 _MOD = "implement.orchestrator"
+
+# Sentinel for _base_mocks default parameter detection
+_THREAD_T1 = ReviewThread(id="t1", is_resolved=False, is_outdated=False, body="Fix this bug")
+_THREAD_LIST = [_THREAD_T1]
 
 # Sentinel for _base_mocks default parameter detection
 _UNSET = object()
@@ -710,7 +714,7 @@ class TestReviewFixLoop:
         """Review finds issues → fix resolves them → merge."""
         result = self._run_with_loop(
             unresolved_threads_sequence=[
-                [{"id": "t1"}],  # after review: 1 thread
+                _THREAD_LIST,  # after review: 1 thread
                 [],  # after fix: resolved
             ],
         )
@@ -721,10 +725,10 @@ class TestReviewFixLoop:
         """Two rounds of review-fix, still unresolved → PR left open."""
         result = self._run_with_loop(
             unresolved_threads_sequence=[
-                [{"id": "t1"}],  # round 1 review
-                [{"id": "t1"}],  # round 1 fix — still there
-                [{"id": "t1"}],  # round 2 review
-                [{"id": "t1"}],  # round 2 fix — still there
+                _THREAD_LIST,  # round 1 review
+                _THREAD_LIST,  # round 1 fix — still there
+                _THREAD_LIST,  # round 2 review
+                _THREAD_LIST,  # round 2 fix — still there
             ],
             merge_result=False,
             pr_after_merge=self._OPEN_PR,
@@ -765,11 +769,47 @@ class TestReviewFixLoop:
         assert result.pr_number is None
 
     def test_already_merged_skips_loop(self):
-        """CLI merged during implement → skip review loop."""
-        result = self._run_with_loop(
-            unresolved_threads_sequence=[],  # should never be called
-            pr_after_merge=self._MERGED_PR,
-        )
+        """CLI merged during implement → skip review loop, no review/fix calls."""
+        merged_pr = self._MERGED_PR
+
+        async def run():
+            with (
+                patch(f"{_MOD}._utcnow", return_value=_TEST_START),
+                patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=MOCK_ISSUE),
+                patch(
+                    "implement.orchestrator.create_branch_worktree",
+                    new_callable=AsyncMock,
+                    return_value=Path("/tmp/wt"),
+                ),
+                patch(
+                    "implement.orchestrator.run_copilot",
+                    new_callable=AsyncMock,
+                    return_value=CLIResult(
+                        output="done", total_premium_requests=5, session_id="s1"
+                    ),
+                ) as mock_copilot,
+                # First find_pr_by_branch returns merged PR → skip loop
+                patch(
+                    f"{_MOD}.find_pr_by_branch",
+                    new_callable=AsyncMock,
+                    return_value=merged_pr,
+                ),
+                patch(
+                    f"{_MOD}.get_unresolved_review_threads",
+                    new_callable=AsyncMock,
+                ) as mock_threads,
+                patch(f"{_MOD}.close_issue", new_callable=AsyncMock),
+                patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
+                patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
+            ):
+                result = await implement_issue(repo="user/repo", issue_number=42)
+                # Only the implement call, no review/fix/merge
+                assert mock_copilot.await_count == 1
+                mock_threads.assert_not_awaited()
+                return result
+
+        result = asyncio.run(run())
         assert result.status == "complete"
         assert result.merged is True
 
@@ -788,7 +828,7 @@ class TestReviewFixLoop:
         """Fix CLI throws TaskError → break loop, leave PR open."""
         review_cli = CLIResult(output="review", total_premium_requests=1, session_id="r1")
         result = self._run_with_loop(
-            unresolved_threads_sequence=[[{"id": "t1"}]],  # review finds issues
+            unresolved_threads_sequence=[_THREAD_LIST],  # review finds issues
             review_side_effects=[review_cli, TaskError("fix crashed", premium_requests=3)],
             merge_result=False,
             pr_after_merge=self._OPEN_PR,
@@ -814,7 +854,7 @@ class TestReviewFixLoop:
         """Premium requests from all CLI calls are summed."""
         result = self._run_with_loop(
             unresolved_threads_sequence=[
-                [{"id": "t1"}],  # after review
+                _THREAD_LIST,  # after review
                 [],  # after fix
             ],
         )

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -15,6 +15,9 @@ from stats import cli_stage_stats, format_stage_stats
 
 _MOD = "implement.orchestrator"
 
+# Sentinel for _base_mocks default parameter detection
+_UNSET = object()
+
 # Fixed time for tests — all mock merged_at values should be after this
 _TEST_START = datetime(2024, 12, 31, tzinfo=UTC)
 
@@ -103,8 +106,36 @@ class TestFormatStageStats:
 class TestImplementIssue:
     """Tests for implement_issue() — thin dispatcher to CLI."""
 
-    def _base_mocks(self, *, pr_data=None, cli_result=None):
-        """Return standard patches for implement_issue tests."""
+    def _base_mocks(self, *, pr_data=None, cli_result=None, final_pr_data=_UNSET):
+        """Return standard patches for implement_issue tests.
+
+        When ``pr_data`` is an unmerged PR the review-fix loop runs.
+        ``final_pr_data`` controls what ``find_pr_by_branch`` returns on
+        the second call (after merge).  Defaults to a merged copy of
+        ``pr_data`` so the happy-path completes without extra setup.
+        """
+        already_merged = pr_data and (pr_data.merged_at or pr_data.merged)
+
+        if pr_data and not already_merged:
+            if final_pr_data is _UNSET:
+                final_pr_data = GitHubPullRequest(
+                    number=pr_data.number,
+                    html_url=pr_data.html_url,
+                    merged_at="2025-01-01T00:00:00Z",
+                    merged=True,
+                )
+            find_pr_patch = patch(
+                "implement.orchestrator.find_pr_by_branch",
+                new_callable=AsyncMock,
+                side_effect=[pr_data, final_pr_data],
+            )
+        else:
+            find_pr_patch = patch(
+                "implement.orchestrator.find_pr_by_branch",
+                new_callable=AsyncMock,
+                return_value=pr_data,
+            )
+
         return [
             patch(f"{_MOD}._utcnow", return_value=_TEST_START),
             patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
@@ -119,11 +150,10 @@ class TestImplementIssue:
                 new_callable=AsyncMock,
                 return_value=cli_result or MOCK_CLI_RESULT,
             ),
-            patch(
-                "implement.orchestrator.find_pr_by_branch",
-                new_callable=AsyncMock,
-                return_value=pr_data,
-            ),
+            find_pr_patch,
+            patch(f"{_MOD}.get_unresolved_review_threads", new_callable=AsyncMock, return_value=[]),
+            patch(f"{_MOD}.merge_pr", new_callable=AsyncMock, return_value=True),
+            patch(f"{_MOD}.mark_pr_ready", new_callable=AsyncMock),
             patch(f"{_MOD}.close_issue", new_callable=AsyncMock),
             patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
             patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
@@ -161,24 +191,33 @@ class TestImplementIssue:
         assert result.tokens_line == "↑ 883.6k • ↓ 17.7k • 788.5k (cached)"
         assert result.session_id == "sess-123"
 
-    def test_partial_when_pr_not_merged(self):
-        """CLI creates PR but doesn't merge and no auto-merge → status partial."""
+    def test_partial_when_merge_fails(self):
+        """Loop approves but merge fails → status partial."""
         pr_data = GitHubPullRequest(
             number=99,
             html_url="https://github.com/user/repo/pull/99",
             merged_at=None,
             merged=False,
-            auto_merge=None,
         )
-        mocks = self._base_mocks(pr_data=pr_data)
+        # merge_pr fails → CLI fallback → find_pr_by_branch in fallback + final
+        # Calls: 1) after implement, 2) in _try_merge fallback, 3) final refetch
+        mocks = self._base_mocks(pr_data=pr_data, final_pr_data=pr_data)
+        for i, m in enumerate(mocks):
+            if getattr(m, "attribute", None) == "merge_pr":
+                mocks[i] = patch(f"{_MOD}.merge_pr", new_callable=AsyncMock, return_value=False)
+            # Need 3 calls: after implement, in _try_merge fallback, final refetch
+            if getattr(m, "attribute", None) == "find_pr_by_branch":
+                mocks[i] = patch(
+                    f"{_MOD}.find_pr_by_branch",
+                    new_callable=AsyncMock,
+                    side_effect=[pr_data, pr_data, pr_data],
+                )
         result = self._run(mocks)
         assert result.status == "partial"
         assert result.merged is False
-        assert result.error is not None
-        assert "manual attention" in result.error
 
     def test_complete_when_auto_merge_enabled(self):
-        """CLI enables auto-merge → status complete, issue not closed (GitHub handles it)."""
+        """Loop approves, merge fails, but auto-merge set → status complete."""
         pr_data = GitHubPullRequest.model_validate(
             {
                 "number": 99,
@@ -188,7 +227,18 @@ class TestImplementIssue:
                 "auto_merge": {"enabled_by": {"login": "bot"}, "merge_method": "squash"},
             }
         )
-        mocks = self._base_mocks(pr_data=pr_data)
+        # merge_pr fails, CLI fallback fails, but auto_merge → complete
+        # find_pr_by_branch: 3 calls (implement, _try_merge fallback, final)
+        mocks = self._base_mocks(pr_data=pr_data, final_pr_data=pr_data)
+        for i, m in enumerate(mocks):
+            if getattr(m, "attribute", None) == "merge_pr":
+                mocks[i] = patch(f"{_MOD}.merge_pr", new_callable=AsyncMock, return_value=False)
+            if getattr(m, "attribute", None) == "find_pr_by_branch":
+                mocks[i] = patch(
+                    f"{_MOD}.find_pr_by_branch",
+                    new_callable=AsyncMock,
+                    side_effect=[pr_data, pr_data, pr_data],
+                )
         result = self._run(mocks)
         assert result.status == "complete"
         assert result.merged is False
@@ -233,6 +283,9 @@ class TestImplementIssue:
     def test_passes_github_token_to_cli(self):
         """CLI receives GH_TOKEN for git push and API access."""
         pr_data = GitHubPullRequest(number=1, html_url="u", merged_at=None, merged=False)
+        merged_pr = GitHubPullRequest(
+            number=1, html_url="u", merged_at="2025-01-01T00:00:00Z", merged=True
+        )
 
         async def run():
             with (
@@ -249,7 +302,18 @@ class TestImplementIssue:
                     new_callable=AsyncMock,
                     return_value=MOCK_CLI_RESULT,
                 ) as mock_cli,
-                patch(f"{_MOD}.find_pr_by_branch", new_callable=AsyncMock, return_value=pr_data),
+                patch(
+                    f"{_MOD}.find_pr_by_branch",
+                    new_callable=AsyncMock,
+                    side_effect=[pr_data, merged_pr],
+                ),
+                patch(
+                    f"{_MOD}.get_unresolved_review_threads",
+                    new_callable=AsyncMock,
+                    return_value=[],
+                ),
+                patch(f"{_MOD}.merge_pr", new_callable=AsyncMock, return_value=True),
+                patch(f"{_MOD}.mark_pr_ready", new_callable=AsyncMock),
                 patch(f"{_MOD}.close_issue", new_callable=AsyncMock),
                 patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
                 patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
@@ -296,7 +360,7 @@ class TestImplementIssue:
         mock_close.assert_awaited_once_with("user/repo", 42)
 
     def test_does_not_close_issue_when_not_merged(self):
-        """Issue stays open when PR is not merged."""
+        """Issue stays open when merge fails after review approval."""
         pr_data = GitHubPullRequest(
             number=99,
             html_url="https://github.com/user/repo/pull/99",
@@ -319,7 +383,19 @@ class TestImplementIssue:
                     new_callable=AsyncMock,
                     return_value=MOCK_CLI_RESULT,
                 ),
-                patch(f"{_MOD}.find_pr_by_branch", new_callable=AsyncMock, return_value=pr_data),
+                # find_pr_by_branch: 3 calls (implement, _try_merge fallback, final)
+                patch(
+                    f"{_MOD}.find_pr_by_branch",
+                    new_callable=AsyncMock,
+                    side_effect=[pr_data, pr_data, pr_data],
+                ),
+                patch(
+                    f"{_MOD}.get_unresolved_review_threads",
+                    new_callable=AsyncMock,
+                    return_value=[],
+                ),
+                patch(f"{_MOD}.merge_pr", new_callable=AsyncMock, return_value=False),
+                patch(f"{_MOD}.mark_pr_ready", new_callable=AsyncMock),
                 patch(f"{_MOD}.close_issue", new_callable=AsyncMock) as mock_close,
                 patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
                 patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
@@ -515,3 +591,232 @@ class TestImplementIssue:
 
         mock_cleanup = asyncio.run(run())
         mock_cleanup.assert_awaited_once_with("agent/issue-42")
+
+
+class TestReviewFixLoop:
+    """Tests for the review-fix loop in implement_issue()."""
+
+    # PR that is open (not merged, not draft-related — just open)
+    _OPEN_PR = GitHubPullRequest(
+        number=99,
+        html_url="https://github.com/user/repo/pull/99",
+        merged_at=None,
+        merged=False,
+    )
+
+    # PR after merge
+    _MERGED_PR = GitHubPullRequest(
+        number=99,
+        html_url="https://github.com/user/repo/pull/99",
+        merged_at="2025-01-01T00:00:00Z",
+        merged=True,
+    )
+
+    def _run_with_loop(
+        self,
+        *,
+        unresolved_threads_sequence: list[list] | None = None,
+        review_side_effects: list | None = None,
+        fix_side_effects: list | None = None,
+        merge_result: bool = True,
+        pr_after_merge: GitHubPullRequest | None = None,
+    ):
+        """Run implement_issue with mocked review-fix loop behavior.
+
+        unresolved_threads_sequence: list of return values for successive
+            get_unresolved_review_threads calls (after review, after fix, ...).
+        """
+        if unresolved_threads_sequence is None:
+            unresolved_threads_sequence = [[]]  # clean review
+
+        threads_iter = iter(unresolved_threads_sequence)
+        review_cli = CLIResult(output="review done", total_premium_requests=1, session_id="rev-1")
+        fix_cli = CLIResult(output="fix done", total_premium_requests=1)
+
+        # run_copilot calls: implement, then review/fix alternating
+        copilot_calls: list[CLIResult | TaskError] = [MOCK_CLI_RESULT]  # implement
+        if review_side_effects:
+            copilot_calls.extend(review_side_effects)
+        else:
+            # Default: review succeeds, fix succeeds (enough for 2 rounds)
+            for _ in range(4):
+                copilot_calls.append(review_cli)
+                if fix_side_effects:
+                    copilot_calls.extend(fix_side_effects)
+                else:
+                    copilot_calls.append(fix_cli)
+
+        call_index = 0
+
+        async def mock_copilot(*args, **kwargs):
+            nonlocal call_index
+            idx = call_index
+            call_index += 1
+            if idx < len(copilot_calls):
+                val = copilot_calls[idx]
+                if isinstance(val, Exception):
+                    raise val
+                return val
+            return fix_cli
+
+        # find_pr_by_branch: first call returns open PR, subsequent may return merged
+        find_pr_calls = 0
+
+        async def mock_find_pr(*args, **kwargs):
+            nonlocal find_pr_calls
+            find_pr_calls += 1
+            if find_pr_calls == 1:
+                return self._OPEN_PR
+            return pr_after_merge or (self._MERGED_PR if merge_result else self._OPEN_PR)
+
+        async def mock_threads(*args, **kwargs):
+            try:
+                return next(threads_iter)
+            except StopIteration:
+                return []
+
+        async def run():
+            with (
+                patch(f"{_MOD}._utcnow", return_value=_TEST_START),
+                patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=MOCK_ISSUE),
+                patch(
+                    f"{_MOD}.create_branch_worktree",
+                    new_callable=AsyncMock,
+                    return_value=Path("/tmp/wt"),
+                ),
+                patch(f"{_MOD}.run_copilot", side_effect=mock_copilot),
+                patch(f"{_MOD}.find_pr_by_branch", side_effect=mock_find_pr),
+                patch(f"{_MOD}.get_unresolved_review_threads", side_effect=mock_threads),
+                patch(f"{_MOD}.merge_pr", new_callable=AsyncMock, return_value=merge_result),
+                patch(f"{_MOD}.mark_pr_ready", new_callable=AsyncMock),
+                patch(f"{_MOD}.close_issue", new_callable=AsyncMock),
+                patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
+                patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
+            ):
+                return await implement_issue(repo="user/repo", issue_number=42)
+
+        return asyncio.run(run())
+
+    def test_approved_on_first_review_then_merge(self):
+        """Review finds no issues → merge immediately."""
+        result = self._run_with_loop(
+            unresolved_threads_sequence=[[]],  # no threads after review
+        )
+        assert result.status == "complete"
+        assert result.merged is True
+
+    def test_fix_resolves_issues_then_merge(self):
+        """Review finds issues → fix resolves them → merge."""
+        result = self._run_with_loop(
+            unresolved_threads_sequence=[
+                [{"id": "t1"}],  # after review: 1 thread
+                [],  # after fix: resolved
+            ],
+        )
+        assert result.status == "complete"
+        assert result.merged is True
+
+    def test_max_rounds_exceeded_leaves_pr_open(self):
+        """Two rounds of review-fix, still unresolved → PR left open."""
+        result = self._run_with_loop(
+            unresolved_threads_sequence=[
+                [{"id": "t1"}],  # round 1 review
+                [{"id": "t1"}],  # round 1 fix — still there
+                [{"id": "t1"}],  # round 2 review
+                [{"id": "t1"}],  # round 2 fix — still there
+            ],
+            merge_result=False,
+            pr_after_merge=self._OPEN_PR,
+        )
+        assert result.status == "partial"
+        assert result.merged is False
+
+    def test_no_pr_skips_loop(self):
+        """Implement creates no PR → failed, no loop."""
+
+        async def run():
+            with (
+                patch(f"{_MOD}._utcnow", return_value=_TEST_START),
+                patch(f"{_MOD}.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(f"{_MOD}.get_issue", new_callable=AsyncMock, return_value=MOCK_ISSUE),
+                patch(
+                    f"{_MOD}.create_branch_worktree",
+                    new_callable=AsyncMock,
+                    return_value=Path("/tmp/wt"),
+                ),
+                patch(
+                    f"{_MOD}.run_copilot",
+                    new_callable=AsyncMock,
+                    return_value=MOCK_CLI_RESULT,
+                ),
+                patch(
+                    f"{_MOD}.find_pr_by_branch",
+                    new_callable=AsyncMock,
+                    return_value=None,
+                ),
+                patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
+                patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),
+            ):
+                return await implement_issue(repo="user/repo", issue_number=42)
+
+        result = asyncio.run(run())
+        assert result.status == "failed"
+        assert result.pr_number is None
+
+    def test_already_merged_skips_loop(self):
+        """CLI merged during implement → skip review loop."""
+        result = self._run_with_loop(
+            unresolved_threads_sequence=[],  # should never be called
+            pr_after_merge=self._MERGED_PR,
+        )
+        assert result.status == "complete"
+        assert result.merged is True
+
+    def test_review_failure_breaks_loop(self):
+        """Review CLI throws TaskError → break loop, leave PR open."""
+        result = self._run_with_loop(
+            review_side_effects=[TaskError("review crashed", premium_requests=2)],
+            merge_result=False,
+            pr_after_merge=self._OPEN_PR,
+        )
+        assert result.status == "partial"
+        assert result.merged is False
+        assert result.premium_requests >= 2
+
+    def test_fix_failure_breaks_loop(self):
+        """Fix CLI throws TaskError → break loop, leave PR open."""
+        review_cli = CLIResult(output="review", total_premium_requests=1, session_id="r1")
+        result = self._run_with_loop(
+            unresolved_threads_sequence=[[{"id": "t1"}]],  # review finds issues
+            review_side_effects=[review_cli, TaskError("fix crashed", premium_requests=3)],
+            merge_result=False,
+            pr_after_merge=self._OPEN_PR,
+        )
+        assert result.status == "partial"
+        assert result.merged is False
+
+    def test_merge_failure_returns_partial(self):
+        """REST merge fails, CLI fallback also fails → partial."""
+        merge_fallback_fail = TaskError("merge failed", premium_requests=1)
+        result = self._run_with_loop(
+            unresolved_threads_sequence=[[]],  # approved
+            merge_result=False,
+            review_side_effects=[
+                CLIResult(output="review", total_premium_requests=1, session_id="r1"),
+                merge_fallback_fail,  # CLI merge fallback
+            ],
+            pr_after_merge=self._OPEN_PR,
+        )
+        assert result.status == "partial"
+
+    def test_premium_requests_accumulate_across_loop(self):
+        """Premium requests from all CLI calls are summed."""
+        result = self._run_with_loop(
+            unresolved_threads_sequence=[
+                [{"id": "t1"}],  # after review
+                [],  # after fix
+            ],
+        )
+        # MOCK_CLI_RESULT (implement) = 5, review = 1, fix = 1
+        assert result.premium_requests >= 7

--- a/stacks/agents/app/tests/test_main.py
+++ b/stacks/agents/app/tests/test_main.py
@@ -349,14 +349,11 @@ def test_monitor_records_metrics_on_success(mock_wait, mock_logs, mock_rm):
     mock_rm.assert_awaited_once_with("abc123")
 
 
-@patch("main.comment_on_issue", new_callable=AsyncMock)
 @patch("main.remove_container", new_callable=AsyncMock)
 @patch("main.get_logs", new_callable=AsyncMock)
 @patch("main.wait_container", new_callable=AsyncMock)
-def test_monitor_posts_review_comment_after_successful_implement(
-    mock_wait, mock_logs, mock_rm, mock_comment
-):
-    """Successful implement runs should trigger a fresh review via PR comment."""
+def test_monitor_does_not_trigger_review_after_implement(mock_wait, mock_logs, mock_rm):
+    """Review is now handled inside the implement worker, not triggered by the monitor."""
     mock_wait.return_value = 0
     mock_logs.return_value = (
         '{"status": "complete", "repo": "user/repo", "pr_number": 99, "premium_requests": 2}\n'
@@ -364,26 +361,9 @@ def test_monitor_posts_review_comment_after_successful_implement(
 
     asyncio.run(_monitor_worker("abc123", task_type="implement", number=10, start=0.0))
 
-    mock_comment.assert_awaited_once_with("user/repo", 99, "/review")
     assert (
         _metric_value("agent_task_total", {"task_type": "implement", "status": "complete"}) == 1.0
     )
-
-
-@patch("main.comment_on_issue", new_callable=AsyncMock)
-@patch("main.remove_container", new_callable=AsyncMock)
-@patch("main.get_logs", new_callable=AsyncMock)
-@patch("main.wait_container", new_callable=AsyncMock)
-def test_monitor_skips_review_comment_when_implement_result_has_no_repo(
-    mock_wait, mock_logs, mock_rm, mock_comment
-):
-    """The monitor should not crash or comment if the implement result lacks a repo."""
-    mock_wait.return_value = 0
-    mock_logs.return_value = '{"status": "complete", "pr_number": 99}\n'
-
-    asyncio.run(_monitor_worker("abc123", task_type="implement", number=10, start=0.0))
-
-    mock_comment.assert_not_awaited()
 
 
 @patch("main.remove_container", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary

Replace the fire-and-forget implement flow with a full review-fix loop:
**implement → review → fix → merge**. Each step is a separate CLI call sharing the same worktree.

## What changed

### New: Review-fix loop in orchestrator
- After CLI creates a draft PR, the orchestrator runs up to 2 rounds of review → fix
- Two session chains: implement→fix (`--resume`) and review→review (`--resume`)
- Fix step resumes from implement session (knows why code was written)
- Review round 2+ resumes from review session (knows what was flagged)

### New: GitHub service helpers
- `get_unresolved_review_threads()` — GraphQL query for active review threads
- `merge_pr()` — REST API squash merge
- `mark_pr_ready()` — undraft a PR via REST API
- `ReviewThread` Pydantic model for typed thread data

### Merge strategy
1. REST API squash merge (fast, zero tokens)
2. CLI fallback: rebase + resolve conflicts + merge (if REST fails)
3. If both fail: leave PR open with comment

### Removed
- `_trigger_independent_review()` from main.py — review now happens inside the loop
- CLI merge/ready steps from SKILL.md — orchestrator owns the merge

## Testing
- 211 tests passing (103 new/updated)
- Full coverage: clean review, fix+merge, max rounds, no PR, already merged, review/fix/merge failures, premium accumulation

Closes #125