### PR TITLE
feat(knowledge): longer excerpts + RRF hybrid search

### DIFF
--- a/.github/skills/knowledge-search/SKILL.md
+++ b/.github/skills/knowledge-search/SKILL.md
@@ -7,7 +7,7 @@ user-invocable: true
 
 # Knowledge Base Search
 
-You have access to a personal knowledge base containing ~190 markdown documents — work notes, coding references, system design studies, side project docs, and daily notes. Use it to ground your answers in the user's own writing.
+You have access to a personal knowledge base containing markdown documents and PDFs — work notes, coding references, system design studies, side project docs, and more. Use it to ground your answers in the user's own writing.
 
 ## How to search
 
@@ -25,16 +25,16 @@ The command takes ~5 seconds (container startup + embedding + vector search).
 
 ## Reading the output
 
-Results are ranked by cosine similarity score (0–1, higher = more relevant):
+Results are ranked by relevance using hybrid search (combines semantic similarity with keyword matching). Higher scores = more relevant:
 
 ```
-1. score=0.603 source=/notes/Coding/System Design/Practice/Design a rate limiter.md chunk=0
+1. score=0.031 source=/notes/Coding/System Design/Practice/Design a rate limiter.md chunk=0
    --- title: Scalable Rate Limiter Design tags: ...
 ```
 
 - `source` — the note's file path (under `/notes/`)
 - `chunk` — which section of the document matched
-- The excerpt is truncated to 200 chars — if you need the full content, read the file
+- Excerpts show up to ~2000 chars of chunk content
 
 ## Reading full note content
 
@@ -66,5 +66,5 @@ ssh beelink "cat '/home/colin/code/notes/Coding/System Design/Practice/Design a 
 
 - Search queries work best as natural language questions or topic descriptions, not keywords
 - Try multiple searches with different phrasings if the first doesn't return good results
-- Scores below 0.35 are usually noise — don't cite those results
+- Results are ranked by Reciprocal Rank Fusion — absolute score values are small (~0.01–0.03) but ordering is meaningful
 - The knowledge base is updated on every push to the notes repo (automated pipeline)

--- a/stacks/knowledge/app/knowledge/__main__.py
+++ b/stacks/knowledge/app/knowledge/__main__.py
@@ -7,6 +7,7 @@ import json
 import sys
 from pathlib import Path
 
+from .database import connect, run_migrations
 from .ingest import DEFAULT_DIRECTORY_GLOB, ingest_directory, ingest_file, ingest_text
 from .search import DEFAULT_RESULT_LIMIT, format_search_results, search
 
@@ -39,6 +40,10 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    db = connect()
+    run_migrations(db)
+    db.close()
 
     if args.command == "ingest":
         _handle_ingest(args)

--- a/stacks/knowledge/app/knowledge/database.py
+++ b/stacks/knowledge/app/knowledge/database.py
@@ -38,6 +38,18 @@ def connect(db_url: str | None = None) -> DatabaseConnection:
     return connection
 
 
