### PR TITLE
feat(knowledge): support PDF ingestion via pypdf

### DIFF
--- a/stacks/knowledge/app/knowledge/ingest.py
+++ b/stacks/knowledge/app/knowledge/ingest.py
@@ -23,8 +23,8 @@ from .models import Chunk, DirectoryIngestResult, Document, IngestResult
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIRECTORY_GLOB = "**/*.md"
-_DEFAULT_DIRECTORY_EXTRA_GLOBS = ("**/*.txt",)
-_INGESTIBLE_SUFFIXES = frozenset({".md", ".txt"})
+_DEFAULT_DIRECTORY_EXTRA_GLOBS = ("**/*.txt", "**/*.pdf")
+_INGESTIBLE_SUFFIXES = frozenset({".md", ".txt", ".pdf"})
 
 
 def ingest_file(
@@ -34,7 +34,7 @@ def ingest_file(
     token: str | None = None,
 ) -> IngestResult:
     """Ingest a single file into the knowledge base."""
-    content = path.read_text(encoding="utf-8")
+    content = _read_file_content(path)
     title = _title_from_file(path, content)
     source_path = str(path)
     return _ingest(
@@ -317,6 +317,22 @@ def _delete_orphaned_documents(
 
 def _source_prefix_for_directory(directory: Path) -> str:
     return f"{directory.as_posix().rstrip('/')}/"
+
+
+def _read_file_content(path: Path) -> str:
+    """Read file content, extracting text from PDFs."""
+    if path.suffix.lower() == ".pdf":
+        return _extract_pdf_text(path)
+    return path.read_text(encoding="utf-8")
+
+
+def _extract_pdf_text(path: Path) -> str:
+    """Extract text from a PDF using pypdf."""
+    from pypdf import PdfReader
+
+    reader = PdfReader(path)
+    pages = [page.extract_text() or "" for page in reader.pages]
+    return "\n\n".join(page for page in pages if page.strip())
 
 
 def _title_from_file(path: Path, content: str) -> str:

--- a/stacks/knowledge/app/knowledge/ingest.py
+++ b/stacks/knowledge/app/knowledge/ingest.py
@@ -35,12 +35,14 @@ def ingest_file(
 ) -> IngestResult:
     """Ingest a single file into the knowledge base."""
     content = _read_file_content(path)
+    content_hash = _file_content_hash(path)
     title = _title_from_file(path, content)
     source_path = str(path)
     return _ingest(
         content=content,
         title=title,
         source_path=source_path,
+        content_hash=content_hash,
         conn=conn,
         token=token,
     )
@@ -102,8 +104,10 @@ def _ingest(
     source_path: str,
     conn: DatabaseConnection | None,
     token: str | None,
+    content_hash: str | None = None,
 ) -> IngestResult:
-    content_hash = hashlib.sha256(content.encode()).hexdigest()
+    if content_hash is None:
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
     own_conn = conn is None
     db = conn or connect()
 
@@ -317,6 +321,11 @@ def _delete_orphaned_documents(
 
 def _source_prefix_for_directory(directory: Path) -> str:
     return f"{directory.as_posix().rstrip('/')}/"
+
+
+def _file_content_hash(path: Path) -> str:
+    """Hash raw file bytes for change detection (catches binary-only PDF changes)."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _read_file_content(path: Path) -> str:

--- a/stacks/knowledge/app/pyproject.toml
+++ b/stacks/knowledge/app/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pgvector>=0.4",
     "pydantic>=2",
     "psycopg[binary]>=3.2",
+    "pypdf>=5",
 ]
 
 [dependency-groups]

--- a/stacks/knowledge/app/tests/test_ingest.py
+++ b/stacks/knowledge/app/tests/test_ingest.py
@@ -8,7 +8,14 @@ from uuid import UUID
 import pytest
 
 from knowledge import __main__ as cli
-from knowledge.ingest import _title_from_file, ingest_directory, ingest_file, ingest_text
+from knowledge.ingest import (
+    _extract_pdf_text,
+    _read_file_content,
+    _title_from_file,
+    ingest_directory,
+    ingest_file,
+    ingest_text,
+)
 from knowledge.models import EMBEDDING_DIMENSION, DirectoryIngestResult, Document, IngestResult
 
 
@@ -530,3 +537,93 @@ def test_title_from_markdown_heading(tmp_path: Path) -> None:
 def test_title_from_filename(tmp_path: Path) -> None:
     path = tmp_path / "my-cool-doc.txt"
     assert _title_from_file(path, "plain text") == "My Cool Doc"
+
+
+def _create_test_pdf(path: Path, text: str = "Hello from PDF") -> None:
+    """Create a minimal PDF with text content for testing."""
+    content_stream = f"BT /F1 12 Tf 100 700 Td ({text}) Tj ET"
+    pdf_bytes = (
+        b"%PDF-1.4\n"
+        b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+        b"/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n"
+        b"4 0 obj<</Length " + str(len(content_stream)).encode() + b">>\n"
+        b"stream\n" + content_stream.encode() + b"\nendstream\nendobj\n"
+        b"5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n"
+        b"xref\n0 6\n"
+        b"0000000000 65535 f \n"
+        b"0000000009 00000 n \n"
+        b"0000000058 00000 n \n"
+        b"0000000115 00000 n \n"
+        b"0000000266 00000 n \n"
+        b"0000000000 00000 n \n"
+        b"trailer<</Size 6/Root 1 0 R>>\n"
+        b"startxref\n0\n%%EOF"
+    )
+    path.write_bytes(pdf_bytes)
+
+
+def test_extract_pdf_text(tmp_path: Path) -> None:
+    """PDF text extraction returns page content."""
+    pdf_path = tmp_path / "test.pdf"
+    _create_test_pdf(pdf_path, "Sample document text")
+    result = _extract_pdf_text(pdf_path)
+    assert "Sample document text" in result
+
+
+def test_read_file_content_pdf(tmp_path: Path) -> None:
+    """_read_file_content dispatches to PDF extraction for .pdf files."""
+    pdf_path = tmp_path / "test.pdf"
+    _create_test_pdf(pdf_path, "PDF content here")
+    result = _read_file_content(pdf_path)
+    assert "PDF content here" in result
+
+
+def test_read_file_content_markdown(tmp_path: Path) -> None:
+    """_read_file_content reads text files normally."""
+    md_path = tmp_path / "test.md"
+    md_path.write_text("# Hello\n\nWorld")
+    result = _read_file_content(md_path)
+    assert result == "# Hello\n\nWorld"
+
+
+@patch("knowledge.ingest.connect")
+@patch("knowledge.ingest.get_embeddings", side_effect=_fake_embeddings)
+@patch("knowledge.ingest.insert_chunks", return_value=[])
+@patch("knowledge.ingest.upsert_document")
+@patch("knowledge.ingest.delete_document_chunks")
+@patch("knowledge.ingest.get_document_by_source", return_value=None)
+def test_ingest_pdf_file(
+    mock_get_source: MagicMock,
+    mock_delete: MagicMock,
+    mock_upsert: MagicMock,
+    mock_insert: MagicMock,
+    mock_embed: MagicMock,
+    mock_connect: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Full ingest_file pipeline works for PDFs."""
+    mock_connect.return_value = _fake_connect()
+    saved_doc = Document(
+        id=UUID("00000000-0000-0000-0000-000000000002"),
+        source_path="test.pdf",
+        title="Test",
+        content_hash="abc",
+    )
+    mock_upsert.return_value = saved_doc
+
+    pdf_path = tmp_path / "test.pdf"
+    _create_test_pdf(pdf_path, "Ingestible PDF content")
+
+    result = ingest_file(pdf_path)
+
+    assert isinstance(result, IngestResult)
+    assert result.documents_processed == 1
+    mock_embed.assert_called_once()
+
+
+def test_title_from_pdf_uses_filename(tmp_path: Path) -> None:
+    """PDF titles use filename since there's no markdown heading."""
+    path = tmp_path / "uk261-regulation.pdf"
+    assert _title_from_file(path, "some extracted text") == "Uk261 Regulation"

--- a/stacks/knowledge/app/tests/test_ingest.py
+++ b/stacks/knowledge/app/tests/test_ingest.py
@@ -10,6 +10,7 @@ import pytest
 from knowledge import __main__ as cli
 from knowledge.ingest import (
     _extract_pdf_text,
+    _file_content_hash,
     _read_file_content,
     _title_from_file,
     ingest_directory,
@@ -627,3 +628,22 @@ def test_title_from_pdf_uses_filename(tmp_path: Path) -> None:
     """PDF titles use filename since there's no markdown heading."""
     path = tmp_path / "uk261-regulation.pdf"
     assert _title_from_file(path, "some extracted text") == "Uk261 Regulation"
+
+
+def test_pdf_hash_uses_raw_bytes(tmp_path: Path) -> None:
+    """PDF change detection hashes raw bytes, not extracted text.
+
+    A PDF with different bytes but identical extracted text must produce
+    a different hash so re-ingestion is triggered.
+    """
+    pdf_a = tmp_path / "a.pdf"
+    pdf_b = tmp_path / "b.pdf"
+    _create_test_pdf(pdf_a, "Same text")
+    _create_test_pdf(pdf_b, "Same text")
+
+    # Append garbage bytes to pdf_b — extracted text is unchanged
+    with pdf_b.open("ab") as f:
+        f.write(b"\x00" * 64)
+
+    assert _extract_pdf_text(pdf_a) == _extract_pdf_text(pdf_b)
+    assert _file_content_hash(pdf_a) != _file_content_hash(pdf_b)

--- a/stacks/knowledge/app/uv.lock
+++ b/stacks/knowledge/app/uv.lock
@@ -59,6 +59,7 @@ dependencies = [
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
+    { name = "pypdf" },
 ]
 
 [package.dev-dependencies]
@@ -74,6 +75,7 @@ requires-dist = [
     { name = "pgvector", specifier = ">=0.4" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2" },
+    { name = "pypdf", specifier = ">=5" },
 ]
 
 [package.metadata.requires-dev]
@@ -286,6 +288,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/3f/9f2167401c2e94833ca3b69535bad89e533b5de75fefe4197a2c224baec2/pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d", size = 5315679, upload-time = "2026-04-15T16:37:36.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d6/1d5c60cc17bbdf37c1552d9c03862fc6d32c5836732a0415b2d637edc2d0/pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa", size = 336308, upload-time = "2026-04-15T16:37:34.851Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds PDF text extraction to the knowledge base ingest pipeline. PDFs are now first-class citizens alongside markdown and plain text.

## Changes

- Added `pypdf>=5` dependency
- Added `.pdf` to `_INGESTIBLE_SUFFIXES` and directory glob patterns
- `_read_file_content()` dispatches to `_extract_pdf_text()` for PDF files
- `_extract_pdf_text()` uses pypdf's `PdfReader` to extract text page-by-page
- Tests: 5 new tests covering extraction, dispatch, full pipeline, and title derivation

## Why pypdf

- Pure Python — no system dependencies or C compilation needed in Docker
- Lightweight (single dep, no pdfminer/poppler/tesseract)
- Handles our PDFs perfectly: court filings (7KB extracted), invoices (1.3KB), regulation text, EDF vulnerability diagrams
- Recommended by the Anthropic PDF skill for basic text extraction

## Tested against real PDFs

```
projects/flight-compensation/documents/KLMinvoice24122025.pdf → 1,276 chars
projects/flight-compensation/documents/695ff7fe...Determination.pdf → 7,247 chars
areas/edf/images/Kraken Live Vulnerability Journey.pdf → 1,324 chars
```

All extract cleanly with zero configuration.

Closes #204