### PR TITLE
feat(agent): add token parsing, structured events, and dashboard overhaul

### DIFF
--- a/stacks/agents/app/implement/orchestrator.py
+++ b/stacks/agents/app/implement/orchestrator.py
@@ -110,6 +110,35 @@ class _LoopContext:
     implement_session_id: str | None
 
 
+@dataclass
+class _TokenAccumulator:
+    """Accumulates stats across multiple CLI calls."""
+
+    premium_requests: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+    reasoning_tokens: int = 0
+    cli_calls: int = 0
+    review_fix_rounds: int = 0
+
+    def add_result(self, result: CLIResult) -> None:
+        self.premium_requests += result.total_premium_requests
+        self.input_tokens += result.input_tokens
+        self.output_tokens += result.output_tokens
+        self.cached_tokens += result.cached_tokens
+        self.reasoning_tokens += result.reasoning_tokens
+        self.cli_calls += 1
+
+    def add_error(self, exc: TaskError) -> None:
+        self.premium_requests += exc.premium_requests
+        self.input_tokens += exc.input_tokens
+        self.output_tokens += exc.output_tokens
+        self.cached_tokens += exc.cached_tokens
+        self.reasoning_tokens += exc.reasoning_tokens
+        self.cli_calls += 1
+
+
 # ── Helpers ──────────────────────────────────────────────
 
 
@@ -140,23 +169,32 @@ def _is_merged(pr_data: GitHubPullRequest) -> bool:
 def _build_result(
     pr_data: GitHubPullRequest | None,
     elapsed: float,
-    premium_requests: int,
-    cli_result: CLIResult,
+    acc: _TokenAccumulator,
+    cli_result: CLIResult | None,
     repo: str,
+    model: str,
+    reasoning_effort: str,
 ) -> TaskResult:
     """Build a TaskResult from PR state after CLI completes."""
-    # Determine status-specific fields
     if not pr_data:
         return TaskResult(
             status="failed",
             error="CLI did not create a PR",
             repo=repo,
+            model=model,
+            reasoning_effort=reasoning_effort,
             elapsed_seconds=elapsed,
-            premium_requests=premium_requests,
-            api_time_seconds=cli_result.api_time_seconds,
-            models=cli_result.models,
-            tokens_line=cli_result.tokens_line,
-            session_id=cli_result.session_id,
+            premium_requests=acc.premium_requests,
+            input_tokens=acc.input_tokens,
+            output_tokens=acc.output_tokens,
+            cached_tokens=acc.cached_tokens,
+            reasoning_tokens=acc.reasoning_tokens,
+            cli_calls=acc.cli_calls,
+            review_fix_rounds=acc.review_fix_rounds,
+            api_time_seconds=cli_result.api_time_seconds if cli_result else None,
+            models=cli_result.models if cli_result else None,
+            tokens_line=cli_result.tokens_line if cli_result else None,
+            session_id=cli_result.session_id if cli_result else None,
         )
 
     status = "complete" if (_is_merged(pr_data) or pr_data.auto_merge is not None) else "partial"
@@ -170,12 +208,20 @@ def _build_result(
         pr_number=pr_data.number,
         pr_url=pr_data.html_url,
         repo=repo,
+        model=model,
+        reasoning_effort=reasoning_effort,
         elapsed_seconds=elapsed,
-        premium_requests=premium_requests,
-        api_time_seconds=cli_result.api_time_seconds,
-        models=cli_result.models,
-        tokens_line=cli_result.tokens_line,
-        session_id=cli_result.session_id,
+        premium_requests=acc.premium_requests,
+        input_tokens=acc.input_tokens,
+        output_tokens=acc.output_tokens,
+        cached_tokens=acc.cached_tokens,
+        reasoning_tokens=acc.reasoning_tokens,
+        cli_calls=acc.cli_calls,
+        review_fix_rounds=acc.review_fix_rounds,
+        api_time_seconds=cli_result.api_time_seconds if cli_result else None,
+        models=cli_result.models if cli_result else None,
+        tokens_line=cli_result.tokens_line if cli_result else None,
+        session_id=cli_result.session_id if cli_result else None,
     )
 
 
@@ -187,12 +233,13 @@ async def _run_review_fix_loop(
     pr_number: int,
     issue_data: GitHubIssue,
     issue_number: int,
-) -> tuple[bool, int]:
-    """Run the review → fix loop. Returns (approved, premium_requests_used)."""
-    total_premium = 0
+    acc: _TokenAccumulator,
+) -> bool:
+    """Run the review → fix loop. Returns whether the PR was approved."""
     review_session_id: str | None = None
 
     for round_num in range(1, MAX_REVIEW_FIX_ROUNDS + 1):
