### PR TITLE
fix: bump yamllint line-length to 150 for digest-pinned images

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -2,7 +2,7 @@ extends: default
 
 rules:
   line-length:
-    max: 120
+    max: 150
   truthy:
     check-keys: false
   comments:


### PR DESCRIPTION
Docker digest pinning (`pinDigests: true` from #167) appends `@sha256:...` to image tags, pushing compose image lines to ~130-140 chars. The previous 120-char limit breaks CI on every Renovate digest pin PR (#172).

Bumps the yamllint line-length max from 120 → 150.