### PR TITLE
feat: redesign stats row with gauges, fix observability docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Grafana (:3001) ← Prometheus (metrics) ← Alloy (host + container scraping)
                                         ← CrowdSec (security metrics)
 ```
 
-- **Dashboards:** Container Overview, Security (pre-provisioned)
+- **Dashboards:** Container Overview, Agent Tasks, Security (pre-provisioned)
 - **Alerting:** CPU >80%, RAM >90%, Disk >80% → private Discord channel
 - **Security:** CrowdSec IDS with collaborative threat intel + UFW firewall bouncer
 - **External:** Healthchecks.io heartbeat (alerts on full server outage)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -16,10 +16,25 @@ authoritative sources.
 | **Alloy** | Scrapes metrics and ships Docker logs into Prometheus/Loki |
 | **CrowdSec** | Security detections and firewall decisions, also exported as metrics |
 
-Dashboards are provisioned from:
+Dashboards are provisioned from JSON files — Grafana reloads them on
+restart but **will not accept API saves** for provisioned dashboards. To
+edit, modify the JSON and restart Grafana.
 
-- [Container Overview](../stacks/observability/dashboards/container-overview.json)
-- [Security](../stacks/observability/dashboards/security.json)
+- [Container Overview](../stacks/observability/dashboards/container-overview.json) — host gauges, container table, CPU/memory trends
+- [Agent Tasks](../stacks/observability/dashboards/agent-tasks.json) — implement/review task metrics
+- [Security](../stacks/observability/dashboards/security.json) — CrowdSec detections and firewall decisions
+
+### Dashboard patterns
+
+All queries use `max by (name)` (container metrics) or `max()` (host
+metrics) to deduplicate series. When Alloy is recreated, its Prometheus
+`instance` label changes but old series persist until the staleness
+window expires — without aggregation, every metric appears twice.
+
+Datasource UIDs are pinned to `prometheus` and `loki` in
+`provisioning/datasources/datasources.yaml`. Grafana does not update
+UIDs on existing datasources via provisioning — if they drift, fix the
+SQLite DB directly.
 
 ## Logs: Loki via Alloy
 
@@ -57,7 +72,7 @@ Then query it in Grafana Explore:
 
 Prometheus receives metrics from:
 
-- **Host:** Alloy's Unix exporter (`job="node"`)
+- **Host:** Alloy's Unix exporter (`job="integrations/unix"` — Alloy overrides the configured `job_name`)
 - **Containers:** Alloy's cAdvisor exporter (`job="docker"`)
 - **CrowdSec:** direct scrape (`job="crowdsec"`)
 - **Agent service:** `http://100.100.146.119:8585/metrics` (`job="agent"`)

--- a/stacks/observability/dashboards/container-overview.json
+++ b/stacks/observability/dashboards/container-overview.json
@@ -23,48 +23,41 @@
   "liveNow": false,
   "panels": [
     {
+      "id": 11,
+      "title": "Cores",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.6
-              },
-              {
-                "color": "red",
-                "value": 0.8
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 2,
         "x": 0,
         "y": 0
       },
-      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
       "options": {
-        "colorMode": "background",
+        "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
@@ -76,7 +69,7 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto",
+        "textMode": "value",
         "wideLayout": true
       },
       "targets": [
@@ -85,19 +78,27 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\",job=\"integrations/unix\"}[5m]))",
+          "expr": "count(node_cpu_seconds_total{mode=\"idle\",job=\"integrations/unix\"})",
           "instant": true,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Host CPU %",
-      "type": "stat",
-      "description": "avg() already collapses duplicate series from scraper restarts."
+      "description": "Physical CPU cores on the host."
     },
     {
+      "id": 12,
+      "title": "Host CPU",
+      "type": "gauge",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 2,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -105,8 +106,6 @@
             "mode": "thresholds"
           },
           "mappings": [],
-          "max": 1,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -116,29 +115,24 @@
               },
               {
                 "color": "yellow",
-                "value": 0.8
+                "value": 50
               },
               {
                 "color": "red",
-                "value": 0.9
+                "value": 80
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
-      "id": 8,
       "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -147,9 +141,9 @@
           "fields": "",
           "values": false
         },
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
       "targets": [
         {
@@ -157,20 +151,27 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "1 - (max(node_memory_MemAvailable_bytes{job=\"integrations/unix\"}) / max(node_memory_MemTotal_bytes{job=\"integrations/unix\"}))",
+          "expr": "(1 - avg(rate(node_cpu_seconds_total{mode=\"idle\",job=\"integrations/unix\"}[5m]))) * 100",
           "instant": true,
-          "refId": "A",
-          "legendFormat": ""
+          "legendFormat": "",
+          "refId": "A"
         }
       ],
