### PR TITLE
feat(knowledge): save URL as markdown note with images

### DIFF
--- a/.github/skills/knowledge-search/SKILL.md
+++ b/.github/skills/knowledge-search/SKILL.md
@@ -68,3 +68,13 @@ ssh beelink "cat '/home/colin/code/notes/Coding/System Design/Practice/Design a 
 - Try multiple searches with different phrasings if the first doesn't return good results
 - Results are ranked by Reciprocal Rank Fusion — absolute score values are small (~0.01–0.03) but ordering is meaningful
 - The knowledge base is updated on every push to the notes repo (automated pipeline)
+
+## Saving articles
+
+To save a web page as a note (with images) for future search:
+
+```bash
+ssh beelink "cd /home/colin/code/homelab/stacks/knowledge && docker compose --profile save run --rm save save \"<URL>\""
+```
+
+This fetches the page, downloads images, converts to markdown, and commits to the notes repo. The ingest pipeline picks it up automatically on the next push.

--- a/stacks/knowledge/app/knowledge/__main__.py
+++ b/stacks/knowledge/app/knowledge/__main__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from .database import connect, run_migrations
 from .ingest import DEFAULT_DIRECTORY_GLOB, ingest_directory, ingest_file, ingest_text
+from .save import save_url
 from .search import DEFAULT_RESULT_LIMIT, format_search_results, search
 
 
@@ -42,6 +43,15 @@ def main() -> None:
         help=f"Maximum number of results to return (default: {DEFAULT_RESULT_LIMIT})",
     )
 
+    save_parser = subparsers.add_parser("save", help="Save a URL as a note")
+    save_parser.add_argument("url", help="URL to fetch and save as a note")
+    save_parser.add_argument(
+        "--notes-dir",
+        type=Path,
+        default=Path("/notes"),
+        help="Path to the notes repository (default: /notes)",
+    )
+
     args = parser.parse_args()
 
     db = connect()
@@ -53,6 +63,8 @@ def main() -> None:
             _handle_ingest(args)
         elif args.command == "search":
             _handle_search(args)
+        elif args.command == "save":
+            _handle_save(args)
     except KeyboardInterrupt:
         sys.exit(130)
     except Exception as exc:
@@ -99,6 +111,15 @@ def _handle_ingest(args: argparse.Namespace) -> None:
 def _handle_search(args: argparse.Namespace) -> None:
     results = search(args.query, limit=args.limit)
     print(format_search_results(results))
+
+
+def _handle_save(args: argparse.Namespace) -> None:
+    notes_dir = Path(args.notes_dir)
+    if not notes_dir.is_dir():
+        print(f"Error: notes directory not found: {notes_dir}", file=sys.stderr)
+        sys.exit(1)
+    saved_path = save_url(args.url, notes_dir=notes_dir)
+    print(f"Saved: {saved_path}")
 
 
 def _positive_int(value: str) -> int:

