### PR TITLE
fix: address review findings on knowledge ingestion

### DIFF
--- a/stacks/knowledge/app/knowledge/__main__.py
+++ b/stacks/knowledge/app/knowledge/__main__.py
@@ -19,6 +19,9 @@ def main() -> None:
     ingest_parser.add_argument("--path", type=Path, help="File to ingest (.md or .txt)")
     ingest_parser.add_argument("--text", help="Raw text to ingest")
     ingest_parser.add_argument("--title", help="Title for raw text (required with --text)")
+    ingest_parser.add_argument(
+        "--source-id", help="Stable ID for text notes (disambiguates duplicate titles)"
+    )
 
     args = parser.parse_args()
 
@@ -46,7 +49,9 @@ def _handle_ingest(args: argparse.Namespace) -> None:
             sys.exit(1)
         result = ingest_file(path, workspace=args.workspace)
     else:
-        result = ingest_text(args.text, title=args.title, workspace=args.workspace)
+        result = ingest_text(
+            args.text, title=args.title, workspace=args.workspace, source_id=args.source_id
+        )
 
     print(json.dumps(result.model_dump(mode="json"), indent=2))
 

--- a/stacks/knowledge/app/knowledge/database.py
+++ b/stacks/knowledge/app/knowledge/database.py
@@ -43,7 +43,10 @@ def create_workspace(conn: DatabaseConnection, workspace: Workspace) -> Workspac
             INSERT INTO workspaces (name, description)
             VALUES (%s, %s)
             ON CONFLICT (name) DO UPDATE