+        acc.review_fix_rounds = round_num
         # ── Review step ──
         logger.info("Review round %d for %s#%d", round_num, ctx.repo, pr_number)
         review_prompt = REVIEW_PROMPT_TEMPLATE.format(
@@ -206,15 +253,16 @@ async def _run_review_fix_loop(
             review_result = await run_copilot(
                 ctx.worktree_path,
                 review_prompt,
+                stage="review",
                 model=ctx.model,
                 effort=ctx.reasoning_effort,
                 session_id=review_session_id,
                 github_token=ctx.token,
             )
-            total_premium += review_result.total_premium_requests
+            acc.add_result(review_result)
             review_session_id = review_result.session_id
         except TaskError as exc:
-            total_premium += exc.premium_requests
+            acc.add_error(exc)
             logger.warning("Review round %d failed: %s", round_num, exc)
             await safe_comment(ctx.repo, pr_number, f"⚠️ Review round {round_num} failed — {exc}")
             break
@@ -227,7 +275,7 @@ async def _run_review_fix_loop(
             break
         if not unresolved:
             logger.info("Review round %d: approved (no unresolved threads)", round_num)
-            return True, total_premium
+            return True
 
         logger.info(
             "Review round %d: %d unresolved thread(s), starting fix",
@@ -244,14 +292,15 @@ async def _run_review_fix_loop(
             fix_result = await run_copilot(
                 ctx.worktree_path,
                 fix_prompt,
+                stage="fix",
                 model=ctx.model,
                 effort=ctx.reasoning_effort,
                 session_id=ctx.implement_session_id,
                 github_token=ctx.token,
             )
-            total_premium += fix_result.total_premium_requests
+            acc.add_result(fix_result)
         except TaskError as exc:
-            total_premium += exc.premium_requests
+            acc.add_error(exc)
             logger.warning("Fix round %d failed: %s", round_num, exc)
             await safe_comment(ctx.repo, pr_number, f"⚠️ Fix round {round_num} failed — {exc}")
             break
@@ -262,7 +311,7 @@ async def _run_review_fix_loop(
             break
         if not unresolved:
             logger.info("Fix round %d resolved all threads", round_num)
-            return True, total_premium
+            return True
 
         logger.info(
             "Fix round %d: %d thread(s) still unresolved",
@@ -270,19 +319,21 @@ async def _run_review_fix_loop(
             len(unresolved),
         )
 
-    return False, total_premium
+    return False
 
 
 # ── Merge ────────────────────────────────────────────────
 
 
-async def _try_merge(ctx: _LoopContext, pr_number: int, branch_name: str) -> tuple[bool, int]:
-    """Attempt to merge a PR. Returns (merged, premium_requests_used)."""
+async def _try_merge(
+    ctx: _LoopContext, pr_number: int, branch_name: str, acc: _TokenAccumulator
+) -> bool:
+    """Attempt to merge a PR. Returns whether the merge succeeded."""
     await mark_pr_ready(ctx.repo, pr_number)
 
     if await merge_pr(ctx.repo, pr_number):
         logger.info("PR #%d merged via REST API", pr_number)
-        return True, 0
+        return True
 
     # Fallback: CLI merge
     logger.info("REST merge failed for #%d, trying CLI fallback", pr_number)
@@ -293,21 +344,23 @@ async def _try_merge(ctx: _LoopContext, pr_number: int, branch_name: str) -> tup
         merge_result = await run_copilot(
             ctx.worktree_path,
             merge_prompt,
+            stage="merge",
             model=ctx.model,
             effort=ctx.reasoning_effort,
             session_id=ctx.implement_session_id,
             github_token=ctx.token,
         )
-        premium = merge_result.total_premium_requests
+        acc.add_result(merge_result)
         pr_data = await find_pr_by_branch(ctx.repo, branch_name)
         if pr_data and _is_merged(pr_data):
             logger.info("PR #%d merged via CLI fallback", pr_number)
-            return True, premium
+            return True
         logger.warning("CLI fallback did not merge PR #%d", pr_number)
-        return False, premium
+        return False
     except TaskError as exc:
+        acc.add_error(exc)
         logger.warning("CLI merge fallback failed: %s", exc)
-        return False, exc.premium_requests
+        return False
 
 
 # ── Main entry point ─────────────────────────────────────
@@ -341,7 +394,7 @@ async def implement_issue(
             "refusing to inject untrusted content into CLI prompt"
         )
 
-    total_premium_requests = 0
+    acc = _TokenAccumulator()
     cli_result: CLIResult | None = None
     result: TaskResult | None = None
 
@@ -356,9 +409,14 @@ async def implement_issue(
             body=issue_data.body or "(no description)",
         )
         cli_result = await run_copilot(
-            worktree_path, prompt, model=model, effort=reasoning_effort, github_token=token
+            worktree_path,
+            prompt,
+            stage="implement",
+            model=model,
+            effort=reasoning_effort,
+            github_token=token,
         )
-        total_premium_requests += cli_result.total_premium_requests
+        acc.add_result(cli_result)
 
         pr_data = await find_pr_by_branch(repo, branch_name)
         if pr_data and _is_stale_pr(pr_data, start_wall):
@@ -373,7 +431,7 @@ async def implement_issue(
 
         if not pr_data:
             elapsed = _monotonic() - start
-            result = _build_result(None, elapsed, total_premium_requests, cli_result, repo)
+            result = _build_result(None, elapsed, acc, cli_result, repo, model, reasoning_effort)
             return result
 
         await lock_pr(repo, pr_data.number)
@@ -388,14 +446,12 @@ async def implement_issue(
                 token=token,
                 implement_session_id=cli_result.session_id,
             )
-            approved, loop_premium = await _run_review_fix_loop(
-                ctx, pr_data.number, issue_data, issue_number
+            approved = await _run_review_fix_loop(
+                ctx, pr_data.number, issue_data, issue_number, acc
             )
-            total_premium_requests += loop_premium
 
             if approved:
-                _merged, merge_premium = await _try_merge(ctx, pr_data.number, branch_name)
-                total_premium_requests += merge_premium
+                await _try_merge(ctx, pr_data.number, branch_name, acc)
                 pr_data = await find_pr_by_branch(repo, branch_name)
             else:
                 await safe_comment(
@@ -406,7 +462,7 @@ async def implement_issue(
                 )
 
         elapsed = _monotonic() - start
-        result = _build_result(pr_data, elapsed, total_premium_requests, cli_result, repo)
+        result = _build_result(pr_data, elapsed, acc, cli_result, repo, model, reasoning_effort)
 
         if result.merged:
             await close_issue(repo, issue_number)
@@ -416,7 +472,14 @@ async def implement_issue(
     except TaskError:
         raise
     except Exception as exc:
-        raise TaskError(str(exc), premium_requests=total_premium_requests) from exc
+        raise TaskError(
+            str(exc),
+            premium_requests=acc.premium_requests,
+            input_tokens=acc.input_tokens,
+            output_tokens=acc.output_tokens,
+            cached_tokens=acc.cached_tokens,
+            reasoning_tokens=acc.reasoning_tokens,
+        ) from exc
 
     finally:
         await cleanup_branch_worktree(branch_name)

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -18,6 +18,7 @@ from metrics import (
     TASK_DURATION_SECONDS,
     TASK_IN_PROGRESS,
     TASK_TOTAL,
+    TOKENS_TOTAL,
 )
 from models import TaskResult
 from services.docker import (
@@ -104,12 +105,29 @@ def _worker_log_format() -> str:
 
 
 def _record_task_metrics(
-    *, task_type: str, status: str, duration_seconds: float, premium_requests: int
+    *,
+    task_type: str,
+    status: str,
+    duration_seconds: float,
+    premium_requests: int,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cached_tokens: int = 0,
+    reasoning_tokens: int = 0,
 ) -> None:
     TASK_DURATION_SECONDS.labels(task_type=task_type, status=status).observe(duration_seconds)
     TASK_TOTAL.labels(task_type=task_type, status=status).inc()
     if premium_requests:
         PREMIUM_REQUESTS_TOTAL.labels(task_type=task_type).inc(premium_requests)
+    token_map = {
+        "input": input_tokens,
+        "output": output_tokens,
+        "cached": cached_tokens,
+        "reasoning": reasoning_tokens,
+    }
+    for direction, count in token_map.items():
+        if count:
+            TOKENS_TOTAL.labels(task_type=task_type, direction=direction).inc(count)
 
 
 class ReviewRequest(BaseModel):
@@ -170,6 +188,10 @@ async def _monitor_worker(container_id: str, *, task_type: str, number: int, sta
             status=status,
             duration_seconds=duration,
             premium_requests=premium,
+            input_tokens=result.input_tokens if result else 0,
+            output_tokens=result.output_tokens if result else 0,
+            cached_tokens=result.cached_tokens if result else 0,
+            reasoning_tokens=result.reasoning_tokens if result else 0,
         )
         error = result.error if result and result.error else ""
         logger.info(

--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -56,6 +56,10 @@ async def lifespan(_app: FastAPI):
             status=status,
             duration_seconds=float(w.get("duration_seconds", 0)),
             premium_requests=premium,
+            input_tokens=result.input_tokens if result else 0,
+            output_tokens=result.output_tokens if result else 0,
+            cached_tokens=result.cached_tokens if result else 0,
+            reasoning_tokens=result.reasoning_tokens if result else 0,
         )
         logger.info(
             "Harvested metrics from orphaned worker %s #%s (status=%s, premium=%d)",

--- a/stacks/agents/app/metrics.py
+++ b/stacks/agents/app/metrics.py
@@ -25,6 +25,13 @@ PREMIUM_REQUESTS_TOTAL = Counter(
     labelnames=("task_type",),
     registry=METRICS_REGISTRY,
 )
+TOKENS_TOTAL = Counter(
+    "agent_tokens_total",
+    "Total tokens consumed by agent tasks.",
+    labelnames=("task_type", "direction"),
+    registry=METRICS_REGISTRY,
+)
+TOKEN_DIRECTIONS = ("input", "output", "cached", "reasoning")
 TASK_IN_PROGRESS = Gauge(
     "agent_task_in_progress",
     "Current number of in-flight agent tasks.",
@@ -37,6 +44,8 @@ def _initialize_metrics() -> None:
     for task_type in TASK_TYPES:
         TASK_IN_PROGRESS.labels(task_type=task_type).set(0)
         PREMIUM_REQUESTS_TOTAL.labels(task_type=task_type)
+        for direction in TOKEN_DIRECTIONS:
+            TOKENS_TOTAL.labels(task_type=task_type, direction=direction)
         for status in TASK_STATUSES:
             TASK_DURATION_SECONDS.labels(task_type=task_type, status=status)
             TASK_TOTAL.labels(task_type=task_type, status=status)
@@ -48,6 +57,7 @@ def reset_metrics() -> None:
         TASK_DURATION_SECONDS,
         TASK_TOTAL,
         PREMIUM_REQUESTS_TOTAL,
+        TOKENS_TOTAL,
         TASK_IN_PROGRESS,
     ):
         with collector._lock:

--- a/stacks/agents/app/models.py
+++ b/stacks/agents/app/models.py
@@ -77,6 +77,12 @@ class TaskResult(BaseModel):
     api_time_seconds: float | None = None
     reasoning_effort: str | None = None
     premium_requests: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+    reasoning_tokens: int = 0
+    cli_calls: int = 0
+    review_fix_rounds: int = 0
     models: dict[str, str] | None = None
     tokens_line: str | None = None
     session_id: str | None = None

--- a/stacks/agents/app/review/orchestrator.py
+++ b/stacks/agents/app/review/orchestrator.py
@@ -129,6 +129,7 @@ async def review_pr(
         result = await run_copilot(
             worktree_path,
             prompt,
+            stage="review",
             model=model,
             effort=reasoning_effort,
             session_id=session_id,
@@ -140,11 +141,17 @@ async def review_pr(
 
         return TaskResult(
             status="complete",
+            repo=repo,
             model=model,
             elapsed_seconds=elapsed,
             api_time_seconds=result.api_time_seconds,
             reasoning_effort=reasoning_effort,
             premium_requests=result.total_premium_requests,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            cached_tokens=result.cached_tokens,
+            reasoning_tokens=result.reasoning_tokens,
+            cli_calls=1,
             models=result.models,
             tokens_line=result.tokens_line,
             session_id=result.session_id,

--- a/stacks/agents/app/services/copilot.py
+++ b/stacks/agents/app/services/copilot.py
@@ -56,11 +56,25 @@ def _redact_secrets(text: str, extra_secrets: frozenset[str] = frozenset()) -> s
 
 
 class TaskError(Exception):
-    """Wraps a post-CLI failure, preserving the premium request count for metrics."""
+    """Wraps a post-CLI failure, preserving stats for metrics accumulation."""
 
-    def __init__(self, message: str, *, premium_requests: int = 0, commented: bool = False) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        premium_requests: int = 0,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cached_tokens: int = 0,
+        reasoning_tokens: int = 0,
+        commented: bool = False,
+    ) -> None:
         super().__init__(message)
         self.premium_requests = premium_requests
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.cached_tokens = cached_tokens
+        self.reasoning_tokens = reasoning_tokens
         # True when an error comment was already posted on the PR/issue,
         # so callers can avoid double-posting.
         self.commented = commented
@@ -76,6 +90,10 @@ class CLIResult:
     session_time_seconds: int = 0
     models: dict[str, str] = field(default_factory=dict)
     tokens_line: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+    reasoning_tokens: int = 0
     session_transcript: str | None = None
     session_id: str | None = None
 
@@ -104,6 +122,39 @@ def _parse_time(value: str) -> int:
     if m := re.search(r"(\d+)s", value):
         total += int(m.group(1))
     return total
+
+
+def _parse_token_value(value: str) -> int:
+    """Parse a token count like '5.5m', '34.0k', or '19900' into an integer."""
+    value = value.strip()
+    if value.endswith("m"):
+        return int(float(value[:-1]) * 1_000_000)
+    if value.endswith("k"):
+        return int(float(value[:-1]) * 1_000)
+    return int(float(value))
+
+
+def _parse_tokens(tokens_line: str) -> dict[str, int]:
+    """Parse token stats from CLI output.
+
+    Format: ↑ 5.5m • ↓ 34.0k • 5.3m (cached) • 19.9k (reasoning)
+    """
+    result = {"input": 0, "output": 0, "cached": 0, "reasoning": 0}
+    if not tokens_line:
+        return result
+
+    for part in tokens_line.split("•"):
+        part = part.strip()
+        if part.startswith("↑"):
+            result["input"] = _parse_token_value(part[1:])
+        elif part.startswith("↓"):
+            result["output"] = _parse_token_value(part[1:])
+        elif "(cached)" in part:
+            result["cached"] = _parse_token_value(part.replace("(cached)", ""))
+        elif "(reasoning)" in part:
+            result["reasoning"] = _parse_token_value(part.replace("(reasoning)", ""))
+
+    return result
 
 
 def _parse_stats(output: str) -> dict:
@@ -168,10 +219,44 @@ def _log_expected_process_cleanup(action: str, pid: int | None) -> None:
     )
 
 
+def _emit_cli_completed(
+    *,
+    stage: str,
+    model: str,
+    effort: str,
+    stats: dict,
+    tokens: dict[str, int],
+    session_id: str | None,
+    exit_code: int | None,
+    success: bool,
+) -> None:
+    """Emit a structured cli_completed event for Loki ingestion."""
+    logger.info(
+        "cli_completed",
+        extra={
+            "event": "cli_completed",
+            "stage": stage,
+            "model": model,
+            "effort": effort,
+            "premium_requests": stats.get("premium_requests", 0),
+            "input_tokens": tokens["input"],
+            "output_tokens": tokens["output"],
+            "cached_tokens": tokens["cached"],
+            "reasoning_tokens": tokens["reasoning"],
+            "session_time_seconds": stats.get("session_time", 0),
+            "api_time_seconds": stats.get("api_time", 0),
+            "session_id": session_id or "",
+            "exit_code": exit_code,
+            "success": success,
+        },
+    )
+
+
 async def run_copilot(
     worktree_path: Path,
     prompt: str,
     *,
+    stage: str = "default",
     model: str = "gpt-5.4",
     effort: str = "high",
     session_id: str | None = None,
@@ -290,18 +375,48 @@ async def run_copilot(
     except TimeoutError as err:
         await _stop_process()
         stats = _parse_stats("\n".join(stdout_lines + stderr_lines))
+        tokens = _parse_tokens(stats.get("tokens_line", ""))
+        _emit_cli_completed(
+            stage=stage,
+            model=model,
+            effort=effort,
+            stats=stats,
+            tokens=tokens,
+            session_id=None,
+            exit_code=None,
+            success=False,
+        )
         raise TaskError(
             f"Copilot CLI timed out after {TIMEOUT_SECONDS}s",
             premium_requests=stats["premium_requests"],
+            input_tokens=tokens["input"],
+            output_tokens=tokens["output"],
+            cached_tokens=tokens["cached"],
+            reasoning_tokens=tokens["reasoning"],
         ) from err
 
     if proc.returncode != 0:
         error = _redact_secrets("\n".join(stderr_lines) or "\n".join(stdout_lines), secrets)
         logger.error("Copilot CLI failed (exit %d): %s", proc.returncode, error)
         stats = _parse_stats("\n".join(stdout_lines + stderr_lines))
+        tokens = _parse_tokens(stats.get("tokens_line", ""))
+        _emit_cli_completed(
+            stage=stage,
+            model=model,
+            effort=effort,
+            stats=stats,
+            tokens=tokens,
+            session_id=None,
+            exit_code=proc.returncode,
+            success=False,
+        )
         raise TaskError(
             f"Copilot CLI exited with code {proc.returncode}: {error}",
             premium_requests=stats["premium_requests"],
+            input_tokens=tokens["input"],
+            output_tokens=tokens["output"],
+            cached_tokens=tokens["cached"],
+            reasoning_tokens=tokens["reasoning"],
         )
 
     output = "\n".join(stdout_lines)
@@ -317,9 +432,21 @@ async def run_copilot(
         logger.warning("No session transcript found at %s", transcript_path)
 
     stats = _parse_stats(all_output)
+    tokens = _parse_tokens(stats.get("tokens_line", ""))
     parsed_session_id = _parse_session_id(all_output)
     if not parsed_session_id and transcript:
         parsed_session_id = _parse_session_id(transcript)
+
+    _emit_cli_completed(
+        stage=stage,
+        model=model,
+        effort=effort,
+        stats=stats,
+        tokens=tokens,
+        session_id=parsed_session_id,
+        exit_code=proc.returncode,
+        success=True,
+    )
 
     return CLIResult(
         output=output,
@@ -328,6 +455,10 @@ async def run_copilot(
         session_time_seconds=stats["session_time"],
         models=stats["models"],
         tokens_line=stats.get("tokens_line", ""),
+        input_tokens=tokens["input"],
+        output_tokens=tokens["output"],
+        cached_tokens=tokens["cached"],
+        reasoning_tokens=tokens["reasoning"],
         session_transcript=transcript,
         session_id=parsed_session_id,
     )

--- a/stacks/agents/app/tests/test_copilot.py
+++ b/stacks/agents/app/tests/test_copilot.py
@@ -13,6 +13,8 @@ from services.copilot import (
     _parse_session_id,
     _parse_stats,
     _parse_time,
+    _parse_token_value,
+    _parse_tokens,
     run_copilot,
 )
 
@@ -116,6 +118,51 @@ def test_parse_new_format_short_time():
     stats = _parse_stats("Requests  3 Premium (6m 16s)\n")
     assert stats["premium_requests"] == 3
     assert stats["session_time"] == 6 * 60 + 16
+
+
+class TestParseTokens:
+    def test_full_new_format(self):
+        tokens = _parse_tokens("↑ 5.5m • ↓ 34.0k • 5.3m (cached) • 19.9k (reasoning)")
+        assert tokens == {
+            "input": 5_500_000,
+            "output": 34_000,
+            "cached": 5_300_000,
+            "reasoning": 19_900,
+        }
+
+    def test_input_output_only(self):
+        tokens = _parse_tokens("↑ 100k • ↓ 2.5k")
+        assert tokens["input"] == 100_000
+        assert tokens["output"] == 2_500
+        assert tokens["cached"] == 0
+        assert tokens["reasoning"] == 0
+
+    def test_empty_string(self):
+        tokens = _parse_tokens("")
+        assert tokens == {"input": 0, "output": 0, "cached": 0, "reasoning": 0}
+
+    def test_small_values_without_suffix(self):
+        tokens = _parse_tokens("↑ 500 • ↓ 100")
+        assert tokens["input"] == 500
+        assert tokens["output"] == 100
+
+    def test_millions(self):
+        assert _parse_token_value("2.2m") == 2_200_000
+
+    def test_thousands(self):
+        assert _parse_token_value("34.0k") == 34_000
+
+    def test_plain_number(self):
+        assert _parse_token_value("402") == 402
+
+    def test_new_format_stats_include_tokens(self):
+        """_parse_stats on new format captures tokens_line for downstream parsing."""
+        stats = _parse_stats(SAMPLE_OUTPUT_NEW_FORMAT)
+        tokens = _parse_tokens(stats.get("tokens_line", ""))
+        assert tokens["input"] == 5_500_000
+        assert tokens["output"] == 34_000
+        assert tokens["cached"] == 5_300_000
+        assert tokens["reasoning"] == 19_900
 
 
 def test_stats_line_strips_est_premium():

--- a/stacks/agents/app/worker.py
+++ b/stacks/agents/app/worker.py
@@ -289,6 +289,29 @@ async def main() -> int:
     # Write result as JSON to stdout for the API monitor to parse
     print(result.model_dump_json(exclude_unset=True), flush=True)
 
+    # Structured event for Loki — carries all dimensions for dashboard queries
+    logger.info(
+        "task_completed",
+        extra={
+            "event": "task_completed",
+            "status": result.status,
+            "repo": result.repo or settings.repo,
+            "duration_seconds": result.elapsed_seconds,
+            "premium_requests": result.premium_requests,
+            "input_tokens": result.input_tokens,
+            "output_tokens": result.output_tokens,
+            "cached_tokens": result.cached_tokens,
+            "reasoning_tokens": result.reasoning_tokens,
+            "model": result.model,
+            "reasoning_effort": result.reasoning_effort,
+            "merged": result.merged,
+            "pr_number": result.pr_number,
+            "review_fix_rounds": result.review_fix_rounds,
+            "cli_calls": result.cli_calls,
+            "error": result.error or "",
+        },
+    )
+
     status = result.status
     logger.info(
         "Worker finished: %s %s#%s → %s",

--- a/stacks/agents/app/worker.py
+++ b/stacks/agents/app/worker.py
@@ -180,6 +180,10 @@ async def _run_implement(repo: str, issue_number: int, model: str, effort: str) 
         result = TaskResult(
             status="failed",
             premium_requests=exc.premium_requests,
+            input_tokens=exc.input_tokens,
+            output_tokens=exc.output_tokens,
+            cached_tokens=exc.cached_tokens,
+            reasoning_tokens=exc.reasoning_tokens,
             error=str(exc),
         )
         await _publish_implement_result(
@@ -241,7 +245,14 @@ async def _run_review(
         await _update_progress_comment(repo, progress_comment_id, f"⚠️ Review failed — {exc}")
         if not exc.commented:
             await safe_comment(repo, pr_number, f"⚠️ **Review failed** — {exc}")
-        return TaskResult(status="failed", premium_requests=exc.premium_requests)
+        return TaskResult(
+            status="failed",
+            premium_requests=exc.premium_requests,
+            input_tokens=exc.input_tokens,
+            output_tokens=exc.output_tokens,
+            cached_tokens=exc.cached_tokens,
+            reasoning_tokens=exc.reasoning_tokens,
+        )
 
     except Exception as exc:
         logger.exception("Review failed for %s#%d", repo, pr_number)

--- a/stacks/observability/config.alloy
+++ b/stacks/observability/config.alloy
@@ -119,6 +119,8 @@ loki.process "docker" {
       logger       = "logger",
       issue_number = "issue_number",
       pr_number    = "pr_number",
+      event        = "event",
+      stage        = "stage",
     }
   }
 

--- a/stacks/observability/dashboards/agent-tasks.json
+++ b/stacks/observability/dashboards/agent-tasks.json
@@ -23,9 +23,77 @@
   "liveNow": false,
   "panels": [
     {
+      "type": "stat",
+      "title": "Active Workers",
       "datasource": {
         "type": "prometheus",
         "uid": ""
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(agent_task_in_progress)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          }
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Total Tasks",
+      "datasource": {
+        "type": "prometheus",
+        "uid": ""
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -38,7 +106,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "green",
                 "value": null
               }
             ]
@@ -47,18 +115,7 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
       "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -66,22 +123,37 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "orientation": "auto"
       },
       "targets": [
         {
-          "expr": "sum(agent_task_total{job=\"agent\"})",
-          "legendFormat": "",
-          "refId": "A"
+          "expr": "sum(agent_task_total)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          }
         }
-      ],
-      "title": "Total Tasks",
-      "type": "stat"
+      ]
     },
     {
+      "type": "stat",
+      "title": "Success Rate",
       "datasource": {
         "type": "prometheus",
         "uid": ""
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -99,22 +171,11 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
-      "id": 2,
       "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -122,22 +183,37 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "orientation": "auto"
       },
       "targets": [
         {
-          "expr": "sum(agent_task_total{job=\"agent\", status=\"complete\"})",
-          "legendFormat": "",
-          "refId": "A"
+          "expr": "sum(agent_task_total{status=\"complete\"}) / sum(agent_task_total) * 100",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          }
         }
-      ],
-      "title": "Completed",
-      "type": "stat"
+      ]
     },
     {
+      "type": "stat",
+      "title": "Failed",
       "datasource": {
         "type": "prometheus",
         "uid": ""
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -150,7 +226,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
+                "color": "green",
                 "value": null
               }
             ]
@@ -159,18 +235,7 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 0
-      },
-      "id": 3,
       "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -178,22 +243,37 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "orientation": "auto"
       },
       "targets": [
         {
-          "expr": "sum(agent_task_total{job=\"agent\", status=\"failed\"})",
-          "legendFormat": "",
-          "refId": "A"
+          "expr": "sum(agent_task_total{status=\"failed\"})",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          }
         }
-      ],
-      "title": "Failed",
-      "type": "stat"
+      ]
     },
     {
+      "type": "stat",
+      "title": "Premium Requests",
       "datasource": {
         "type": "prometheus",
         "uid": ""
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -206,7 +286,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "purple",
+                "color": "green",
                 "value": null
               }
             ]
@@ -215,18 +295,7 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "id": 4,
       "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -234,59 +303,43 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "orientation": "auto"
       },
       "targets": [
         {
-          "expr": "sum(agent_premium_requests_total{job=\"agent\"})",
-          "legendFormat": "",
-          "refId": "A"
+          "expr": "sum(agent_premium_requests_total)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          }
         }
-      ],
-      "title": "Premium Requests",
-      "type": "stat"
+      ]
     },
     {
+      "type": "stat",
+      "title": "Total Tokens",
       "datasource": {
         "type": "prometheus",
         "uid": ""
       },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "fixedColor": "orange",
+            "mode": "fixed"
           },
           "mappings": [],
           "thresholds": {
@@ -300,138 +353,156 @@
           },
           "unit": "short"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "complete"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "failed"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "partial"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "rejected"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 4
-      },
-      "id": 5,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom"
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "orientation": "auto"
       },
       "targets": [
         {
-          "expr": "increase(agent_task_total{job=\"agent\"}[$__interval])",
-          "legendFormat": "{{status}}",
-          "refId": "A"
+          "expr": "sum(agent_tokens_total)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          }
         }
-      ],
-      "title": "Tasks by Status",
-      "type": "timeseries"
+      ]
     },
     {
+      "type": "piechart",
+      "title": "Tasks by Status",
       "datasource": {
         "type": "prometheus",
         "uid": ""
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 4
       },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 15,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (status)(agent_task_total)",
+          "legendFormat": "{{status}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          }
+        }
+      ]
+    },
+    {
+      "type": "piechart",
+      "title": "Tokens by Direction",
+      "datasource": {
+        "type": "prometheus",
+        "uid": ""
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (direction)(agent_tokens_total)",
+          "legendFormat": "{{direction}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          }
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "title": "Avg Duration by Type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": ""
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
           },
           "mappings": [],
           "thresholds": {
@@ -440,6 +511,14 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 900
               }
             ]
           },
@@ -447,152 +526,402 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 4
-      },
-      "id": 6,
       "options": {
-        "legend": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
           "calcs": [
-            "mean",
-            "max"
+            "lastNotNull"
           ],
-          "displayMode": "table",
-          "placement": "bottom"
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "showUnfilled": true,
+        "minVizWidth": 8,
+        "minVizHeight": 16
       },
       "targets": [
         {
-          "expr": "rate(agent_task_duration_seconds_sum{job=\"agent\"}[$__rate_interval]) / rate(agent_task_duration_seconds_count{job=\"agent\"}[$__rate_interval])",
-          "legendFormat": "{{task_type}} ({{status}})",
-          "refId": "A"
+          "expr": "sum by (task_type)(agent_task_duration_seconds_sum) / sum by (task_type)(agent_task_duration_seconds_count)",
+          "legendFormat": "{{task_type}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          }
         }
-      ],
-      "title": "Average Task Duration",
-      "type": "timeseries"
+      ]
     },
     {
+      "type": "table",
+      "title": "Recent Tasks",
       "datasource": {
-        "type": "loki"
+        "type": "loki",
+        "uid": ""
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 24,
         "x": 0,
         "y": 12
       },
-      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 80
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "task_type"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "duration_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          }
+        ]
+      },
       "options": {
-        "dedupStrategy": "none",
-        "enableLogDetails": true,
-        "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": true,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "wrapLogMessage": true
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "displayName": "Time",
+            "desc": true
+          }
+        ]
       },