-      "title": "Host RAM %",
-      "type": "stat",
-      "description": "max() deduplicates across scraper instance labels. textMode=value hides raw label text."
+      "description": "avg() collapses duplicate series from scraper restarts."
     },
     {
+      "id": 13,
+      "title": "Host RAM",
+      "type": "gauge",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 5,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -178,10 +179,8 @@
             "mode": "thresholds"
           },
           "mappings": [],
-          "max": 1,
-          "min": 0,
           "thresholds": {
-            "mode": "absolute",
+            "mode": "percentage",
             "steps": [
               {
                 "color": "green",
@@ -189,29 +188,24 @@
               },
               {
                 "color": "yellow",
-                "value": 0.7
+                "value": 70
               },
               {
                 "color": "red",
-                "value": 0.8
+                "value": 85
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "bytes",
+          "min": 0,
+          "max": 16541065216,
+          "decimals": 1
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 0
-      },
-      "id": 9,
       "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -220,9 +214,9 @@
           "fields": "",
           "values": false
         },
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
       "targets": [
         {
@@ -230,20 +224,100 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "1 - (max(node_filesystem_avail_bytes{mountpoint=\"/\",job=\"integrations/unix\"}) / max(node_filesystem_size_bytes{mountpoint=\"/\",job=\"integrations/unix\"}))",
+          "expr": "max(node_memory_MemTotal_bytes{job=\"integrations/unix\"}) - max(node_memory_MemAvailable_bytes{job=\"integrations/unix\"})",
           "instant": true,
-          "refId": "A",
-          "legendFormat": ""
+          "legendFormat": "",
+          "refId": "A"
         }
       ],
-      "title": "Disk Usage %",
-      "type": "stat",
-      "description": "max() deduplicates across scraper instance labels. textMode=value hides raw label text."
+      "description": "Used bytes with gauge bar showing % of 16 GB total. max() deduplicates across scraper instances."
     },
     {
+      "id": 14,
+      "title": "Disk",
+      "type": "gauge",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0,
+          "max": 500332396544,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(node_filesystem_size_bytes{mountpoint=\"/\",job=\"integrations/unix\"}) - max(node_filesystem_avail_bytes{mountpoint=\"/\",job=\"integrations/unix\"})",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Used bytes with gauge bar showing % of 466 GB total. max() deduplicates across scraper instances."
+    },
+    {
+      "id": 15,
+      "title": "Uptime",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 11,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -265,15 +339,8 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "id": 10,
       "options": {
-        "colorMode": "background",
+        "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
@@ -296,18 +363,25 @@
           },
           "expr": "max(time() - node_boot_time_seconds{job=\"integrations/unix\"})",
           "instant": true,
-          "refId": "A",
-          "legendFormat": ""
+          "legendFormat": "",
+          "refId": "A"
         }
       ],
-      "title": "Host Uptime",
-      "type": "stat",
-      "description": "max() deduplicates across scraper instance labels. textMode=value hides raw label text."
+      "description": "max() deduplicates across scraper instance labels."
     },
     {
+      "id": 16,
+      "title": "Containers",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 14,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -329,13 +403,6 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 0,
-        "y": 4
-      },
-      "id": 1,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -360,17 +427,25 @@
           },
           "expr": "count(max by (name) (container_memory_working_set_bytes{job=\"docker\",name!=\"\"}))",
           "instant": true,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Containers",