+def run_migrations(conn: DatabaseConnection) -> None:
+    """Run schema migrations. Safe to call repeatedly (idempotent)."""
+    with _cursor(conn) as cursor:
+        cursor.execute("""
+            ALTER TABLE chunks
+                ADD COLUMN IF NOT EXISTS tsv tsvector
+                GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS chunks_tsv_idx ON chunks USING gin (tsv)")
+    conn.commit()
+
+
 def upsert_document(conn: DatabaseConnection, document: Document) -> Document:
     with _cursor(conn) as cursor:
         cursor.execute(
@@ -115,12 +127,24 @@ def search_chunks(
     query_embedding: list[float],
     *,
     limit: int = 10,
+    query_text: str = "",
 ) -> list[SearchResult]:
     if limit <= 0:
         raise ValueError("limit must be greater than zero")
 
     normalized_embedding = normalize_embedding(query_embedding)
 
+    if query_text.strip():
+        return _hybrid_search(conn, normalized_embedding, query_text, limit)
+    return _vector_search(conn, normalized_embedding, limit)
+
+
+def _vector_search(
+    conn: DatabaseConnection,
+    embedding: list[float],
+    limit: int,
+) -> list[SearchResult]:
+    """Pure vector similarity search."""
     with _cursor(conn) as cursor:
         cursor.execute(
             """
@@ -143,7 +167,81 @@ def search_chunks(
             ORDER BY c.embedding <=> %s::vector
             LIMIT %s
             """,
-            (normalized_embedding, normalized_embedding, limit),
+            (embedding, embedding, limit),
+        )
+        rows = cursor.fetchall()
+
+    return [_search_result_from_row(row) for row in rows]
+
+
+_RRF_K = 60
+
+
+def _hybrid_search(
+    conn: DatabaseConnection,
+    embedding: list[float],
+    query_text: str,
+    limit: int,
+) -> list[SearchResult]:
+    """RRF hybrid: merge vector similarity and keyword (tsvector) rankings.
+
+    Uses websearch_to_tsquery for safe parsing of natural-language queries.
+    """
+    candidate_limit = limit * 3
+
+    with _cursor(conn) as cursor:
+        cursor.execute(
+            """
+            WITH vector_ranked AS (
+                SELECT c.id, ROW_NUMBER() OVER (ORDER BY c.embedding <=> %(emb)s::vector) AS rank_v
+                FROM chunks c
+                LIMIT %(candidates)s
+            ),
+            keyword_ranked AS (
+                SELECT c.id,
+                    ROW_NUMBER() OVER (
+                        ORDER BY ts_rank_cd(c.tsv, websearch_to_tsquery('english', %(tsq)s)) DESC
+                    ) AS rank_k
+                FROM chunks c
+                WHERE c.tsv @@ websearch_to_tsquery('english', %(tsq)s)
+                LIMIT %(candidates)s
+            ),
+            rrf AS (
+                SELECT
+                    COALESCE(v.id, k.id) AS chunk_id,
+                    COALESCE(1.0 / (%(k)s + v.rank_v), 0.0)
+                      + COALESCE(1.0 / (%(k)s + k.rank_k), 0.0) AS rrf_score
+                FROM vector_ranked v
+                FULL OUTER JOIN keyword_ranked k ON v.id = k.id
+                ORDER BY rrf_score DESC
+                LIMIT %(lim)s
+            )
+            SELECT
+                d.id AS document_id,
+                d.source_path AS document_source_path,
+                d.title AS document_title,
+                d.content_hash AS document_content_hash,
+                d.ingested_at AS document_ingested_at,
+                c.id AS chunk_id,
+                c.document_id AS chunk_document_id,
+                c.chunk_index AS chunk_chunk_index,
+                c.content AS chunk_content,
+                c.embedding AS chunk_embedding,
+                c.metadata AS chunk_metadata,
+                c.created_at AS chunk_created_at,
+                rrf.rrf_score AS score
+            FROM rrf
+            JOIN chunks c ON c.id = rrf.chunk_id
+            JOIN documents d ON d.id = c.document_id
+            ORDER BY rrf.rrf_score DESC
+            """,
+            {
+                "emb": embedding,
+                "tsq": query_text,
+                "k": _RRF_K,
+                "candidates": candidate_limit,
+                "lim": limit,
+            },
         )
         rows = cursor.fetchall()
 

--- a/stacks/knowledge/app/knowledge/search.py
+++ b/stacks/knowledge/app/knowledge/search.py
@@ -5,7 +5,7 @@ from .embeddings import get_embeddings
 from .models import SearchResult
 
 DEFAULT_RESULT_LIMIT = 5
-_EXCERPT_LENGTH = 200
+_EXCERPT_LENGTH = 2000
 
 
 def search(
@@ -24,7 +24,7 @@ def search(
 
     try:
         query_embedding = _embed_query(normalized_query, token=token)
-        return search_chunks(db, query_embedding, limit=limit)
+        return search_chunks(db, query_embedding, limit=limit, query_text=normalized_query)
     finally:
         if own_conn:
             db.close()

--- a/stacks/knowledge/app/tests/test_ingest.py
+++ b/stacks/knowledge/app/tests/test_ingest.py
@@ -443,6 +443,8 @@ def test_cli_ingest_directory_prints_summary(
         calls["token"] = token
         return expected
 
+    monkeypatch.setattr(cli, "connect", lambda: MagicMock())
+    monkeypatch.setattr(cli, "run_migrations", lambda conn: None)
     monkeypatch.setattr(cli, "ingest_directory", fake_ingest_directory)
     monkeypatch.setattr(
         sys,
@@ -477,6 +479,8 @@ def test_cli_rejects_glob_without_directory(
     # Arrange
     file_path = tmp_path / "note.md"
     file_path.write_text("# Note\n\nBody")
+    monkeypatch.setattr(cli, "connect", lambda: MagicMock())
+    monkeypatch.setattr(cli, "run_migrations", lambda conn: None)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -507,6 +511,8 @@ def test_cli_rejects_multiple_ingest_sources(
     file_path = tmp_path / "note.md"
     notes_dir.mkdir()
     file_path.write_text("# Note\n\nBody")
+    monkeypatch.setattr(cli, "connect", lambda: MagicMock())
+    monkeypatch.setattr(cli, "run_migrations", lambda conn: None)
     monkeypatch.setattr(
         sys,
         "argv",

--- a/stacks/knowledge/app/tests/test_search.py
+++ b/stacks/knowledge/app/tests/test_search.py
@@ -44,8 +44,8 @@ def test_format_search_results_includes_ranked_result_details() -> None:
 
 
 def test_format_search_results_truncates_long_content() -> None:
-    # Arrange
-    result = _search_result(content="word " * 60)
+    # Arrange — content must exceed 2000 chars to trigger truncation
+    result = _search_result(content="word " * 500)
 
     # Act
     formatted = format_search_results([result])
@@ -84,6 +84,7 @@ def test_search_embeds_query_and_uses_default_limit(
         conn,
         [0.1] * EMBEDDING_DIMENSION,
         limit=DEFAULT_RESULT_LIMIT,
+        query_text="vector database",
     )
     conn.close.assert_called_once_with()
 

--- a/stacks/knowledge/init.sql
+++ b/stacks/knowledge/init.sql
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS chunks (
     content TEXT NOT NULL,
     embedding vector(3072) NOT NULL,
     metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
@@ -26,3 +27,4 @@ CREATE INDEX IF NOT EXISTS chunks_document_id_idx ON chunks (document_id);
 CREATE INDEX IF NOT EXISTS chunks_embedding_hnsw_idx
     ON chunks
     USING hnsw (embedding vector_cosine_ops);
+CREATE INDEX IF NOT EXISTS chunks_tsv_idx ON chunks USING gin (tsv);

--- a/stacks/knowledge/migrations/001_add_tsv_column.sql
+++ b/stacks/knowledge/migrations/001_add_tsv_column.sql
@@ -1,0 +1,6 @@
+-- Add tsvector column for full-text keyword search (RRF hybrid)
+ALTER TABLE chunks
+    ADD COLUMN IF NOT EXISTS tsv tsvector
+    GENERATED ALWAYS AS (to_tsvector('english', content)) STORED;
+
+CREATE INDEX IF NOT EXISTS chunks_tsv_idx ON chunks USING gin (tsv);


### PR DESCRIPTION
## What

Two search quality improvements that address the biggest pain points from the knowledge-search skill evaluation.

## Changes

### 1. Longer excerpts (200 → 2000 chars)

Previously, search returned 200-char excerpts that cut off mid-sentence and were useless without reading the full file. Now returns the full chunk content (~500 tokens), which is what the agent actually needs.

### 2. RRF hybrid search

Combines vector similarity (semantic) with keyword search (tsvector) using Reciprocal Rank Fusion:

```
score = 1/(60 + rank_vector) + 1/(60 + rank_keyword)
```

- Keyword search catches exact terms that embeddings miss (acronyms, proper nouns, error codes)
- Vector search catches semantic meaning that keywords miss
- RRF merges both without needing to normalize scores

**Schema**: Adds a generated `tsv` tsvector column (auto-populated from content) with a GIN index. Migration included.

### Graceful fallback

If the tsv column hasn't been added yet (migration not run), search falls back to pure vector mode — no breaking change on deploy.

## Migration

Run on the knowledge DB:
```sql
ALTER TABLE chunks ADD COLUMN IF NOT EXISTS tsv tsvector
    GENERATED ALWAYS AS (to_tsvector('english', content)) STORED;
CREATE INDEX IF NOT EXISTS chunks_tsv_idx ON chunks USING gin (tsv);
```

Partially addresses #201