-      "targets": [
+      "transformations": [
         {
-          "expr": "{task_type=~\"$task_type\", container_name=~\"worker-.*|agents-agent.*\"} | json | message != `` | line_format `{{.message}}`",
-          "refId": "A"
-        }
-      ],
-      "title": "Agent Logs",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki"
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 22
-      },
-      "id": 8,
-      "options": {
-        "dedupStrategy": "none",
-        "enableLogDetails": true,
-        "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": true,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "wrapLogMessage": true
-      },
-      "targets": [
-        {
-          "expr": "{task_type=~\"$task_type\", level=\"WARNING\"} | json | message != `` | line_format `{{.message}}`",
-          "refId": "A"
+          "id": "extractFields",
+          "options": {
+            "source": "Line"
+          }
         },
         {
-          "expr": "{task_type=~\"$task_type\", level=\"ERROR\"} | json | message != `` | line_format `{{.message}}`",
-          "refId": "B"
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Line": true,
+              "Labels": true,
+              "tsNs": true,
+              "id": true,
+              "event": true,
+              "logger": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "task_type": 1,
+              "status": 2,
+              "repo": 3,
+              "pr_number": 4,
+              "premium_requests": 5,
+              "input_tokens": 6,
+              "output_tokens": 7,
+              "duration_seconds": 8,
+              "cli_calls": 9,
+              "review_fix_rounds": 10,
+              "model": 11,
+              "merged": 12,
+              "error": 13
+            }
+          }
         }
       ],
