### PR TITLE
fix: add build-time smoke test and mise trust for agent worktrees

### DIFF
--- a/stacks/agents/app/Dockerfile
+++ b/stacks/agents/app/Dockerfile
@@ -68,6 +68,17 @@ RUN UV_VERSION=$(uv --version | awk '{print $2}') && \
 # already registered above so mise skips them.
 RUN mise install --yes && mise reshim
 
+# Verify all mise-managed tools are installed. Fails the build if anything is
+# missing — catches version drift between mise.toml and the Dockerfile before
+# the image ships.
+RUN mise ls --json | python3 -c "\
+import json, sys; tools = json.load(sys.stdin); \
+missing = [t for t in tools if not tools[t][0].get('installed')]; \
+sys.exit(f'Missing tools: {missing}') if missing else print('All mise tools verified ✓')"
+# Verify non-mise tools and that shims resolve correctly.
+RUN python3 --version && uv --version && envsubst --version && \
+    /mise/shims/shellcheck --version | head -1 && /mise/shims/actionlint --version
+
 WORKDIR /app
 COPY stacks/agents/app/pyproject.toml stacks/agents/app/uv.lock ./
 RUN uv sync --frozen

--- a/stacks/agents/app/Dockerfile
+++ b/stacks/agents/app/Dockerfile
@@ -100,6 +100,8 @@ RUN chmod +x /entrypoint.sh
 
 ENV HOME=/home/agent
 ENV PATH="/mise/shims:/app/.venv/bin:$PATH"
+# Trust mise configs in worktrees (agent clones repos into /reviews/).
+ENV MISE_TRUSTED_CONFIG_PATHS="/reviews"
 
 # Copilot CLI authenticates via COPILOT_GITHUB_TOKEN env var (set in compose)
 


### PR DESCRIPTION
## What's changed

Two additions to the agent Dockerfile:

### Build-time smoke test (lines 71-79)
Verifies at `docker build` time that all mise tools are installed and their binaries resolve. Catches tool drift before production — if a tool is missing or version changes, the build fails.

### `MISE_TRUSTED_CONFIG_PATHS=/reviews`
When the agent clones a repo into `/reviews/`, mise refused to read the project's `mise.toml` (trust error). This env var pre-trusts that path so `mise run ci` works in worktrees.

### Verified
- `docker build --no-cache` passes on beelink
- Full agent simulation: clone → `mise ls` → `uv sync` → `mise run lint` → `mise run typecheck` → `mise run test` — all 228 tests pass, zero tool installation time

Closes #156 (remaining work from the container tooling fix)