### PR TITLE
fix: venv PATH order and Loki job label for agent logs

### DIFF
--- a/stacks/agents/app/Dockerfile
+++ b/stacks/agents/app/Dockerfile
@@ -99,7 +99,7 @@ COPY stacks/agents/app/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENV HOME=/home/agent
-ENV PATH="/mise/shims:/app/.venv/bin:$PATH"
+ENV PATH="/app/.venv/bin:/mise/shims:$PATH"
 # Trust mise configs in worktrees (agent clones repos into /reviews/).
 ENV MISE_TRUSTED_CONFIG_PATHS="/reviews"
 

--- a/stacks/observability/config.alloy
+++ b/stacks/observability/config.alloy
@@ -78,6 +78,14 @@ discovery.relabel "docker_logs" {
     target_label = "instance"
     replacement  = constants.hostname
   }
+  // Map agent API and worker containers to job="agent" so Loki queries
+  // match the same job label used by the Prometheus agent scrape target.
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(agents-agent-.*|worker-.*)"
+    target_label  = "job"
+    replacement   = "agent"
+  }
 }
 
 // ================================


### PR DESCRIPTION
## Problem

Two bugs preventing the agent dashboard from showing data:

1. **Workers crash on startup** — `ModuleNotFoundError: No module named 'pydantic'`. The Dockerfile PATH puts `/mise/shims` before `/app/.venv/bin`, so `python` resolves to the bare system interpreter (no packages installed).

2. **All Loki panels empty** — Dashboard queries use `{job="agent"}` but Alloy never assigns a `job` label to container logs. The agent API and worker container logs were being ingested but unreachable by the dashboard.

## Fix

- **Dockerfile**: Swap PATH to `/app/.venv/bin:/mise/shims:...` so `python` resolves to the venv interpreter
- **Alloy config**: Add relabel rule mapping `agents-agent-*` and `worker-*` containers to `job="agent"`, matching the Prometheus scrape target label