### PR TITLE
feat(observability): add JSON parsing pipeline to Alloy log processor

### DIFF
--- a/stacks/observability/config.alloy
+++ b/stacks/observability/config.alloy
@@ -94,6 +94,34 @@ loki.source.docker "containers" {
 loki.process "docker" {
   forward_to = [loki.write.default.receiver]
 
+  // Parse JSON log lines (silently passes through non-JSON lines)
+  stage.json {
+    expressions = {
+      level        = "level",
+      logger       = "logger",
+      task_type    = "task_type",
+      issue_number = "issue_number",
+      pr_number    = "pr_number",
+    }
+  }
+
+  // Low-cardinality fields as Loki labels (fast stream filtering)
+  stage.labels {
+    values = {
+      level     = "level",
+      task_type = "task_type",
+    }
+  }
+
+  // High-cardinality fields as structured metadata (searchable, no stream explosion)
+  stage.structured_metadata {
+    values = {
+      logger       = "logger",
+      issue_number = "issue_number",
+      pr_number    = "pr_number",
+    }
+  }
+
   // Drop noisy observability stack logs to avoid feedback loops
   stage.drop {
     source     = "container_name"


### PR DESCRIPTION
Adds JSON log parsing to the Alloy `loki.process` pipeline (`config.alloy`).

**What changed:**
- `stage.json` extracts `level`, `logger`, `task_type`, `issue_number`, `pr_number` from JSON log lines
- `stage.labels` promotes low-cardinality fields (`level`, `task_type`) to Loki stream labels for fast filtering
- `stage.structured_metadata` stores high-cardinality fields (`issue_number`, `pr_number`, `logger`) as searchable metadata without stream explosion
- Non-JSON logs from other containers pass through unchanged
- Existing `stage.drop` filter for alloy/loki feedback loops preserved

Part of #115 (agent observability). Companion change: #137 adds the Python logging context fields that this pipeline will extract.

Closes #115