### PR TITLE
fix(knowledge): harden security, reliability, and performance

### DIFF
--- a/stacks/knowledge/app/Dockerfile
+++ b/stacks/knowledge/app/Dockerfile
@@ -13,4 +13,4 @@ COPY knowledge/ knowledge/
 RUN adduser --system --no-create-home app
 USER app
 
-ENTRYPOINT ["uv", "run", "python", "-m", "knowledge"]
+ENTRYPOINT [".venv/bin/python", "-m", "knowledge"]

--- a/stacks/knowledge/app/Dockerfile
+++ b/stacks/knowledge/app/Dockerfile
@@ -10,4 +10,7 @@ RUN uv sync --frozen --no-dev
 
 COPY knowledge/ knowledge/
 
+RUN adduser --system --no-create-home app
+USER app
+
 ENTRYPOINT ["uv", "run", "python", "-m", "knowledge"]

--- a/stacks/knowledge/app/knowledge/__main__.py
+++ b/stacks/knowledge/app/knowledge/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -12,6 +13,8 @@ from .search import DEFAULT_RESULT_LIMIT, format_search_results, search
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
     parser = argparse.ArgumentParser(prog="knowledge", description="Knowledge base CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -40,10 +43,16 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if args.command == "ingest":
-        _handle_ingest(args)
-    elif args.command == "search":
-        _handle_search(args)
+    try:
+        if args.command == "ingest":
+            _handle_ingest(args)
+        elif args.command == "search":
+            _handle_search(args)
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _handle_ingest(args: argparse.Namespace) -> None:

--- a/stacks/knowledge/app/knowledge/database.py
+++ b/stacks/knowledge/app/knowledge/database.py
@@ -70,7 +70,7 @@ def insert_chunks(conn: DatabaseConnection, chunks: list[Chunk]) -> list[Chunk]:
         VALUES (COALESCE(%s, gen_random_uuid()), %s, %s, %s, %s, %s, COALESCE(%s, now()))
         RETURNING id, document_id, chunk_index, content, embedding, metadata, created_at
     """
-    params = [
+    params_seq = [
         (
             c.id,
             c.document_id,
@@ -85,9 +85,14 @@ def insert_chunks(conn: DatabaseConnection, chunks: list[Chunk]) -> list[Chunk]:
 
     inserted: list[Chunk] = []
     with _cursor(conn) as cursor:
-        for row_params in params:
-            cursor.execute(sql, row_params)
-            inserted.append(_chunk_from_row(_fetchone(cursor, operation="insert chunk")))
+        cursor.executemany(sql, params_seq, returning=True)
+        while True:
+            row = cursor.fetchone()
+            if row is None:
+                if not cursor.nextset():
+                    break
+                continue
+            inserted.append(_chunk_from_row(row))
 
     return inserted
 
@@ -134,7 +139,6 @@ def search_chunks(
                 c.document_id AS chunk_document_id,
                 c.chunk_index AS chunk_chunk_index,
                 c.content AS chunk_content,
-                c.embedding AS chunk_embedding,
                 c.metadata AS chunk_metadata,
                 c.created_at AS chunk_created_at,
                 GREATEST(0.0, LEAST(1.0, 1 - (c.embedding <=> %s::vector))) AS score
@@ -272,7 +276,6 @@ def _search_result_from_row(row: DBRow) -> SearchResult:
                 "document_id": row["chunk_document_id"],
                 "chunk_index": row["chunk_chunk_index"],
                 "content": row["chunk_content"],
-                "embedding": row["chunk_embedding"],
                 "metadata": row["chunk_metadata"],
                 "created_at": row["chunk_created_at"],
             }

--- a/stacks/knowledge/app/knowledge/embeddings.py
+++ b/stacks/knowledge/app/knowledge/embeddings.py
@@ -17,10 +17,14 @@ TOKEN_ENV = "COPILOT_GITHUB_TOKEN"
 _MAX_RETRIES = 6
 _INITIAL_BACKOFF = 2.0
 _MAX_BACKOFF = 60.0
+_BATCH_SIZE = 20
 
 
 def get_embeddings(texts: list[str], *, token: str | None = None) -> list[list[float]]:
-    """Call GitHub Models API to embed a batch of texts. Returns one vector per input."""
+    """Call GitHub Models API to embed a batch of texts. Returns one vector per input.
+
+    Splits into batches of _BATCH_SIZE to stay within per-request token limits.
+    """
     if not texts:
         return []
 
@@ -28,22 +32,30 @@ def get_embeddings(texts: list[str], *, token: str | None = None) -> list[list[f
     if not resolved_token:
         raise RuntimeError(f"{TOKEN_ENV} must be set for embedding requests")
 
-    payload = {"input": texts, "model": MODEL_NAME}
     headers = {"Authorization": f"Bearer {resolved_token}", "Content-Type": "application/json"}
 
-    data = _post_with_retry(payload, headers)
-    embeddings = _parse_response(data, expected=len(texts))
-    return embeddings
+    all_embeddings: list[list[float]] = []
+    for batch in _batches(texts, _BATCH_SIZE):
+        payload = {"input": batch, "model": MODEL_NAME}
+        data = _post_with_retry(payload, headers)
+        all_embeddings.extend(_parse_response(data, expected=len(batch)))
+
+    return all_embeddings
+
+
+def _batches(items: list[str], size: int) -> list[list[str]]:
+    """Split a list into consecutive batches of at most *size* items."""
+    return [items[i : i + size] for i in range(0, len(items), size)]
 
 
 def _post_with_retry(payload: dict, headers: dict) -> dict:
-    """POST with exponential backoff on 429 / 5xx, respects Retry-After header."""
+    """POST with exponential backoff on 429 / 5xx / transport errors."""
     backoff = _INITIAL_BACKOFF
-    last_error: httpx.HTTPStatusError | None = None
+    last_error: Exception | None = None
 
     for attempt in range(_MAX_RETRIES):
-        response = httpx.post(GITHUB_MODELS_URL, json=payload, headers=headers, timeout=60.0)
         try:
+            response = httpx.post(GITHUB_MODELS_URL, json=payload, headers=headers, timeout=60.0)
             response.raise_for_status()
             return response.json()  # type: ignore[no-any-return]
         except httpx.HTTPStatusError as exc:
@@ -61,6 +73,17 @@ def _post_with_retry(payload: dict, headers: dict) -> dict:
                 backoff = min(backoff * 2, _MAX_BACKOFF)
                 continue
             raise
+        except httpx.TransportError as exc:
+            last_error = exc
+            logger.warning(
+                "Embedding API transport error: %s (attempt %d/%d), retrying in %.1fs",
+                exc,
+                attempt + 1,
+                _MAX_RETRIES,
+                backoff,
+            )
+            time.sleep(backoff)
+            backoff = min(backoff * 2, _MAX_BACKOFF)
 
     if last_error is not None:
         raise last_error

--- a/stacks/knowledge/app/knowledge/ingest.py
+++ b/stacks/knowledge/app/knowledge/ingest.py
@@ -120,6 +120,10 @@ def _ingest(
             content_hash=content_hash,
             token=token,
         )
+    except BaseException:
+        if not own_conn:
+            db.rollback()
+        raise
     finally:
         if own_conn:
             db.close()

--- a/stacks/knowledge/app/knowledge/models.py
+++ b/stacks/knowledge/app/knowledge/models.py
@@ -53,7 +53,7 @@ class Chunk(KnowledgeModel):
     document_id: UUID
     chunk_index: int = Field(ge=0)
     content: str = Field(min_length=1)
-    embedding: list[float]
+    embedding: list[float] | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime | None = None
 
@@ -64,7 +64,9 @@ class Chunk(KnowledgeModel):
 
     @field_validator("embedding", mode="before")
     @classmethod
-    def validate_embedding(cls, value: Any) -> list[float]:
+    def validate_embedding(cls, value: Any) -> list[float] | None:
+        if value is None:
+            return None
         return normalize_embedding(value)
 
     @field_validator("metadata", mode="before")

--- a/stacks/knowledge/app/tests/test_embeddings.py
+++ b/stacks/knowledge/app/tests/test_embeddings.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from knowledge.embeddings import (
+    _BATCH_SIZE,
     GITHUB_MODELS_URL,
     MODEL_NAME,
     TOKEN_ENV,
@@ -93,3 +94,58 @@ def test_parse_response_sorts_by_index() -> None:
     data = {"data": [_fake_embedding(1), _fake_embedding(0)]}
     result = _parse_response(data, expected=2)
     assert len(result) == 2
+
+
+def test_get_embeddings_retries_on_transport_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    ok = _ok_response(1)
+
+    with (
+        patch(
+            "knowledge.embeddings.httpx.post",
+            side_effect=[httpx.ConnectError("connection refused"), ok],
+        ) as mock_post,
+        patch("knowledge.embeddings.time.sleep"),
+    ):
+        result = get_embeddings(["hello"])
+
+    assert len(result) == 1
+    assert mock_post.call_count == 2
+
+
+def test_get_embeddings_batches_large_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    texts = [f"text-{i}" for i in range(_BATCH_SIZE + 5)]
+
+    batch1_response = _ok_response(_BATCH_SIZE)
+    batch2_response = _ok_response(5)
+
+    with patch(
+        "knowledge.embeddings.httpx.post",
+        side_effect=[batch1_response, batch2_response],
+    ) as mock_post:
+        result = get_embeddings(texts)
+
+    assert len(result) == _BATCH_SIZE + 5
+    assert mock_post.call_count == 2
+    # First call has batch_size items, second has the remainder
+    first_payload = mock_post.call_args_list[0].kwargs["json"]["input"]
+    second_payload = mock_post.call_args_list[1].kwargs["json"]["input"]
+    assert len(first_payload) == _BATCH_SIZE
+    assert len(second_payload) == 5
+
+
+def test_get_embeddings_exhausts_retries_on_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+
+    with (
+        patch(
+            "knowledge.embeddings.httpx.post",
+            side_effect=httpx.ReadTimeout("timed out"),
+        ),
+        patch("knowledge.embeddings.time.sleep"),
+        pytest.raises(httpx.ReadTimeout),
+    ):
+        get_embeddings(["hello"])

--- a/stacks/knowledge/app/tests/test_ingest.py
+++ b/stacks/knowledge/app/tests/test_ingest.py
@@ -647,3 +647,27 @@ def test_pdf_hash_uses_raw_bytes(tmp_path: Path) -> None:
 
     assert _extract_pdf_text(pdf_a) == _extract_pdf_text(pdf_b)
     assert _file_content_hash(pdf_a) != _file_content_hash(pdf_b)
+
+
+@patch("knowledge.ingest.connect")
+@patch("knowledge.ingest.get_embeddings", side_effect=RuntimeError("API down"))
+@patch("knowledge.ingest.get_document_by_source", return_value=None)
+def test_ingest_file_rolls_back_shared_connection_on_error(
+    mock_get_source: MagicMock,
+    mock_embed: MagicMock,
+    mock_connect: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """When a shared connection is passed and ingest fails, it must be rolled back."""
+    # Arrange
+    md_file = tmp_path / "note.md"
+    md_file.write_text("# Note\n\nSome content for embedding.")
+    shared_conn = _fake_connect()
+
+    # Act
+    with pytest.raises(RuntimeError, match="API down"):
+        ingest_file(md_file, conn=shared_conn)
+
+    # Assert — shared connection rolled back, NOT closed (caller owns it)
+    shared_conn.rollback.assert_called_once()
+    shared_conn.close.assert_not_called()

--- a/stacks/knowledge/compose.yaml
+++ b/stacks/knowledge/compose.yaml
@@ -8,6 +8,8 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:?}
       - POSTGRES_USER=${POSTGRES_USER:?}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?}
+    shm_size: 256mb
+    mem_limit: 4g
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 30s
@@ -20,6 +22,7 @@ services:
   ingest:
     profiles: [ingest]
     build: ./app
+    mem_limit: 2g
     environment:
       - PGHOST=postgres
       - PGPORT=5432


### PR DESCRIPTION
## What

Addresses findings from a technical audit of the knowledge stack. Fixes critical, high, and medium-severity issues across security, reliability, and performance.

## Changes

### Security
- **Non-root container** — `Dockerfile` now runs the app as a non-privileged `app` user
- **Resource limits** — Postgres capped at 4GB, ingest at 2GB (prevents runaway usage on 16GB host)

### Reliability
- **Transport error retry** — `ConnectError`, `ReadTimeout`, DNS failures now retried with exponential backoff (previously only HTTP 429/5xx were retried)
- **Embedding batch size** — API calls split into batches of 20 to stay within per-request token limits (large documents previously caused unretried 400 errors)
- **Connection rollback** — shared database connections are now rolled back on ingest failure (previously left in broken transaction state)
- **shm_size** — Postgres gets 256MB shared memory (prevents HNSW index operation failures on Docker's default 64MB)
- **Logging** — CLI now calls `logging.basicConfig()` (all log messages were silently dropped)
- **Error handling** — CLI shows `Error: <message>` instead of raw Python tracebacks

### Performance
- **Batch chunk inserts** — `executemany` replaces N individual roundtrips for chunk insertion
- **Lighter search results** — Dropped unused 3072-float embedding vectors from search SELECT (~24KB/result savings)

## Testing

- New tests for transport error retry, batch exhaustion, and embedding batching
- New test for shared connection rollback on ingest failure
- All 52 existing + new tests pass, lint/typecheck clean

Partially addresses the audit surfaced by #208 review discussion.