### PR TITLE
chore: add Docker Compose CLI plugin to agent container

### DIFF
--- a/stacks/agents/app/Dockerfile
+++ b/stacks/agents/app/Dockerfile
@@ -11,6 +11,8 @@ ARG COPILOT_CLI_VERSION=v1.0.26
 ARG GH_VERSION=2.89.0
 # renovate: datasource=github-releases depName=moby/moby
 ARG DOCKER_VERSION=28.2.2
+# renovate: datasource=github-releases depName=docker/compose
+ARG DOCKER_COMPOSE_VERSION=5.1.3
 
 # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
 COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
@@ -31,6 +33,12 @@ RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_$
 # Install Docker CLI for spawning ephemeral worker containers (ADR-011)
 RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
     | tar -xz --strip-components=1 -C /usr/local/bin docker/docker
+
+# Install Docker Compose CLI plugin so workers can run `docker compose config`
+RUN mkdir -p /usr/local/lib/docker/cli-plugins && \
+    curl -fsSL "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64" \
+    -o /usr/local/lib/docker/cli-plugins/docker-compose && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
 # Install mise and provision all dev tools (shellcheck, actionlint, trivy)
 # so the Copilot CLI has the same toolchain as local dev.


### PR DESCRIPTION
Workers need `docker compose config` for `mise run ci` compose validation. Without it, the Copilot CLI wastes ~20 minutes trying to install it and often hits the 30-minute timeout.

Pinned and Renovate-tracked via the same ARG pattern as other tools.