### PR TITLE
fix: deploy resets to origin/main instead of ff-only pull

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,7 +47,8 @@ jobs:
           ALL_SECRETS: ${{ toJson(secrets) }}
         run: |
           cd /home/colin/code/homelab
-          git pull --ff-only
+          git fetch origin main
+          git reset --hard origin/main
           scripts/generate-env.sh
           scripts/deploy.sh
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,8 @@ else
 fi
 
 cd "$(dirname "$0")/.."
-git pull --ff-only
+git fetch origin main
+git reset --hard origin/main
 
 install_timer() {
   local unit_base="$1"


### PR DESCRIPTION
## Problem

`git pull --ff-only` fails when there are local edits on beelink (e.g. testing Grafana dashboards directly). This blocks deploys until someone SSHs in and manually resets.

## Fix

Replace `git pull --ff-only` with `git fetch origin main && git reset --hard origin/main` in both:
- `.github/workflows/deploy.yaml` (line 50)
- `scripts/deploy.sh` (line 16)

## Why this is safe

- **Repo is the single source of truth** — local edits are debugging artifacts, not config
- **Secrets (`.env`)** are generated from GitHub secrets at deploy time, gitignored — never overwritten
- **Docker volumes** (persistent data in `stacks/*/data/`) are outside the git tree — untouched
- **The deploy trigger is push-to-main** — intent is always "make server match repo"