-      "title": "Warnings & Errors",
-      "type": "logs"
+      "targets": [
+        {
+          "expr": "{job=\"agent\"} | json | event = `task_completed`",
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": ""
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Trends",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "Task Throughput (daily)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "barAlignment": 0,
+                "fillOpacity": 80,
+                "lineWidth": 0,
+                "spanNulls": false,
+                "axisBorderShow": false,
+                "axisCenteredZero": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "expr": "increase(sum by (task_type)(agent_task_total)[1d])",
+              "legendFormat": "{{task_type}}",
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": ""
+              }
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Premium Requests (daily)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "barAlignment": 0,
+                "fillOpacity": 80,
+                "lineWidth": 0,
+                "spanNulls": false,
+                "axisBorderShow": false,
+                "axisCenteredZero": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "expr": "increase(sum by (task_type)(agent_premium_requests_total)[1d])",
+              "legendFormat": "{{task_type}}",
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Logs",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "panels": [
+        {
+          "type": "logs",
+          "title": "Agent Logs",
+          "datasource": {
+            "type": "loki",
+            "uid": ""
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 22
+          },
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": false,
+            "enableLogDetails": true,
+            "sortOrder": "Descending"
+          },
+          "targets": [
+            {
+              "expr": "{job=\"agent\"}",
+              "refId": "A",
+              "datasource": {
+                "type": "loki",
+                "uid": ""
+              }
+            }
+          ]
+        },
+        {
+          "type": "logs",
+          "title": "Warnings & Errors",
+          "datasource": {
+            "type": "loki",
+            "uid": ""
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 30
+          },
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": false,
+            "enableLogDetails": true,
+            "sortOrder": "Descending"
+          },
+          "targets": [
+            {
+              "expr": "{job=\"agent\"} | json | level =~ `WARNING|ERROR`",
+              "refId": "A",
+              "datasource": {
+                "type": "loki",
+                "uid": ""
+              }
+            }
+          ]
+        }
+      ]
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 39,
-  "style": "dark",
   "tags": [
-    "homelab",
     "agent"
   ],
   "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "implement|review",
