### PR TITLE
fix: use Tailscale IP for CrowdSec metrics scrape

### DIFF
--- a/stacks/crowdsec/compose.yaml
+++ b/stacks/crowdsec/compose.yaml
@@ -19,13 +19,8 @@ services:
     ports:
       # CrowdSec API for bouncers
       - "127.0.0.1:8080:8080"
-    networks:
-      - default
-      - monitoring
-
-networks:
-  monitoring:
-    external: true
+      # Prometheus metrics (scraped by Alloy via Tailscale IP)
+      - "100.100.146.119:6060:6060"
 
 volumes:
   crowdsec-config:

--- a/stacks/observability/compose.yaml
+++ b/stacks/observability/compose.yaml
@@ -63,13 +63,6 @@ services:
     depends_on:
       - prometheus
       - loki
-    networks:
-      - default
-      - monitoring
-
-networks:
-  monitoring:
-    external: true
 
 volumes:
   grafana-data:

--- a/stacks/observability/config.alloy
+++ b/stacks/observability/config.alloy
@@ -155,7 +155,7 @@ loki.write "default" {
 
 prometheus.scrape "crowdsec" {
   targets = [{
-    __address__ = "crowdsec:6060",
+    __address__ = "100.100.146.119:6060",
   }]
   forward_to      = [prometheus.remote_write.default.receiver]
   scrape_interval = "30s"


### PR DESCRIPTION
## Problem

Security dashboard stopped showing data. CrowdSec metrics scrape was failing because Docker DNS on the external monitoring network lost the crowdsec service name resolution after container restarts across compose stacks.

## Fix

Follow the existing cross-stack networking convention (Tailscale IP instead of Docker DNS):

- Expose CrowdSec metrics on 100.100.146.119:6060 (Tailscale interface only)
- Update Alloy scrape target from crowdsec:6060 to 100.100.146.119:6060
- Remove the monitoring external network from both stacks (no longer needed)