-            SET description = EXCLUDED.description
+            SET description = CASE
+                WHEN EXCLUDED.description = '' THEN workspaces.description
+                ELSE EXCLUDED.description
+            END
             RETURNING name, description, created_at
             """,
             (workspace.name, workspace.description),

--- a/stacks/knowledge/app/knowledge/embeddings.py
+++ b/stacks/knowledge/app/knowledge/embeddings.py
@@ -10,10 +10,8 @@ from .models import EMBEDDING_DIMENSION
 
 logger = logging.getLogger(__name__)
 
-GITHUB_MODELS_URL = (
-    "https://models.github.ai/inference/openai/deployments/text-embedding-3-large/embeddings"
-)
-MODEL_NAME = "text-embedding-3-large"
+GITHUB_MODELS_URL = "https://models.github.ai/inference/embeddings"
+MODEL_NAME = "openai/text-embedding-3-large"
 TOKEN_ENV = "GITHUB_TOKEN"
 
 _MAX_RETRIES = 3

--- a/stacks/knowledge/app/knowledge/ingest.py
+++ b/stacks/knowledge/app/knowledge/ingest.py
@@ -48,14 +48,22 @@ def ingest_text(
     *,
     title: str,
     workspace: str,
+    source_id: str | None = None,
     conn: DatabaseConnection | None = None,
     token: str | None = None,
 ) -> IngestResult:
-    """Ingest raw text as a document."""
+    """Ingest raw text as a document.
+
+    *source_id* disambiguates notes with the same title. When omitted the
+    content hash is used, so identical titles with different content won't
+    collide.
+    """
+    content_hash = hashlib.sha256(text.encode()).hexdigest()
+    key = source_id or content_hash[:12]
     return _ingest(
         content=text,
         title=title,
-        source_path=f"text://{title}",
+        source_path=f"text://{title}/{key}",
         workspace=workspace,
         conn=conn,
         token=token,
@@ -119,10 +127,21 @@ def _do_ingest(
     chunks_text = chunk_text(content)
     if not chunks_text:
         logger.warning("No chunks produced from: %s", source_path)
+        # Still update the document and delete stale chunks so search
+        # doesn't return content from a previous version.
+        if existing:
+            doc = Document(
+                workspace=workspace,
+                source_path=source_path,
+                title=title,
+                content_hash=content_hash,
+            )
+            saved_doc = upsert_document(conn, doc)
+            delete_document_chunks(conn, saved_doc)
         conn.commit()
         return IngestResult(
             workspace=workspace,
-            documents_processed=1,
+            documents_processed=1 if existing else 0,
             chunks_created=0,
             documents_skipped=0,
         )

--- a/stacks/knowledge/app/tests/test_embeddings.py
+++ b/stacks/knowledge/app/tests/test_embeddings.py
@@ -4,6 +4,8 @@ import httpx
 import pytest
 
 from knowledge.embeddings import (
+    GITHUB_MODELS_URL,
+    MODEL_NAME,
     TOKEN_ENV,
     _parse_response,
     get_embeddings,
@@ -36,8 +38,11 @@ def test_get_embeddings_calls_api(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(result) == 2
     assert len(result[0]) == EMBEDDING_DIMENSION
     mock_post.assert_called_once()
-    call_kwargs = mock_post.call_args
-    assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer test-token"
+    call_args = mock_post.call_args
+    assert call_args.kwargs["headers"]["Authorization"] == "Bearer test-token"
+    # Verify correct GitHub Models endpoint and model ID
+    assert call_args.args[0] == GITHUB_MODELS_URL
+    assert call_args.kwargs["json"]["model"] == MODEL_NAME
 
 
 def test_get_embeddings_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/stacks/knowledge/app/tests/test_ingest.py
+++ b/stacks/knowledge/app/tests/test_ingest.py
@@ -179,7 +179,91 @@ def test_ingest_text_uses_text_uri(
     # Assert
     assert result.documents_processed == 1
     call_args = mock_upsert.call_args[0]
-    assert call_args[1].source_path == "text://Quick Note"
+    assert call_args[1].source_path.startswith("text://Quick Note/")
+
+
+@patch("knowledge.ingest.connect")
+@patch("knowledge.ingest.get_embeddings", side_effect=_fake_embeddings)
+@patch("knowledge.ingest.insert_chunks", return_value=[])
+@patch("knowledge.ingest.upsert_document")
+@patch("knowledge.ingest.delete_document_chunks")
+@patch("knowledge.ingest.create_workspace")
+@patch("knowledge.ingest.get_document_by_source", return_value=None)
+def test_ingest_text_different_content_same_title_no_collision(
+    mock_get_source: MagicMock,
+    mock_create_ws: MagicMock,
+    mock_delete: MagicMock,
+    mock_upsert: MagicMock,
+    mock_insert: MagicMock,
+    mock_embed: MagicMock,
+    mock_connect: MagicMock,
+) -> None:
+    """Two text ingests with same title but different content get different source_paths."""
+    # Arrange
+    mock_connect.return_value = _fake_connect()
+    saved = Document(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        workspace="notes",
+        source_path="text://Note/abc",
+        title="Note",
+        content_hash="abc",
+    )
+    mock_upsert.return_value = saved
+
+    # Act
+    ingest_text("Content A", title="Note", workspace="notes")
+    path_a = mock_upsert.call_args[0][1].source_path
+
+    ingest_text("Content B", title="Note", workspace="notes")
+    path_b = mock_upsert.call_args[0][1].source_path
+
+    # Assert — different content hashes produce different source paths
+    assert path_a != path_b
+    assert path_a.startswith("text://Note/")
+    assert path_b.startswith("text://Note/")
+
+
+@patch("knowledge.ingest.connect")
+@patch("knowledge.ingest.get_embeddings", side_effect=_fake_embeddings)
+@patch("knowledge.ingest.insert_chunks", return_value=[])
+@patch("knowledge.ingest.upsert_document")
+@patch("knowledge.ingest.delete_document_chunks")
+@patch("knowledge.ingest.create_workspace")
+@patch("knowledge.ingest.get_document_by_source")
+def test_zero_chunks_on_reingest_deletes_stale_data(
+    mock_get_source: MagicMock,
+    mock_create_ws: MagicMock,
+    mock_delete: MagicMock,
+    mock_upsert: MagicMock,
+    mock_insert: MagicMock,
+    mock_embed: MagicMock,
+    mock_connect: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Re-ingesting a file that produces zero chunks should delete old chunks."""
+    # Arrange — file with only a heading (chunker returns [])
+    test_file = tmp_path / "empty.md"
+    test_file.write_text("# Just A Heading")
+
+    existing = Document(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        workspace="notes",
+        source_path=str(test_file),
+        title="Old",
+        content_hash="old-hash",
+    )
+    mock_connect.return_value = _fake_connect()
+    mock_get_source.return_value = existing
+    mock_upsert.return_value = existing
+
+    # Act
+    result = ingest_file(test_file, workspace="notes")
+
+    # Assert — stale chunks cleaned up, no embeddings requested
+    assert result.documents_processed == 1
+    assert result.chunks_created == 0
+    mock_delete.assert_called_once()
+    mock_embed.assert_not_called()
 
 
 def test_title_from_markdown_heading(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes 4 issues identified by GPT-5.4 code review of #166.

### 1. Wrong embedding API endpoint (High)
- **Was:** Azure-style deployment URL `/inference/openai/deployments/.../embeddings`
- **Now:** Documented GitHub Models endpoint `/inference/embeddings` with qualified model ID `openai/text-embedding-3-large`
- Added contract test asserting URL and model name

### 2. Zero-chunk re-ingest leaves stale data (High)
- **Was:** If a previously-ingested file produces 0 chunks (e.g. edited to just headings), old chunks stayed searchable
- **Now:** Deletes stale chunks and updates document row on zero-chunk re-ingest
- Added test `test_zero_chunks_on_reingest_deletes_stale_data`

### 3. Text title collision (High)
- **Was:** `text://Title` as source_path — same title overwrites previous note
- **Now:** `text://Title/hash12` — content-hash suffix prevents collision. Optional `--source-id` for stable keys
- Added test `test_ingest_text_different_content_same_title_no_collision`

### 4. Workspace description wiped on ingest (Medium)
- **Was:** `ON CONFLICT DO UPDATE SET description = EXCLUDED.description` — default empty string overwrote real descriptions
- **Now:** Preserves existing description when the incoming one is empty

### Tests
30 total (2 new: title collision, zero-chunk re-ingest). All pass.