### PR TITLE
fix: use actual .env var names in ingest-notes.sh

### DIFF
--- a/scripts/ingest-notes.sh
+++ b/scripts/ingest-notes.sh
@@ -20,7 +20,7 @@ load_env_file() {
 load_env_file "$KNOWLEDGE_ENV_FILE"
 load_env_file "$AGENTS_ENV_FILE"
 
-export KNOWLEDGE_DB_URL="${KNOWLEDGE_DB_URL:-postgresql://knowledge:${KNOWLEDGE_DB_PASSWORD:?}@localhost:5432/knowledge}"
+export KNOWLEDGE_DB_URL="${KNOWLEDGE_DB_URL:-postgresql://${POSTGRES_USER:?}:${POSTGRES_PASSWORD:?}@localhost:5432/${POSTGRES_DB:?}}"
 : "${COPILOT_GITHUB_TOKEN:?COPILOT_GITHUB_TOKEN must be set}"
 
 cd "$NOTES_DIR"


### PR DESCRIPTION
The knowledge stack .env uses POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB (the standard Postgres container vars), not KNOWLEDGE_DB_PASSWORD. The ingest script was failing with `KNOWLEDGE_DB_PASSWORD: parameter null or not set`.

Found during e2e testing of the auto-ingest workflow on ColinCee/notes.