### PR TITLE
fix: enable auto-merge for uv minor/patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -61,10 +61,11 @@
       "automerge": false
     },
     {
-      "description": "Group uv updates across mise.toml and Dockerfile",
+      "description": "Group uv updates across mise.toml and Dockerfile — drift check guards correctness",
       "groupName": "uv",
       "matchDepPatterns": ["^uv$", "astral-sh/uv"],
-      "automerge": false
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
     },
     {
       "description": "Major updates always require manual review",


### PR DESCRIPTION
The uv group rule had `automerge: false` because it touches the Dockerfile. Now that we have:

- **Grouping fix** (#182) — `matchDepPatterns` ensures both mise.toml and Dockerfile update together
- **Drift check** (`check-versions.sh`) — CI fails if versions diverge

It's safe to auto-merge uv minor/patch. Major updates still require manual review.