### PR TITLE
fix: quote .env values and source for sync script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -38,6 +38,8 @@ for stack in "${stacks[@]}"; do
   case "$stack" in
     agents)         docker compose -f "$file" up -d --build --remove-orphans ;;
     observability)  docker compose -f "$file" up -d --remove-orphans
+                    # Source .env for sync script (generate-env.sh exports don't propagate)
+                    set -a; source "stacks/observability/.env"; set +a
                     scripts/sync-dashboards.sh ;;
     flight-tracker) docker compose -f "$file" pull
                     docker compose -f "$file" up -d --remove-orphans

--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -25,5 +25,6 @@ for stack in "${stacks[@]}"; do
   example="stacks/${stack}/.env.example"
   [[ -f "$example" ]] || continue
   vars=$(grep -oP '\$\{[A-Z_]+\}' "$example" | sort -u | tr '\n' ' ')
-  envsubst "$vars" < "$example" > "stacks/${stack}/.env"
+  # Single-quote values so docker compose doesn't interpolate $ in passwords
+  envsubst "$vars" < "$example" | sed "s/=\(.*\)/='\1'/" > "stacks/${stack}/.env"
 done


### PR DESCRIPTION
## Problem

Deploy fails at `sync-dashboards.sh` with:
```
GRAFANA_ADMIN_PASSWORD: Set GRAFANA_ADMIN_PASSWORD
```

Two root causes:

1. **generate-env.sh exports don't propagate** — it runs as a subprocess (has shebang), so `deploy.sh` never inherits the exported env vars
2. **$wvt in password gets interpolated** — the Grafana password contains `$wvt` which docker compose interprets as a variable reference, corrupting the value

## Fix

- **generate-env.sh**: Single-quote values in .env output so docker compose treats them literally
- **deploy.sh**: Source observability .env before running sync-dashboards.sh