-      "type": "stat",
       "description": "max by (name) collapses duplicate series when the Alloy scraper container is recreated."
     },
     {
+      "id": 17,
+      "title": "Ctr CPU",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -392,13 +467,6 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 8,
-        "y": 4
-      },
-      "id": 2,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -423,16 +491,24 @@
           },
           "expr": "sum(max by (name) (rate(container_cpu_usage_seconds_total{job=\"docker\",name!=\"\"}[5m]))) * 100",
           "instant": true,
+          "legendFormat": "",
           "refId": "A"
         }
-      ],
-      "title": "Total CPU",
-      "type": "stat"
+      ]
     },
     {
+      "id": 18,
+      "title": "Ctr RAM",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -445,31 +521,15 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "purple",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 11274289152
-              },
-              {
-                "color": "red",
-                "value": 12884901888
               }
             ]
           },
-          "unit": "bytes",
-          "max": null
+          "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 16,
-        "y": 4
-      },
-      "id": 3,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -494,11 +554,11 @@
           },
           "expr": "sum(max by (name) (container_memory_working_set_bytes{job=\"docker\",name!=\"\"}))",
           "instant": true,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Container RAM",
-      "type": "stat"
+      "description": "max by (name) collapses duplicate series from scraper restarts."
     },
     {
       "datasource": {
@@ -674,7 +734,7 @@
         "h": 14,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 4
       },
       "id": 4,
       "options": {
@@ -881,7 +941,7 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "(.+)-\\d+$",
+            "regex": "(.+)-1$",
             "renamePattern": "$1"
           }
         }
@@ -983,7 +1043,7 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "(.+)-\\d+$",
+            "regex": "(.+)-1$",
             "renamePattern": "$1"
           }
         }


### PR DESCRIPTION
## Changes

### Dashboard: single stats row with gauges

Merge 7 stat panels (2 rows, h=8) into a single row of 8 panels (h=4):

```
┌───────┬──────────┬──────────┬───────────┬─────────┬────────┬──────┬──────┐
│ 4     │ CPU 12%  │ 3.2 GB   │ 210 GB    │  2mo    │  13    │ 8%   │1.7GB │
│ cores │ ████░░░░ │ ██░░░░░░ │ █████░░░░ │ uptime  │ contrs │ctr   │ctr   │
└───────┴──────────┴──────────┴───────────┴─────────┴────────┴──────┴──────┘
  stat     gauge      gauge      gauge      stat     stat    stat   stat
```

- **Gauge panels** for CPU/RAM/Disk show precise value + visual fill bar with threshold coloring
- RAM gauge: shows used bytes (e.g. "3.2 GB") with bar at % of 16 GB total
- Disk gauge: shows used bytes with bar at % of 466 GB total
- Saves 4 grid units of vertical space for the table and graphs below

### Container name regex fix

Changed `(.+)-\d+$` to `(.+)-1$` in timeseries legend transforms. The old regex stripped all trailing numbers, losing meaningful identifiers like `worker-implement-141` (issue number). The new regex only strips the Compose replica suffix (`-1`).

### Observability docs audit

- Fix wrong job label: `job="node"` → `job="integrations/unix"` (Alloy overrides the configured `job_name`)
- Add Agent Tasks dashboard to dashboard list
- Document provisioning constraints (can't API-save provisioned dashboards)
- Document dedup pattern (`max()`/`max by (name)`) and why it's needed
- Document datasource UID pinning and the Grafana DB constraint
- Update README dashboard list

Already verified live on the server.