### PR TITLE
feat: add knowledge ingestion pipeline

### DIFF
--- a/stacks/knowledge/app/knowledge/__init__.py
+++ b/stacks/knowledge/app/knowledge/__init__.py
@@ -4,12 +4,14 @@ from .database import (
     create_workspace,
     delete_document_chunks,
     get_document_by_hash,
+    get_document_by_source,
     insert_chunks,
     list_workspaces,
     resolve_database_url,
     search_chunks,
     upsert_document,
 )
+from .ingest import ingest_file, ingest_text
 from .models import EMBEDDING_DIMENSION, Chunk, Document, IngestResult, SearchResult, Workspace
 
 __all__ = [
@@ -24,6 +26,9 @@ __all__ = [
     "create_workspace",
     "delete_document_chunks",
     "get_document_by_hash",
+    "get_document_by_source",
+    "ingest_file",
+    "ingest_text",
     "insert_chunks",
     "list_workspaces",
     "resolve_database_url",

--- a/stacks/knowledge/app/knowledge/__main__.py
+++ b/stacks/knowledge/app/knowledge/__main__.py
@@ -1,0 +1,55 @@
+"""CLI entrypoint: python -m knowledge ingest ..."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .ingest import ingest_file, ingest_text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="knowledge", description="Knowledge base CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    ingest_parser = subparsers.add_parser("ingest", help="Ingest documents")
+    ingest_parser.add_argument("--workspace", required=True, help="Target workspace name")
+    ingest_parser.add_argument("--path", type=Path, help="File to ingest (.md or .txt)")
+    ingest_parser.add_argument("--text", help="Raw text to ingest")
+    ingest_parser.add_argument("--title", help="Title for raw text (required with --text)")
+
+    args = parser.parse_args()
+
+    if args.command == "ingest":
+        _handle_ingest(args)
+
+
+def _handle_ingest(args: argparse.Namespace) -> None:
+    if args.path and args.text:
+        print("Error: provide --path or --text, not both", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.path and not args.text:
+        print("Error: provide --path or --text", file=sys.stderr)
+        sys.exit(1)
+
+    if args.text and not args.title:
+        print("Error: --title is required with --text", file=sys.stderr)
+        sys.exit(1)
+
+    if args.path:
+        path = Path(args.path)
+        if not path.is_file():
+            print(f"Error: file not found: {path}", file=sys.stderr)
+            sys.exit(1)
+        result = ingest_file(path, workspace=args.workspace)
+    else:
+        result = ingest_text(args.text, title=args.title, workspace=args.workspace)
+
+    print(json.dumps(result.model_dump(mode="json"), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/stacks/knowledge/app/knowledge/chunker.py
+++ b/stacks/knowledge/app/knowledge/chunker.py
@@ -1,0 +1,106 @@
+"""Split text into overlapping chunks, preserving markdown heading context."""
+
+from __future__ import annotations
+
+import re
+
+_TARGET_TOKENS = 500
+_OVERLAP_TOKENS = 50
+# Rough approximation: 1 token ≈ 4 chars (GPT-family tokenizers).
+_CHARS_PER_TOKEN = 4
+_TARGET_CHARS = _TARGET_TOKENS * _CHARS_PER_TOKEN
+_OVERLAP_CHARS = _OVERLAP_TOKENS * _CHARS_PER_TOKEN
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+
+
+def chunk_text(text: str, *, heading_prefix: str = "") -> list[str]:
+    """Split *text* into chunks of roughly _TARGET_TOKENS tokens with _OVERLAP_TOKENS overlap.
+
+    If *heading_prefix* is provided it is prepended to every chunk so the
+    embedding model has section context.
+    """
+    if not text.strip():
+        return []
+
+    sections = _split_by_headings(text)
+    raw_chunks: list[str] = []
+
+    for section_heading, section_body in sections:
+        prefix = section_heading or heading_prefix
+        _chunk_section(section_body, prefix=prefix, out=raw_chunks)
+
+    return [c for c in raw_chunks if c.strip()]
+
+
+def _split_by_headings(text: str) -> list[tuple[str, str]]:
+    """Split markdown into (heading, body) pairs.
+
+    Non-headed text at the top gets an empty heading.
+    """
+    matches = list(_HEADING_RE.finditer(text))
+    if not matches:
+        return [("", text)]
+
+    sections: list[tuple[str, str]] = []
+    if matches[0].start() > 0:
+        sections.append(("", text[: matches[0].start()]))
+
+    for i, match in enumerate(matches):
+        heading = match.group(0).strip()
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        sections.append((heading, text[start:end]))
+
+    return sections
+
+
+def _chunk_section(body: str, *, prefix: str, out: list[str]) -> None:
+    """Chunk a single section's body, prepending *prefix* to each chunk."""
+    body = body.strip()
+    if not body:
+        return
+
+    prefix_str = f"{prefix}\n\n" if prefix else ""
+
+    if len(body) <= _TARGET_CHARS:
+        out.append(f"{prefix_str}{body}")
+        return
+
+    paragraphs = re.split(r"\n{2,}", body)
+    current: list[str] = []
+    current_len = 0
+
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+
+        para_len = len(para)
+
+        if current and current_len + para_len > _TARGET_CHARS:
+            out.append(f"{prefix_str}{_join(current)}")
+            # Keep overlap from the end of current chunk
+            current, current_len = _take_overlap(current)
+
+        current.append(para)
+        current_len += para_len
+
+    if current:
+        out.append(f"{prefix_str}{_join(current)}")
+
+
+def _join(paragraphs: list[str]) -> str:
+    return "\n\n".join(paragraphs)
+
+
+def _take_overlap(paragraphs: list[str]) -> tuple[list[str], int]:
+    """Return paragraphs from the end that fit within the overlap budget."""
+    overlap: list[str] = []
+    total = 0
+    for para in reversed(paragraphs):
+        if total + len(para) > _OVERLAP_CHARS:
+            break
+        overlap.insert(0, para)
+        total += len(para)
+    return overlap, total

--- a/stacks/knowledge/app/knowledge/database.py
+++ b/stacks/knowledge/app/knowledge/database.py
@@ -79,36 +79,31 @@ def insert_chunks(conn: DatabaseConnection, chunks: list[Chunk]) -> list[Chunk]:
     if not chunks:
         return []
 
-    inserted_chunks: list[Chunk] = []
-    with _cursor(conn) as cursor:
-        for chunk in chunks:
-            cursor.execute(
-                """
-                INSERT INTO chunks (
-                    id,
-                    document_id,
-                    chunk_index,
-                    content,
-                    embedding,
-                    metadata,
-                    created_at
-                )
-                VALUES (COALESCE(%s, gen_random_uuid()), %s, %s, %s, %s, %s, COALESCE(%s, now()))
-                RETURNING id, document_id, chunk_index, content, embedding, metadata, created_at
-                """,
-                (
-                    chunk.id,
-                    chunk.document_id,
-                    chunk.chunk_index,
-                    chunk.content,
-                    chunk.embedding,
-                    Jsonb(chunk.metadata),
-                    chunk.created_at,
-                ),
-            )
-            inserted_chunks.append(_chunk_from_row(_fetchone(cursor, operation="insert chunk")))
+    sql = """
+        INSERT INTO chunks (id, document_id, chunk_index, content, embedding, metadata, created_at)
+        VALUES (COALESCE(%s, gen_random_uuid()), %s, %s, %s, %s, %s, COALESCE(%s, now()))
+        RETURNING id, document_id, chunk_index, content, embedding, metadata, created_at
+    """
+    params = [
+        (
+            c.id,
+            c.document_id,
+            c.chunk_index,
+            c.content,
+            c.embedding,
+            Jsonb(c.metadata),
+            c.created_at,
+        )
+        for c in chunks
+    ]
 
-    return inserted_chunks
+    inserted: list[Chunk] = []
+    with _cursor(conn) as cursor:
+        for row_params in params:
+            cursor.execute(sql, row_params)
+            inserted.append(_chunk_from_row(_fetchone(cursor, operation="insert chunk")))
+
+    return inserted
 
 
 def delete_document_chunks(conn: DatabaseConnection, document: Document) -> int:
@@ -231,6 +226,34 @@ def get_document_by_hash(
         return None
 
     return _document_from_row(row)
+
+
+def get_document_by_source(
+    conn: DatabaseConnection,
+    workspace: str,
+    source_path: str,
+) -> Document | None:
+    """Find a document by workspace + source_path."""
+    normalized_workspace = workspace.strip()
+    normalized_path = source_path.strip()
+    if not normalized_workspace:
+        raise ValueError("workspace must not be blank")
+    if not normalized_path:
+        raise ValueError("source_path must not be blank")
+
+    with _cursor(conn) as cursor:
+        cursor.execute(
+            """
+            SELECT id, workspace, source_path, title, content_hash, ingested_at
+            FROM documents
+            WHERE workspace = %s AND source_path = %s
+            LIMIT 1
+            """,
+            (normalized_workspace, normalized_path),
+        )
+        row = cursor.fetchone()
+
+    return _document_from_row(row) if row else None
 
 
 def _fetchone(cursor: DatabaseCursor, *, operation: str) -> DBRow:

--- a/stacks/knowledge/app/knowledge/embeddings.py
+++ b/stacks/knowledge/app/knowledge/embeddings.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import httpx
+
+from .models import EMBEDDING_DIMENSION
+
+logger = logging.getLogger(__name__)
+
+GITHUB_MODELS_URL = (
+    "https://models.github.ai/inference/openai/deployments/text-embedding-3-large/embeddings"
+)
+MODEL_NAME = "text-embedding-3-large"
+TOKEN_ENV = "GITHUB_TOKEN"
+
+_MAX_RETRIES = 3
+_INITIAL_BACKOFF = 1.0
+
+
+def get_embeddings(texts: list[str], *, token: str | None = None) -> list[list[float]]:
+    """Call GitHub Models API to embed a batch of texts. Returns one vector per input."""
+    if not texts:
+        return []
+
+    resolved_token = token or os.getenv(TOKEN_ENV)
+    if not resolved_token:
+        raise RuntimeError(f"{TOKEN_ENV} must be set for embedding requests")
+
+    payload = {"input": texts, "model": MODEL_NAME}
+    headers = {"Authorization": f"Bearer {resolved_token}", "Content-Type": "application/json"}
+
+    data = _post_with_retry(payload, headers)
+    embeddings = _parse_response(data, expected=len(texts))
+    return embeddings
+
+
+def _post_with_retry(payload: dict, headers: dict) -> dict:
+    """POST with exponential backoff on 429 / 5xx."""
+    backoff = _INITIAL_BACKOFF
+    last_error: httpx.HTTPStatusError | None = None
+
+    for attempt in range(_MAX_RETRIES):
+        response = httpx.post(GITHUB_MODELS_URL, json=payload, headers=headers, timeout=60.0)
+        try:
+            response.raise_for_status()
+            return response.json()  # type: ignore[no-any-return]
+        except httpx.HTTPStatusError as exc:
+            last_error = exc
+            if exc.response.status_code == 429 or exc.response.status_code >= 500:
+                logger.warning(
+                    "Embedding API returned %d (attempt %d/%d), retrying in %.1fs",
+                    exc.response.status_code,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                    backoff,
+                )
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            raise
+
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("No retries attempted")
+
+
+def _parse_response(data: dict, *, expected: int) -> list[list[float]]:
+    """Extract and validate embedding vectors from the API response."""
+    items = data.get("data", [])
+    if len(items) != expected:
+        raise ValueError(f"Expected {expected} embeddings, got {len(items)}")
+
+    sorted_items = sorted(items, key=lambda item: item["index"])
+    embeddings: list[list[float]] = []
+    for item in sorted_items:
+        vec = item["embedding"]
+        if len(vec) != EMBEDDING_DIMENSION:
+            raise ValueError(f"Expected {EMBEDDING_DIMENSION}-dim embedding, got {len(vec)}")
+        embeddings.append(vec)
+
+    return embeddings

--- a/stacks/knowledge/app/knowledge/ingest.py
+++ b/stacks/knowledge/app/knowledge/ingest.py
@@ -1,0 +1,186 @@
+"""Ingestion orchestrator: load → chunk → embed → store."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+from .chunker import chunk_text
+from .database import (
+    DatabaseConnection,
+    connect,
+    create_workspace,
+    delete_document_chunks,
+    get_document_by_source,
+    insert_chunks,
+    upsert_document,
+)
+from .embeddings import get_embeddings
+from .models import Chunk, Document, IngestResult, Workspace
+
+logger = logging.getLogger(__name__)
+
+
+def ingest_file(
+    path: Path,
+    *,
+    workspace: str,
+    conn: DatabaseConnection | None = None,
+    token: str | None = None,
+) -> IngestResult:
+    """Ingest a single file into the knowledge base."""
+    content = path.read_text(encoding="utf-8")
+    title = _title_from_file(path, content)
+    source_path = str(path)
+    return _ingest(
+        content=content,
+        title=title,
+        source_path=source_path,
+        workspace=workspace,
+        conn=conn,
+        token=token,
+    )
+
+
+def ingest_text(
+    text: str,
+    *,
+    title: str,
+    workspace: str,
+    conn: DatabaseConnection | None = None,
+    token: str | None = None,
+) -> IngestResult:
+    """Ingest raw text as a document."""
+    return _ingest(
+        content=text,
+        title=title,
+        source_path=f"text://{title}",
+        workspace=workspace,
+        conn=conn,
+        token=token,
+    )
+
+
+def _ingest(
+    *,
+    content: str,
+    title: str,
+    source_path: str,
+    workspace: str,
+    conn: DatabaseConnection | None,
+    token: str | None,
+) -> IngestResult:
+    content_hash = hashlib.sha256(content.encode()).hexdigest()
+    own_conn = conn is None
+    db = conn or connect()
+
+    try:
+        return _do_ingest(
+            db,
+            content=content,
+            title=title,
+            source_path=source_path,
+            workspace=workspace,
+            content_hash=content_hash,
+            token=token,
+        )
+    finally:
+        if own_conn:
+            db.close()
+
+
+def _do_ingest(
+    conn: DatabaseConnection,
+    *,
+    content: str,
+    title: str,
+    source_path: str,
+    workspace: str,
+    content_hash: str,
+    token: str | None,
+) -> IngestResult:
+    # Ensure workspace exists
+    create_workspace(conn, Workspace(name=workspace))
+
+    # Check for unchanged content
+    existing = _find_existing(conn, workspace, source_path)
+    if existing and existing.content_hash == content_hash:
+        logger.info("Skipping unchanged document: %s", source_path)
+        conn.commit()
+        return IngestResult(
+            workspace=workspace,
+            documents_processed=0,
+            chunks_created=0,
+            documents_skipped=1,
+        )
+
+    # Chunk the content
+    chunks_text = chunk_text(content)
+    if not chunks_text:
+        logger.warning("No chunks produced from: %s", source_path)
+        conn.commit()
+        return IngestResult(
+            workspace=workspace,
+            documents_processed=1,
+            chunks_created=0,
+            documents_skipped=0,
+        )
+
+    # Embed all chunks
+    embeddings = get_embeddings(chunks_text, token=token)
+
+    # Store in a single transaction
+    doc = Document(
+        workspace=workspace,
+        source_path=source_path,
+        title=title,
+        content_hash=content_hash,
+    )
+    saved_doc = upsert_document(conn, doc)
+    assert saved_doc.id is not None, "upsert_document must return a document with an ID"
+
+    # Delete old chunks if re-ingesting
+    if existing:
+        delete_document_chunks(conn, saved_doc)
+
+    chunk_models = [
+        Chunk(
+            document_id=saved_doc.id,
+            chunk_index=i,
+            content=text,
+            embedding=embedding,
+        )
+        for i, (text, embedding) in enumerate(zip(chunks_text, embeddings, strict=True))
+    ]
+    inserted = insert_chunks(conn, chunk_models)
+    conn.commit()
+
+    logger.info(
+        "Ingested %s: %d chunks into workspace '%s'",
+        source_path,
+        len(inserted),
+        workspace,
+    )
+    return IngestResult(
+        workspace=workspace,
+        documents_processed=1,
+        chunks_created=len(inserted),
+        documents_skipped=0,
+    )
+
+
+def _find_existing(conn: DatabaseConnection, workspace: str, source_path: str) -> Document | None:
+    """Find an existing document by workspace + source_path."""
+    return get_document_by_source(conn, workspace, source_path)
+
+
+def _title_from_file(path: Path, content: str) -> str:
+    """Derive title from first markdown heading or filename."""
+    if path.suffix in (".md", ".markdown"):
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("# "):
+                return stripped[2:].strip()
+
+    return path.stem.replace("-", " ").replace("_", " ").title()

--- a/stacks/knowledge/app/tests/test_chunker.py
+++ b/stacks/knowledge/app/tests/test_chunker.py
@@ -1,0 +1,54 @@
+from knowledge.chunker import chunk_text
+
+
+def test_empty_text_returns_no_chunks() -> None:
+    assert chunk_text("") == []
+    assert chunk_text("   ") == []
+
+
+def test_short_text_is_single_chunk() -> None:
+    text = "Hello world, this is a short paragraph."
+    chunks = chunk_text(text)
+    assert len(chunks) == 1
+    assert "Hello world" in chunks[0]
+
+
+def test_heading_prepended_to_chunks() -> None:
+    text = "# My Title\n\nSome content here."
+    chunks = chunk_text(text)
+    assert len(chunks) == 1
+    assert chunks[0].startswith("# My Title")
+    assert "Some content here" in chunks[0]
+
+
+def test_multiple_headings_split_sections() -> None:
+    text = "# Section A\n\nContent A.\n\n# Section B\n\nContent B."
+    chunks = chunk_text(text)
+    assert any("Section A" in c and "Content A" in c for c in chunks)
+    assert any("Section B" in c and "Content B" in c for c in chunks)
+
+
+def test_long_section_splits_into_multiple_chunks() -> None:
+    # ~500 tokens ≈ 2000 chars. Create a section well over that.
+    paragraph = "This is a test paragraph with enough words. " * 20  # ~900 chars
+    text = f"# Big Section\n\n{paragraph}\n\n{paragraph}\n\n{paragraph}\n\n{paragraph}"
+    chunks = chunk_text(text)
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert chunk.startswith("# Big Section")
+
+
+def test_heading_prefix_used_for_plain_text() -> None:
+    text = "Just some plain text without headings."
+    chunks = chunk_text(text, heading_prefix="## Context")
+    assert len(chunks) == 1
+    assert chunks[0].startswith("## Context")
+    assert "plain text" in chunks[0]
+
+
+def test_heading_prefix_not_used_when_section_has_heading() -> None:
+    text = "# Own Heading\n\nBody text."
+    chunks = chunk_text(text, heading_prefix="## Fallback")
+    assert len(chunks) == 1
+    assert chunks[0].startswith("# Own Heading")
+    assert "Fallback" not in chunks[0]

--- a/stacks/knowledge/app/tests/test_embeddings.py
+++ b/stacks/knowledge/app/tests/test_embeddings.py
@@ -1,0 +1,90 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from knowledge.embeddings import (
+    TOKEN_ENV,
+    _parse_response,
+    get_embeddings,
+)
+from knowledge.models import EMBEDDING_DIMENSION
+
+_FAKE_REQUEST = httpx.Request("POST", "https://example.com")
+
+
+def _fake_embedding(index: int = 0) -> dict:
+    return {"embedding": [0.1] * EMBEDDING_DIMENSION, "index": index}
+
+
+def _ok_response(count: int) -> httpx.Response:
+    data = {"data": [_fake_embedding(i) for i in range(count)]}
+    return httpx.Response(200, json=data, request=_FAKE_REQUEST)
+
+
+def test_empty_input_returns_empty() -> None:
+    assert get_embeddings([]) == []
+
+
+def test_get_embeddings_calls_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    response = _ok_response(2)
+
+    with patch("knowledge.embeddings.httpx.post", return_value=response) as mock_post:
+        result = get_embeddings(["hello", "world"])
+
+    assert len(result) == 2
+    assert len(result[0]) == EMBEDDING_DIMENSION
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args
+    assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer test-token"
+
+
+def test_get_embeddings_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    with pytest.raises(RuntimeError, match=TOKEN_ENV):
+        get_embeddings(["hello"])
+
+
+def test_get_embeddings_retries_on_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    rate_limited = httpx.Response(429, json={"error": "rate limited"}, request=_FAKE_REQUEST)
+    ok = _ok_response(1)
+
+    with (
+        patch("knowledge.embeddings.httpx.post", side_effect=[rate_limited, ok]) as mock_post,
+        patch("knowledge.embeddings.time.sleep"),
+    ):
+        result = get_embeddings(["hello"])
+
+    assert len(result) == 1
+    assert mock_post.call_count == 2
+
+
+def test_get_embeddings_raises_on_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    bad_request = httpx.Response(400, json={"error": "bad"}, request=_FAKE_REQUEST)
+
+    with (
+        patch("knowledge.embeddings.httpx.post", return_value=bad_request),
+        pytest.raises(httpx.HTTPStatusError),
+    ):
+        get_embeddings(["hello"])
+
+
+def test_parse_response_validates_count() -> None:
+    data = {"data": [_fake_embedding(0)]}
+    with pytest.raises(ValueError, match="Expected 2 embeddings"):
+        _parse_response(data, expected=2)
+
+
+def test_parse_response_validates_dimension() -> None:
+    data = {"data": [{"embedding": [0.1, 0.2], "index": 0}]}
+    with pytest.raises(ValueError, match=str(EMBEDDING_DIMENSION)):
+        _parse_response(data, expected=1)
+
+
+def test_parse_response_sorts_by_index() -> None:
+    data = {"data": [_fake_embedding(1), _fake_embedding(0)]}
+    result = _parse_response(data, expected=2)
+    assert len(result) == 2

--- a/stacks/knowledge/app/tests/test_ingest.py
+++ b/stacks/knowledge/app/tests/test_ingest.py
@@ -1,0 +1,193 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+from knowledge.ingest import _title_from_file, ingest_file, ingest_text
+from knowledge.models import EMBEDDING_DIMENSION, Document, IngestResult
+
+
+def _fake_embeddings(texts: list[str], **_: object) -> list[list[float]]:
+    return [[0.1] * EMBEDDING_DIMENSION for _ in texts]
+
+
+def _fake_connect() -> MagicMock:
+    conn = MagicMock()
+    conn.commit = MagicMock()
+    conn.close = MagicMock()
+    return conn
+
+
+@patch("knowledge.ingest.connect")
+@patch("knowledge.ingest.get_embeddings", side_effect=_fake_embeddings)
+@patch("knowledge.ingest.insert_chunks", return_value=[])
+@patch("knowledge.ingest.upsert_document")
+@patch("knowledge.ingest.delete_document_chunks")
+@patch("knowledge.ingest.create_workspace")
+@patch("knowledge.ingest.get_document_by_source", return_value=None)
+def test_ingest_file_new_document(
+    mock_get_source: MagicMock,
+    mock_create_ws: MagicMock,
+    mock_delete: MagicMock,
+    mock_upsert: MagicMock,
+    mock_insert: MagicMock,
+    mock_embed: MagicMock,
+    mock_connect: MagicMock,
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    mock_connect.return_value = _fake_connect()
+    saved_doc = Document(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        workspace="notes",
+        source_path="test.md",
+        title="Test",
+        content_hash="abc",
+    )
+    mock_upsert.return_value = saved_doc
+
+    test_file = tmp_path / "test.md"
+    test_file.write_text("# My Doc\n\nSome content here.")
+
+    # Act
+    result = ingest_file(test_file, workspace="notes")
+
+    # Assert
+    assert isinstance(result, IngestResult)
+    assert result.workspace == "notes"
+    assert result.documents_processed == 1
+    assert result.documents_skipped == 0
+    mock_create_ws.assert_called_once()
+    mock_embed.assert_called_once()
+    mock_delete.assert_not_called()
+
+
+@patch("knowledge.ingest.connect")
+@patch("knowledge.ingest.get_embeddings", side_effect=_fake_embeddings)
+@patch("knowledge.ingest.insert_chunks", return_value=[])
+@patch("knowledge.ingest.upsert_document")
+@patch("knowledge.ingest.delete_document_chunks")
+@patch("knowledge.ingest.create_workspace")
+@patch("knowledge.ingest.get_document_by_source")
+def test_ingest_skips_unchanged_content(
+    mock_get_source: MagicMock,
+    mock_create_ws: MagicMock,
+    mock_delete: MagicMock,
+    mock_upsert: MagicMock,
+    mock_insert: MagicMock,
+    mock_embed: MagicMock,
+    mock_connect: MagicMock,
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    content = "# Same Doc\n\nSame content."
+    test_file = tmp_path / "same.md"
+    test_file.write_text(content)
+
+    import hashlib
+
+    content_hash = hashlib.sha256(content.encode()).hexdigest()
+    mock_connect.return_value = _fake_connect()
+    mock_get_source.return_value = Document(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        workspace="notes",
+        source_path=str(test_file),
+        title="Same Doc",
+        content_hash=content_hash,
+    )
+
+    # Act
+    result = ingest_file(test_file, workspace="notes")
+
+    # Assert
+    assert result.documents_skipped == 1
+    assert result.documents_processed == 0
+    mock_embed.assert_not_called()
+    mock_upsert.assert_not_called()
+
+
+@patch("knowledge.ingest.connect")
+@patch("knowledge.ingest.get_embeddings", side_effect=_fake_embeddings)
+@patch("knowledge.ingest.insert_chunks", return_value=[])
+@patch("knowledge.ingest.upsert_document")
+@patch("knowledge.ingest.delete_document_chunks")
+@patch("knowledge.ingest.create_workspace")
+@patch("knowledge.ingest.get_document_by_source")
+def test_ingest_reingests_changed_content(
+    mock_get_source: MagicMock,
+    mock_create_ws: MagicMock,
+    mock_delete: MagicMock,
+    mock_upsert: MagicMock,
+    mock_insert: MagicMock,
+    mock_embed: MagicMock,
+    mock_connect: MagicMock,
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    test_file = tmp_path / "changed.md"
+    test_file.write_text("# Updated\n\nNew content.")
+
+    existing = Document(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        workspace="notes",
+        source_path=str(test_file),
+        title="Old",
+        content_hash="old-hash",
+    )
+    mock_connect.return_value = _fake_connect()
+    mock_get_source.return_value = existing
+    mock_upsert.return_value = existing
+
+    # Act
+    result = ingest_file(test_file, workspace="notes")
+
+    # Assert
+    assert result.documents_processed == 1
+    mock_delete.assert_called_once()
+    mock_embed.assert_called_once()
+
+
+@patch("knowledge.ingest.connect")
+@patch("knowledge.ingest.get_embeddings", side_effect=_fake_embeddings)
+@patch("knowledge.ingest.insert_chunks", return_value=[])
+@patch("knowledge.ingest.upsert_document")
+@patch("knowledge.ingest.delete_document_chunks")
+@patch("knowledge.ingest.create_workspace")
+@patch("knowledge.ingest.get_document_by_source", return_value=None)
+def test_ingest_text_uses_text_uri(
+    mock_get_source: MagicMock,
+    mock_create_ws: MagicMock,
+    mock_delete: MagicMock,
+    mock_upsert: MagicMock,
+    mock_insert: MagicMock,
+    mock_embed: MagicMock,
+    mock_connect: MagicMock,
+) -> None:
+    # Arrange
+    mock_connect.return_value = _fake_connect()
+    saved = Document(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        workspace="notes",
+        source_path="text://Quick Note",
+        title="Quick Note",
+        content_hash="abc",
+    )
+    mock_upsert.return_value = saved
+
+    # Act
+    result = ingest_text("Some quick thought", title="Quick Note", workspace="notes")
+
+    # Assert
+    assert result.documents_processed == 1
+    call_args = mock_upsert.call_args[0]
+    assert call_args[1].source_path == "text://Quick Note"
+
+
+def test_title_from_markdown_heading(tmp_path: Path) -> None:
+    content = "# My Great Title\n\nBody text."
+    path = tmp_path / "doc.md"
+    assert _title_from_file(path, content) == "My Great Title"
+
+
+def test_title_from_filename(tmp_path: Path) -> None:
+    path = tmp_path / "my-cool-doc.txt"
+    assert _title_from_file(path, "plain text") == "My Cool Doc"


### PR DESCRIPTION
## Summary

Adds the ingestion pipeline for the knowledge base — embedding client, markdown chunker, orchestrator, and CLI entrypoint.

### New modules
- **`embeddings.py`** — GitHub Models API client with exponential backoff on 429/5xx
- **`chunker.py`** — splits markdown into ~500-token chunks preserving heading context
- **`ingest.py`** — orchestrator: load → hash-check → chunk → embed → store (transactional)
- **`__main__.py`** — CLI: `python -m knowledge ingest --workspace <ws> --path <file>`

### Nit fixes from #141
- Extracted SQL string from `insert_chunks` loop (was duplicated per iteration)
- Added `get_document_by_source()` as public DB function (ingestion needs workspace+path lookup)

### Key behaviors
- **Content-hash dedup**: SHA-256 of file content; skips unchanged documents
- **Re-ingestion**: deletes old chunks then inserts new ones in a single transaction
- **Auto-creates workspace** if it doesn't exist (upsert)
- **Heading context**: prepends section heading to each chunk for better embedding quality

### Tests
21 new tests (28 total): chunker edge cases, embedding API mocking (retries, errors, batch ordering), ingest orchestration (new/skip/re-ingest/text mode), title derivation.

Closes #142