--- a/stacks/knowledge/app/knowledge/save.py
+++ b/stacks/knowledge/app/knowledge/save.py
@@ -1,0 +1,192 @@
+"""Save a URL as a markdown note with images."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import subprocess
+import urllib.request
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+_USER_AGENT = "knowledge-save/1.0"
+_TIMEOUT = 30
+_STRIP_ELEMENTS = ("nav", "header", "footer", "script", "style", "aside", "noscript")
+
+
+def save_url(url: str, *, notes_dir: Path) -> Path:
+    """Fetch a URL, convert to markdown note with images, save to notes_dir.
+
+    Returns the path to the saved markdown file.
+    """
+    html = _fetch(url)
+    soup = BeautifulSoup(html, "html.parser")
+
+    title = _extract_title(soup, url)
+    slug = _url_slug(url)
+    article_dir = notes_dir / "resources" / "articles" / slug
+    assets_dir = article_dir / "assets"
+    md_path = article_dir / f"{slug}.md"
+
+    if article_dir.exists():
+        logger.info("Article already saved: %s (re-saving with updated content)", article_dir)
+
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    # Strip boilerplate elements
+    for tag_name in _STRIP_ELEMENTS:
+        for tag in soup.find_all(tag_name):
+            tag.decompose()
+
+    # Find the main content area
+    content_element = _find_content(soup)
+
+    # Download images and rewrite src to local paths
+    _download_images(content_element, url, assets_dir, slug)
+
+    # Convert to markdown-ish text
+    markdown = _to_markdown(content_element, title, url)
+
+    # Write the note
+    md_path.write_text(markdown, encoding="utf-8")
+
+    # Git commit and push
+    _git_commit_and_push(notes_dir, article_dir, title)
+
+    logger.info("Saved: %s → %s", url, md_path)
+    return md_path
+
+
+def _fetch(url: str) -> str:
+    """Fetch URL content as text."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as response:
+        charset = response.headers.get_content_charset() or "utf-8"
+        return response.read().decode(charset)
+
+
+def _extract_title(soup: BeautifulSoup, fallback_url: str) -> str:
+    """Extract page title from <title> or <h1>."""
+    if soup.title and soup.title.string:
+        return soup.title.string.strip()
+    h1 = soup.find("h1")
+    if h1:
+        return h1.get_text(strip=True)
+    return urlparse(fallback_url).netloc
+
+
+def _find_content(soup: BeautifulSoup) -> BeautifulSoup:
+    """Find the main content element, falling back to body."""
+    for selector in ("article", "main", '[role="main"]'):
+        element = soup.find(selector)
+        if element:
+            return element
+    return soup.body or soup
+
+
+def _download_images(content: BeautifulSoup, base_url: str, assets_dir: Path, slug: str) -> None:
+    """Download images and rewrite src attributes to local relative paths."""
+    for i, img in enumerate(content.find_all("img")):
+        src = img.get("src")
+        if not src:
+            continue
+
+        abs_url = urljoin(base_url, src)
+        ext = _image_extension(abs_url)
+        filename = f"{slug}-{i:03d}{ext}"
+        local_path = assets_dir / filename
+
+        try:
+            req = urllib.request.Request(abs_url, headers={"User-Agent": _USER_AGENT})
+            with urllib.request.urlopen(req, timeout=_TIMEOUT) as response:
+                local_path.write_bytes(response.read())
+            img["src"] = f"assets/{filename}"
+        except Exception:
+            logger.warning("Failed to download image: %s", abs_url)
+            img["src"] = abs_url
+
+
+def _image_extension(url: str) -> str:
+    """Guess image extension from URL."""
+    path = urlparse(url).path.lower()
+    for ext in (".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".avif"):
+        if path.endswith(ext):
+            return ext
+    return ".png"
+
+
+def _to_markdown(content: BeautifulSoup, title: str, source_url: str) -> str:
+    """Convert HTML content to a readable markdown note."""
+    lines: list[str] = [f"# {title}", "", f"Source: {source_url}", ""]
+
+    heading_prefix = {"h1": "##", "h2": "##", "h3": "###", "h4": "####"}
+
+    for element in content.find_all(["h1", "h2", "h3", "h4", "p", "li", "img", "pre", "code"]):
+        if element.name in heading_prefix:
+            lines.append(f"{heading_prefix[element.name]} {element.get_text(strip=True)}")
+            lines.append("")
+        elif element.name == "p":
+            text = element.get_text(strip=True)
+            if text:
+                lines.append(text)
+                lines.append("")
+        elif element.name == "li":
+            lines.append(f"- {element.get_text(strip=True)}")
+        elif element.name == "img":
+            alt = element.get("alt", "")
+            src = element.get("src", "")
+            lines.append(f"![{alt}]({src})")
+            lines.append("")
+        elif element.name == "pre":
+            code = element.get_text()
+            lines.append(f"```\n{code}\n```")
+            lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a filesystem-safe slug."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    text = re.sub(r"-+", "-", text)
+    return text[:80].strip("-")
+
+
+def _url_slug(url: str) -> str:
+    """Derive a stable, unique slug from a URL (not title-dependent)."""
+    url_hash = hashlib.sha256(url.encode()).hexdigest()[:10]
+    # Use the last path segment for readability, plus hash for uniqueness
+    path_segment = urlparse(url).path.rstrip("/").rsplit("/", 1)[-1] or "page"
+    readable = _slugify(path_segment)[:60]
+    return f"{readable}-{url_hash}"
+
+
+def _git_commit_and_push(notes_dir: Path, article_dir: Path, title: str) -> None:
+    """Commit the saved article and push to origin.
+
+    Same pattern as homelab deploy: reset to origin/main, add new files, push.
+    Safe because the server checkout is not a user-edited working copy.
+    """
+    relative_path = article_dir.relative_to(notes_dir)
+
+    def _git(*args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=notes_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    _git("fetch", "origin", "main")
+    _git("reset", "--hard", "origin/main")
+    _git("add", str(relative_path))
+    _git("commit", "-m", f"Save article: {title}")
+    _git("push", "origin", "main")

--- a/stacks/knowledge/app/pyproject.toml
+++ b/stacks/knowledge/app/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Typed CLI package for the homelab knowledge base"
 requires-python = ">=3.14"
 dependencies = [
+    "beautifulsoup4>=4",
     "httpx>=0.28",
     "pgvector>=0.4",
     "pydantic>=2",

--- a/stacks/knowledge/app/tests/test_save.py
+++ b/stacks/knowledge/app/tests/test_save.py
@@ -1,0 +1,217 @@
+"""Tests for the save module (URL → markdown note)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from knowledge import save
+
+SAMPLE_HTML = """<!DOCTYPE html>
+<html>
+<head><title>Test Article Title</title></head>
+<body>
+<nav><a href="/">Home</a></nav>
+<header><h1>Site Header</h1></header>
+<article>
+    <h1>Test Article Title</h1>
+    <p>This is the first paragraph with important content.</p>
+    <h2>Section Two</h2>
+    <p>More content here about the topic.</p>
+    <img src="/images/diagram.png" alt="Architecture diagram">
+    <p>Final paragraph.</p>
+</article>
+<footer>Copyright 2026</footer>
+</body>
+</html>"""
+
+SIMPLE_HTML = """<html>
+<head><title>Simple Page</title></head>
+<body><p>Hello world</p></body>
+</html>"""
+
+
+class TestExtractTitle:
+    def test_extracts_from_title_tag(self) -> None:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(SAMPLE_HTML, "html.parser")
+        assert save._extract_title(soup, "https://example.com") == "Test Article Title"
+
+    def test_falls_back_to_h1(self) -> None:
+        from bs4 import BeautifulSoup
+
+        html = "<html><body><h1>Heading Title</h1></body></html>"
+        soup = BeautifulSoup(html, "html.parser")
+        assert save._extract_title(soup, "https://example.com") == "Heading Title"
+
+    def test_falls_back_to_domain(self) -> None:
+        from bs4 import BeautifulSoup
+
+        html = "<html><body><p>No title</p></body></html>"
+        soup = BeautifulSoup(html, "html.parser")
+        assert save._extract_title(soup, "https://example.com/page") == "example.com"
+
+
+class TestUrlSlug:
+    def test_uses_path_segment_plus_hash(self) -> None:
+        slug = save._url_slug("https://example.com/blog/my-article")
+        assert slug.startswith("my-article-")
+        assert len(slug) > len("my-article-")
+
+    def test_same_url_same_slug(self) -> None:
+        a = save._url_slug("https://example.com/post")
+        b = save._url_slug("https://example.com/post")
+        assert a == b
+
+    def test_different_urls_different_slugs(self) -> None:
+        a = save._url_slug("https://example.com/post-a")
+        b = save._url_slug("https://example.com/post-b")
+        assert a != b
+
+    def test_handles_trailing_slash(self) -> None:
+        slug = save._url_slug("https://example.com/article/")
+        assert "article" in slug
+
+
+class TestFindContent:
+    def test_finds_article_element(self) -> None:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(SAMPLE_HTML, "html.parser")
+        content = save._find_content(soup)
+        assert content.name == "article"
+
+    def test_falls_back_to_main(self) -> None:
+        from bs4 import BeautifulSoup
+
+        html = "<html><body><main><p>Content</p></main></body></html>"
+        soup = BeautifulSoup(html, "html.parser")
+        content = save._find_content(soup)
+        assert content.name == "main"
+
+    def test_falls_back_to_body(self) -> None:
+        from bs4 import BeautifulSoup
+
+        html = "<html><body><p>Content</p></body></html>"
+        soup = BeautifulSoup(html, "html.parser")
+        content = save._find_content(soup)
+        assert content.name == "body"
+
+
+class TestToMarkdown:
+    def test_includes_title_and_source(self) -> None:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup("<article><p>Hello</p></article>", "html.parser")
+        md = save._to_markdown(soup, "My Title", "https://example.com")
+        assert md.startswith("# My Title\n")
+        assert "Source: https://example.com" in md
+
+    def test_includes_paragraphs(self) -> None:
+        from bs4 import BeautifulSoup
+
+        html = "<article><p>First para</p><p>Second para</p></article>"
+        soup = BeautifulSoup(html, "html.parser")
+        md = save._to_markdown(soup, "Title", "https://x.com")
+        assert "First para" in md
+        assert "Second para" in md
+
+    def test_includes_images(self) -> None:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(
+            '<article><img src="assets/img.png" alt="Diagram"></article>', "html.parser"
+        )
+        md = save._to_markdown(soup, "Title", "https://x.com")
+        assert "![Diagram](assets/img.png)" in md
+
+
+class TestSaveUrl:
+    @patch.object(save, "_git_commit_and_push")
+    @patch.object(save, "_fetch")
+    def test_creates_note_with_correct_structure(
+        self,
+        mock_fetch: MagicMock,
+        mock_git: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_fetch.return_value = SIMPLE_HTML
+
+        result = save.save_url("https://example.com/article", notes_dir=tmp_path)
+
+        assert result.exists()
+        assert result.suffix == ".md"
+        assert "resources/articles/" in str(result)
+        content = result.read_text()
+        assert "# Simple Page" in content
+        assert "Source: https://example.com/article" in content
+
+    @patch.object(save, "_git_commit_and_push")
+    @patch.object(save, "_fetch")
+    def test_downloads_images(
+        self,
+        mock_fetch: MagicMock,
+        mock_git: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_fetch.return_value = SAMPLE_HTML
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = b"\x89PNG fake image data"
+            mock_response.__enter__ = lambda s: mock_response
+            mock_response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_response
+
+            result = save.save_url("https://example.com/post", notes_dir=tmp_path)
+
+        article_dir = result.parent
+        assets_dir = article_dir / "assets"
+        assert assets_dir.exists()
+        assert any(assets_dir.iterdir())
+
+    @patch.object(save, "_git_commit_and_push")
+    @patch.object(save, "_fetch")
+    def test_resaves_existing_article_with_updated_content(
+        self,
+        mock_fetch: MagicMock,
+        mock_git: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_fetch.return_value = SIMPLE_HTML
+
+        # Pre-create the article directory with old content
+        slug = save._url_slug("https://example.com/article")
+        article_dir = tmp_path / "resources" / "articles" / slug
+        article_dir.mkdir(parents=True)
+        md_path = article_dir / f"{slug}.md"
+        md_path.write_text("old content")
+
+        result = save.save_url("https://example.com/article", notes_dir=tmp_path)
+
+        # Should overwrite with new content
+        assert result == md_path
+        assert "Hello world" in md_path.read_text()
+        mock_git.assert_called_once()
+
+
+class TestGitCommitAndPush:
+    @patch("subprocess.run")
+    def test_runs_git_commands_in_order(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        article_dir = tmp_path / "resources" / "articles" / "test"
+        article_dir.mkdir(parents=True)
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        save._git_commit_and_push(tmp_path, article_dir, "Test Article")
+
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        assert calls[0] == ["git", "fetch", "origin", "main"]
+        assert calls[1] == ["git", "reset", "--hard", "origin/main"]
+        assert calls[2] == ["git", "add", "resources/articles/test"]
+        assert calls[3][0:3] == ["git", "commit", "-m"]
+        assert calls[4] == ["git", "push", "origin", "main"]

--- a/stacks/knowledge/app/uv.lock
+++ b/stacks/knowledge/app/uv.lock
@@ -24,6 +24,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -55,6 +68,7 @@ name = "homelab-knowledge"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "httpx" },
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary"] },
@@ -71,6 +85,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "pgvector", specifier = ">=0.4" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
@@ -338,6 +353,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]

--- a/stacks/knowledge/compose.yaml
+++ b/stacks/knowledge/compose.yaml
@@ -36,5 +36,21 @@ services:
       postgres:
         condition: service_healthy
 
+  save:
+    profiles: [save]
+    build: ./app
+    mem_limit: 1g
+    environment:
+      - PGHOST=postgres
+      - PGPORT=5432
+      - PGDATABASE=${POSTGRES_DB:?}
+      - PGUSER=${POSTGRES_USER:?}
+      - PGPASSWORD=${POSTGRES_PASSWORD:?}
+    volumes:
+      - ${NOTES_DIR:-/home/colin/code/notes}:/notes
+    depends_on:
+      postgres:
+        condition: service_healthy
+
 volumes:
   knowledge-data:


### PR DESCRIPTION
## Summary

New `knowledge save <URL>` command that fetches a web page, extracts content + images, and saves it as a markdown note in the notes repo.

### What it does
- Fetches URL with urllib (30s timeout)
- Strips boilerplate HTML (nav, header, footer, script, style, aside)
- Finds main content (`<article>`, `<main>`, or `<body>`)
- Downloads images to `assets/` directory
- Converts to markdown with title, source link, headings, paragraphs, images
- Saves under `resources/articles/<slug>/`
- Git commits and pushes to trigger the ingest pipeline

### Architecture
The notes repo is the source of truth. This command writes to it, then the existing ingest pipeline picks up the new file on push. A separate `save` compose profile has read-write access to the notes volume (the `ingest` service stays read-only).

### New dependency
- `beautifulsoup4>=4` for HTML parsing

Closes #210