### PR TITLE
fix(knowledge): add git to container, run save as host user

### DIFF
--- a/stacks/knowledge/app/Dockerfile
+++ b/stacks/knowledge/app/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.14.4-slim@sha256:538a18f1db92b4210a0b71aca2d14c156a96dedbe8867465c
 # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
 COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /usr/local/bin/uv
 
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev

--- a/stacks/knowledge/compose.yaml
+++ b/stacks/knowledge/compose.yaml
@@ -40,6 +40,7 @@ services:
     profiles: [save]
     build: ./app
     mem_limit: 1g
+    user: "${UID:-1000}:${GID:-1000}"
     environment:
       - PGHOST=postgres
       - PGPORT=5432


### PR DESCRIPTION
The save command needs git to commit to the notes repo and needs to run as the host user (uid 1000) to write to the notes directory.

- Install git in Dockerfile (needed for commit+push)
- Add `user: ${UID:-1000}:${GID:-1000}` to save service (matches notes dir owner)