### PR TITLE
feat: supply chain hardening and tiered auto-merge policy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,10 @@
   "docker": {
     "pinDigests": true
   },
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days",
+    "automerge": true
+  },
   "docker-compose": {
     "fileMatch": ["stacks/.+/compose\\.yaml$"]
   },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,17 +1,73 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "docker:enableMajor"],
-  "platformAutomerge": true,
-  "packageRules": [
-    {
-      "matchManagers": ["docker-compose"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    }
+  "extends": [
+    "config:recommended",
+    "docker:enableMajor",
+    "helpers:pinGitHubActionDigests"
   ],
+  "platformAutomerge": true,
+  "minimumReleaseAge": "3 days",
+  "docker": {
+    "pinDigests": true
+  },
   "docker-compose": {
     "fileMatch": ["stacks/.+/compose\\.yaml$"]
   },
+  "packageRules": [
+    {
+      "description": "Security fixes bypass the 3-day delay and auto-merge immediately",
+      "matchUpdateTypes": ["security"],
+      "minimumReleaseAge": "0 days",
+      "automerge": true
+    },
+    {
+      "description": "Auto-merge Docker image minor/patch updates after vetting period",
+      "matchManagers": ["docker-compose"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Auto-merge mise dev tools (shellcheck, actionlint, trivy) minor/patch",
+      "matchManagers": ["mise"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Auto-merge GitHub Actions minor/patch (SHA-pinned via preset)",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Dockerfile binary tools require manual review (curl'd, no checksums)",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": [
+        "jdx/mise",
+        "github/copilot-cli",
+        "cli/cli",
+        "moby/moby",
+        "docker/compose"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "Group Python version updates across mise.toml and Dockerfile",
+      "groupName": "python",
+      "matchDepNames": ["python"],
+      "automerge": false
+    },
+    {
+      "description": "Group uv updates across mise.toml and Dockerfile",
+      "groupName": "uv",
+      "matchDepNames": ["uv", "ghcr.io/astral-sh/uv"],
+      "automerge": false
+    },
+    {
+      "description": "Major updates always require manual review",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Validate compose files
         run: mise run validate:compose
+
+      - name: Check version consistency
+        run: mise run check:versions

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,7 +30,7 @@ jobs:
   deploy:
     runs-on: beelink
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 

--- a/docs/decisions/014-supply-chain-hardening.md
+++ b/docs/decisions/014-supply-chain-hardening.md
@@ -1,0 +1,91 @@
+# ADR-014: Supply chain hardening and auto-merge policy
+
+**Date:** 2026-04-19
+**Status:** Accepted
+
+## Context
+
+Renovate manages dependency updates but had a single blanket auto-merge rule
+(docker-compose minor/patch only). Most PRs piled up without merging. The repo
+runs a self-hosted GitHub Actions runner on beelink — compromised dependencies
+execute directly on the server with Docker socket access and Tailscale network
+visibility. Supply chain attacks like the Axios npm compromise (March 2026,
+Lazarus Group, ~600K installs in 3 hours) demonstrate that auto-merging without
+safeguards is a direct path to infrastructure compromise.
+
+## Options Considered
+
+### Option A: No auto-merge — review everything manually
+
+Safest, but unsustainable. Dependency PRs pile up and never get merged, leaving
+the server running stale software with known vulnerabilities.
+
+**Verdict:** Rejected. The cure is worse than the disease.
+
+### Option B: Auto-merge everything with no delay
+
+Fast, but one compromised package auto-deploys to the server. The Axios attack
+was live for only 3 hours — enough time for Renovate to create, pass CI, and
+merge a PR.
+
+**Verdict:** Rejected. Unacceptable risk for a self-hosted runner.
+
+### Option C: Tiered auto-merge with delay + pinning (chosen)
+
+Three layers of defense:
+
+1. **3-day minimum release age** — community detects most supply chain attacks
+   within 24–48h. The delay means Renovate never acts on yanked malicious
+   versions. Security fixes (matched via GitHub advisory) bypass the delay.
+2. **Immutable references** — Docker digest pinning prevents retroactive tag
+   mutation. GitHub Actions SHA pinning prevents force-pushed tags.
+3. **Risk-tiered rules** — low-risk updates (compose patches, dev tools,
+   SHA-pinned actions) auto-merge. High-risk updates (Dockerfile binaries,
+   major versions, Python/uv toolchain) require manual review.
+
+**Verdict:** Chosen. Balances security with maintenance burden.
+
+## Decision
+
+### Minimum release age
+
+All updates wait 3 days before Renovate creates the PR. Security updates
+(linked to a GitHub advisory / CVE) skip the delay and auto-merge immediately —
+the fix is pre-vetted by the advisory process.
+
+### Immutable pinning
+
+| What | How | Readability impact |
+|------|-----|--------------------|
+| Docker images | Digest pinning (`grafana:12.4.3@sha256:...`) | Low — tag still visible |
+| GitHub Actions | SHA pinning (`actions/checkout@<sha> # v6`) | Medium — comment preserves version |
+
+Renovate manages both — humans never edit digests or SHAs manually.
+
+### Auto-merge tiers
+
+| Category | Auto-merge | Why |
+|----------|-----------|-----|
+| Security CVE fixes | Yes, 0 delay | Advisory-vetted |
+| Docker compose patch/minor | Yes, 3-day delay | Digest-pinned, community vetted |
+| mise.toml dev tools | Yes, 3-day delay | CI validates, low blast radius |
+| GitHub Actions patch/minor | Yes, 3-day delay | SHA-pinned, immutable |
+| Dockerfile binary tools | No | curl'd without checksums |
+| Python/uv version bumps | No | Affects entire toolchain |
+| Any major update | No | Breaking changes need human review |
+
+### Version grouping
+
+Python (mise.toml + Dockerfile FROM + Dockerfile ARG) and uv (mise.toml +
+Dockerfile COPY) are grouped so Renovate creates one PR per logical tool.
+
+### Drift detection
+
+`scripts/check-versions.sh` asserts version consistency between mise.toml and
+the Dockerfile. Wired into CI — the build fails if versions diverge.
+
+## References
+
+- Renovate docs: [minimumReleaseAge](https://docs.renovatebot.com/configuration-options/#minimumreleaseage), [pinDigests](https://docs.renovatebot.com/docker/#digest-pinning)
+- Axios compromise post-mortem: https://github.com/axios/axios/issues/10636
+- GitHub docs: [Pin actions to SHA](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

--- a/mise.toml
+++ b/mise.toml
@@ -50,7 +50,7 @@ description = "Run tests for the knowledge CLI package"
 run = "cd stacks/knowledge/app && uv run pytest tests/ -v"
 
 [tasks."check:versions"]
-description = "Check version consistency across mise.toml, Dockerfile, and pyproject.toml"
+description = "Check version consistency between mise.toml and Dockerfile"
 run = "scripts/check-versions.sh"
 
 [tasks.ci]

--- a/mise.toml
+++ b/mise.toml
@@ -49,9 +49,13 @@ run = "cd stacks/knowledge/app && uv run ty check ."
 description = "Run tests for the knowledge CLI package"
 run = "cd stacks/knowledge/app && uv run pytest tests/ -v"
 
+[tasks."check:versions"]
+description = "Check version consistency across mise.toml, Dockerfile, and pyproject.toml"
+run = "scripts/check-versions.sh"
+
 [tasks.ci]
 description = "Full CI check (lint + typecheck + test + validate)"
-depends = ["lint", "typecheck", "test", "validate:compose"]
+depends = ["lint", "typecheck", "test", "validate:compose", "check:versions"]
 
 # ── Deploy ─────────────────────────────────────────
 [tasks."deploy:all"]

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Check version consistency across mise.toml, Dockerfile, and pyproject.toml.
+# Fails CI if versions drift between these files.
+set -euo pipefail
+
+DOCKERFILE="stacks/agents/app/Dockerfile"
+MISE="mise.toml"
+
+errors=0
+
+# ── Python ──────────────────────────────────────────
+mise_python=$(grep '^python' "$MISE" | sed 's/.*"\(.*\)"/\1/')
+dockerfile_from=$(head -5 "$DOCKERFILE" | grep '^FROM python:' | sed 's/FROM python:\([0-9.]*\).*/\1/')
+dockerfile_arg=$(grep '^ARG PYTHON_VERSION=' "$DOCKERFILE" | sed 's/ARG PYTHON_VERSION=//')
+
+if [ "$mise_python" != "$dockerfile_from" ]; then
+  echo "❌ Python drift: mise.toml=$mise_python, Dockerfile FROM=$dockerfile_from"
+  errors=$((errors + 1))
+fi
+if [ "$mise_python" != "$dockerfile_arg" ]; then
+  echo "❌ Python drift: mise.toml=$mise_python, Dockerfile ARG=$dockerfile_arg"
+  errors=$((errors + 1))
+fi
+
+# ── uv ──────────────────────────────────────────────
+mise_uv=$(grep '^uv' "$MISE" | sed 's/.*"\(.*\)"/\1/')
+dockerfile_uv=$(grep 'COPY --from=ghcr.io/astral-sh/uv:' "$DOCKERFILE" | sed 's/.*uv:\([0-9.]*\).*/\1/')
+
+if [ "$mise_uv" != "$dockerfile_uv" ]; then
+  echo "❌ uv drift: mise.toml=$mise_uv, Dockerfile COPY=$dockerfile_uv"
+  errors=$((errors + 1))
+fi
+
+# ── Summary ─────────────────────────────────────────
+if [ "$errors" -gt 0 ]; then
+  echo ""
+  echo "Found $errors version inconsistencies. Fix them before merging."
+  exit 1
+fi
+
+echo "✅ All versions consistent"

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Check version consistency across mise.toml, Dockerfile, and pyproject.toml.
-# Fails CI if versions drift between these files.
+# Check version consistency between mise.toml and Dockerfile.
+# Fails CI if python or uv versions drift between these two sources of truth.
 set -euo pipefail
 
 DOCKERFILE="stacks/agents/app/Dockerfile"

--- a/stacks/agents/app/Dockerfile
+++ b/stacks/agents/app/Dockerfile
@@ -1,3 +1,4 @@
+# renovate: datasource=docker depName=python
 FROM python:3.14.4-slim
 
 # Pin tool versions for reproducible builds and supply-chain safety.
@@ -53,6 +54,7 @@ COPY mise.toml /mise/config.toml
 
 # Register base-image Python with mise so it skips compilation.
 # mise detects installed tools by scanning /mise/installs/<tool>/<version>/.
+# renovate: datasource=docker depName=python
 ARG PYTHON_VERSION=3.14.4
 RUN mkdir -p /mise/installs/python/${PYTHON_VERSION}/bin && \
     ln -sf /usr/local/bin/python3 /mise/installs/python/${PYTHON_VERSION}/bin/python && \

--- a/stacks/flight-tracker/compose.yaml
+++ b/stacks/flight-tracker/compose.yaml
@@ -12,7 +12,7 @@ services:
       - HEATMAP_DB_PATH=/app/data/historical_heatmap.parquet
 
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    image: cloudflare/cloudflared:2026.3.0
     restart: unless-stopped
     command: tunnel run --token ${TUNNEL_TOKEN:?}
     depends_on:

--- a/stacks/home-assistant/compose.yaml
+++ b/stacks/home-assistant/compose.yaml
@@ -1,7 +1,7 @@
 services:
   homeassistant:
     container_name: homeassistant
-    image: ghcr.io/home-assistant/home-assistant:stable
+    image: ghcr.io/home-assistant/home-assistant:2026.4.2
     healthcheck:
       test:
         - CMD


### PR DESCRIPTION
## What

Harden the dependency update pipeline with layered supply chain defenses and fix Renovate auto-merge so PRs actually merge.

## Why

- 9 stale Renovate PRs piling up because auto-merge rules were too narrow
- Self-hosted runner means compromised deps execute directly on beelink with Docker socket access
- No version drift detection between mise.toml and Dockerfile
- No delay buffer against supply chain attacks (Axios-style: live for 3 hours, 600K installs)

## Changes

### Renovate config rewrite (`.github/renovate.json`)
- **3-day `minimumReleaseAge`** — community vets before we merge. Security CVE fixes bypass with 0-day delay.
- **Docker digest pinning** (`pinDigests: true`) — immutable image references
- **GitHub Actions SHA pinning** (`helpers:pinGitHubActionDigests`) — immutable action references
- **Tiered auto-merge**: compose/mise/actions patches auto-merge. Dockerfile binaries + all majors require manual review.
- **Grouped updates**: python (mise.toml + Dockerfile) and uv (mise.toml + Dockerfile) update atomically in one PR
- **Native mise manager** enabled — tracks python, uv, shellcheck, actionlint, trivy in mise.toml

### Version drift detection
- New `scripts/check-versions.sh` asserts mise.toml ↔ Dockerfile version consistency
- Wired into `mise run ci` and CI workflow

### Floating tag pinning
- `home-assistant:stable` → `2026.4.2`
- `cloudflared:latest` → `2026.3.0`

### Cleanup
- Align deploy.yaml checkout v4 → v6
- Dockerfile annotations for Renovate tracking on FROM + ARG PYTHON_VERSION

### ADR-014
Documents the supply chain hardening policy, threat model, and auto-merge tier rationale.

## What happens after merge

Renovate will automatically create PRs to:
1. Pin Docker image digests across all compose files
2. Pin GitHub Actions to commit SHAs across all workflow files
3. Re-create dependency PRs with correct grouping and auto-merge rules

The 9 existing stale Renovate PRs should be closed — they'll be superseded.

## Readability impact

| File type | Impact | Mitigation |
|-----------|--------|------------|
| compose.yaml | Low | Tag still visible: `grafana:12.4.3@sha256:...` |
| Workflows | Medium | Comment preserves version: `@<sha> # v6` |
| renovate.json | Medium | `description` field on every rule |
| Dockerfile | Minimal | Two annotation comments |
