### PR TITLE
security: lock agent PRs to prevent comment injection

### DIFF
--- a/stacks/agents/app/implement/orchestrator.py
+++ b/stacks/agents/app/implement/orchestrator.py
@@ -14,6 +14,7 @@ from services.github import (
     get_issue,
     get_token,
     get_unresolved_review_threads,
+    lock_pr,
     mark_pr_ready,
     merge_pr,
     safe_comment,
@@ -419,6 +420,12 @@ async def implement_issue(
             elapsed = _monotonic() - start
             result = _build_result(None, elapsed, total_premium_requests, cli_result, repo)
             return result
+
+        # Lock the PR to prevent external comment injection
+        try:
+            await lock_pr(repo, pr_data.number)
+        except Exception:
+            logger.warning("Failed to lock PR #%d", pr_data.number, exc_info=True)
 
         # CLI already merged the PR → skip review loop
         if pr_data.merged_at is not None or pr_data.merged:

--- a/stacks/agents/app/implement/orchestrator.py
+++ b/stacks/agents/app/implement/orchestrator.py
@@ -84,9 +84,9 @@ MERGE_PROMPT_TEMPLATE = """\
 PR #{pr_number} in {repo} has been approved but could not be merged automatically \
 (likely due to merge conflicts or the branch being out of date).
 
-1. Rebase onto main: `git fetch origin main && git rebase origin/main`
+1. Update branch: `git fetch origin main && git merge origin/main`
 2. Resolve any conflicts
-3. Push: `git push --force origin {branch}`
+3. Push: `git push origin {branch}`
 4. Wait for CI: `gh pr checks {pr_number} --watch`
 5. Merge: `gh pr merge {pr_number} --squash`
 """

--- a/stacks/agents/app/services/github.py
+++ b/stacks/agents/app/services/github.py
@@ -293,6 +293,21 @@ async def merge_pr(repo: str, pr_number: int) -> bool:
     return False
 
 
+async def lock_pr(repo: str, pr_number: int) -> None:
+    """Lock a PR conversation to prevent non-collaborator comments.
+
+    Mitigates prompt injection via external comments on agent PRs.
+    The bot retains full comment access via the App installation token.
+    """
+    async with _client() as client:
+        resp = await client.put(
+            f"{_API}/repos/{repo}/issues/{pr_number}/lock",
+            json={"lock_reason": "resolved"},
+        )
+    if resp.status_code not in (204, 200):
+        logger.warning("Failed to lock PR #%d on %s: HTTP %d", pr_number, repo, resp.status_code)
+
+
 async def mark_pr_ready(repo: str, pr_number: int) -> None:
     """Mark a draft PR as ready for review."""
     async with _client() as client:

--- a/stacks/agents/app/tests/test_github.py
+++ b/stacks/agents/app/tests/test_github.py
@@ -456,3 +456,50 @@ class TestMarkPrReady:
 
         with pytest.raises(RuntimeError, match="Failed to mark PR"):
             asyncio.run(run())
+
+
+class TestLockPr:
+    def test_locks_pr_conversation(self):
+        lock_resp = httpx.Response(
+            204,
+            request=httpx.Request("PUT", "https://api.github.com/issues/42/lock"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.put",
+                    new_callable=AsyncMock,
+                    return_value=lock_resp,
+                ) as mock_put,
+            ):
+                await github.lock_pr("user/repo", 42)
+                return mock_put
+
+        mock_put = asyncio.run(run())
+        call_args = mock_put.await_args
+        assert "/issues/42/lock" in call_args.args[0]
+        assert call_args.kwargs["json"] == {"lock_reason": "resolved"}
+
+    def test_warns_on_failure(self):
+        """Lock failure logs warning but does not raise."""
+        fail_resp = httpx.Response(
+            403,
+            json={"message": "Forbidden"},
+            request=httpx.Request("PUT", "https://api.github.com/issues/42/lock"),
+        )
+
+        async def run():
+            with (
+                patch("services.github.get_token", new_callable=AsyncMock, return_value="token"),
+                patch(
+                    "httpx.AsyncClient.put",
+                    new_callable=AsyncMock,
+                    return_value=fail_resp,
+                ),
+            ):
+                # Should not raise — just warn
+                await github.lock_pr("user/repo", 42)
+
+        asyncio.run(run())  # No exception = pass

--- a/stacks/agents/app/tests/test_implement.py
+++ b/stacks/agents/app/tests/test_implement.py
@@ -158,6 +158,7 @@ class TestImplementIssue:
             patch(f"{_MOD}.get_unresolved_review_threads", new_callable=AsyncMock, return_value=[]),
             patch(f"{_MOD}.merge_pr", new_callable=AsyncMock, return_value=True),
             patch(f"{_MOD}.mark_pr_ready", new_callable=AsyncMock),
+            patch(f"{_MOD}.lock_pr", new_callable=AsyncMock),
             patch(f"{_MOD}.close_issue", new_callable=AsyncMock),
             patch(f"{_MOD}.safe_comment", new_callable=AsyncMock),
             patch(f"{_MOD}.cleanup_branch_worktree", new_callable=AsyncMock),


### PR DESCRIPTION
## Summary

Locks agent PR conversations immediately after creation to prevent external users from injecting content via PR comments.

## Problem

The CLI has `GH_TOKEN` + `gh` CLI and can autonomously decide to read PR comments for context. Even though our prompts don't direct it to read comments (fixed in #128), the CLI could browse them on its own. A malicious commenter on an agent's PR could influence CLI behavior.

## Solution

`lock_pr()` calls `PUT /repos/{owner}/{repo}/issues/{number}/lock` right after the PR is discovered. GitHub's lock:
- **Blocks** non-collaborator comments
- **Preserves** bot access (App installation token has write permissions)
- Uses `resolved` lock reason (least alarming to visitors)

The lock is best-effort — failure logs a warning but doesn't block the lifecycle.

## Testing

- `TestLockPr`: success (204) and failure (403, no raise) paths
- `_base_mocks` and `_run_with_loop` updated with `lock_pr` mock
- 213 tests passing