### PR TITLE
fix: use Tailscale IP for knowledge DB in ingest script

### DIFF
--- a/scripts/ingest-notes.sh
+++ b/scripts/ingest-notes.sh
@@ -22,7 +22,7 @@ load_env_file "$AGENTS_ENV_FILE"
 
 if [[ -z "${KNOWLEDGE_DB_URL:-}" ]]; then
   encoded_password=$(printf '%s' "${POSTGRES_PASSWORD:?}" | python3 -c "import sys; from urllib.parse import quote; print(quote(sys.stdin.read(), safe=''))")
-  export KNOWLEDGE_DB_URL="postgresql://${POSTGRES_USER:?}:${encoded_password}@localhost:5432/${POSTGRES_DB:?}"
+  export KNOWLEDGE_DB_URL="postgresql://${POSTGRES_USER:?}:${encoded_password}@${TAILSCALE_IP:?}:5432/${POSTGRES_DB:?}"
 fi
 : "${COPILOT_GITHUB_TOKEN:?COPILOT_GITHUB_TOKEN must be set}"
 


### PR DESCRIPTION
Knowledge Postgres binds to Tailscale IP, not localhost. Use TAILSCALE_IP from agents .env.