-          "value": "implement|review"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Task Type",
-        "multi": false,
-        "name": "task_type",
-        "options": [
-          {
-            "selected": true,
-            "text": "All",
-            "value": "implement|review"
-          },
-          {
-            "selected": false,
-            "text": "implement",
-            "value": "implement"
-          },
-          {
-            "selected": false,
-            "text": "review",
-            "value": "review"
-          }
-        ],
-        "query": "",
-        "type": "custom"
-      }
-    ]
+    "list": []
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Agent Tasks",
   "uid": "agent-tasks",
-  "version": 0,
-  "weekStart": ""
+  "version": 1
 }

--- a/stacks/observability/dashboards/agent-tasks.json
+++ b/stacks/observability/dashboards/agent-tasks.json
@@ -754,7 +754,7 @@
           },
           "targets": [
             {
-              "expr": "increase(sum by (task_type)(agent_task_total)[1d])",
+              "expr": "sum by (task_type)(increase(agent_task_total[1d]))",
               "legendFormat": "{{task_type}}",
               "refId": "A",
               "datasource": {
@@ -816,7 +816,7 @@
           },
           "targets": [
             {
-              "expr": "increase(sum by (task_type)(agent_premium_requests_total)[1d])",
+              "expr": "sum by (task_type)(increase(agent_premium_requests_total[1d]))",
               "legendFormat": "{{task_type}}",
               "refId": "A",
               "datasource": {


### PR DESCRIPTION
## Summary

Overhauls agent metrics collection and the Grafana dashboard. Previously, token data was captured as raw strings but never parsed, metrics only tracked premium requests and duration, and the dashboard had display bugs (triplicate legends, tiny scrollable panels, wrong visualizations for sparse event data).

### Changes

**Token parsing** — `_parse_tokens()` parses the CLI tokens line into numeric fields. CLIResult and TaskError now carry `input_tokens`, `output_tokens`, `cached_tokens`, `reasoning_tokens`.

**Structured events** — Two standardized log events for Loki:
- `cli_completed` — emitted inside `run_copilot()` after every CLI call (success or failure), with stage, model, effort, tokens, timing, exit_code
- `task_completed` — emitted from worker after full lifecycle, with accumulated totals and outcome

**Token accumulation** — `_TokenAccumulator` in implement orchestrator accumulates tokens, premium, cli_calls, and review_fix_rounds across all stages. Review orchestrator now sets `repo`, `model`, and `reasoning_effort` on TaskResult (were missing).

**New Prometheus metric** — `agent_tokens_total` Counter(task_type, direction) tracks token consumption.

**Dashboard rewrite** — Single-screen control room:
- Row 1: Stat panels (active workers, total tasks, success rate, failed, premium, tokens)
- Row 2: Pie charts (tasks by status, tokens by direction) + bar gauge (avg duration by type)
- Row 3: Loki table of recent tasks with all dimensions
- Row 4: Collapsed trends (daily throughput + premium burn)
- Row 5: Collapsed logs

**Alloy config** — Added `event` and `stage` to structured_metadata extraction.

### Testing
- All 228 existing tests pass
- Added token parsing tests (value parsing, full format, edge cases)
- Pre-commit hooks pass (ruff lint, ruff format, yamllint, actionlint, shellcheck, pytest)