### PR TITLE
fix(dashboard): use cAdvisor for active workers instead of in-memory gauge

### DIFF
--- a/stacks/agents/app/main.py
+++ b/stacks/agents/app/main.py
@@ -16,7 +16,6 @@ from metrics import (
     METRICS_REGISTRY,
     PREMIUM_REQUESTS_TOTAL,
     TASK_DURATION_SECONDS,
-    TASK_IN_PROGRESS,
     TASK_TOTAL,
     TOKENS_TOTAL,
 )
@@ -77,7 +76,6 @@ async def lifespan(_app: FastAPI):
         started_at = float(w.get("started_at", 0))
         elapsed = time.time() - started_at if started_at > 0 else 0
         approx_start = time.monotonic() - elapsed
-        TASK_IN_PROGRESS.labels(task_type=task_type).inc()
         _spawn_monitor(container_id, task_type=task_type, number=number, start=approx_start)
         logger.info("Reconnected monitor for running worker %s #%d", task_type, number)
 
@@ -211,7 +209,6 @@ async def _monitor_worker(container_id: str, *, task_type: str, number: int, sta
     except Exception:
         logger.exception("Monitor failed for worker %s #%d", task_type, number)
     finally:
-        TASK_IN_PROGRESS.labels(task_type=task_type).dec()
         try:
             await remove_container(container_id)
         except Exception:
@@ -257,7 +254,6 @@ async def _dispatch_worker(
     }
 
     start = time.monotonic()
-    TASK_IN_PROGRESS.labels(task_type=task_type).inc()
 
     container_id = await spawn_worker(
         task_type=task_type,

--- a/stacks/agents/app/metrics.py
+++ b/stacks/agents/app/metrics.py
@@ -1,6 +1,6 @@
 """Prometheus metrics for the agent service."""
 
-from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+from prometheus_client import CollectorRegistry, Counter, Histogram
 
 TASK_TYPES = ("review", "implement", "fix")
 TASK_STATUSES = ("complete", "failed", "partial", "rejected")
@@ -32,17 +32,10 @@ TOKENS_TOTAL = Counter(
     registry=METRICS_REGISTRY,
 )
 TOKEN_DIRECTIONS = ("input", "output", "cached", "reasoning")
-TASK_IN_PROGRESS = Gauge(
-    "agent_task_in_progress",
-    "Current number of in-flight agent tasks.",
-    labelnames=("task_type",),
-    registry=METRICS_REGISTRY,
-)
 
 
 def _initialize_metrics() -> None:
     for task_type in TASK_TYPES:
-        TASK_IN_PROGRESS.labels(task_type=task_type).set(0)
         PREMIUM_REQUESTS_TOTAL.labels(task_type=task_type)
         for direction in TOKEN_DIRECTIONS:
             TOKENS_TOTAL.labels(task_type=task_type, direction=direction)
@@ -58,7 +51,6 @@ def reset_metrics() -> None:
         TASK_TOTAL,
         PREMIUM_REQUESTS_TOTAL,
         TOKENS_TOTAL,
-        TASK_IN_PROGRESS,
     ):
         with collector._lock:
             collector._metrics.clear()

--- a/stacks/agents/app/tests/test_main.py
+++ b/stacks/agents/app/tests/test_main.py
@@ -131,7 +131,6 @@ def test_metrics_endpoint_exposes_prometheus_text():
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/plain")
     assert "# HELP agent_task_total" in resp.text
-    assert 'agent_task_in_progress{task_type="review"} 0.0' in resp.text
 
 
 # --- Review endpoint tests ---
@@ -345,7 +344,6 @@ def test_monitor_records_metrics_on_success(mock_wait, mock_logs, mock_rm):
 
     assert _metric_value("agent_task_total", {"task_type": "review", "status": "complete"}) == 1.0
     assert _metric_value("agent_premium_requests_total", {"task_type": "review"}) == 5.0
-    assert _metric_value("agent_task_in_progress", {"task_type": "review"}) == -1.0
     mock_rm.assert_awaited_once_with("abc123")
 
 

--- a/stacks/observability/dashboards/agent-tasks.json
+++ b/stacks/observability/dashboards/agent-tasks.json
@@ -73,7 +73,7 @@
       },
       "targets": [
         {
-          "expr": "sum(agent_task_in_progress)",
+          "expr": "count(container_last_seen{job=\"docker\", name=~\"worker-.*\"}) OR vector(0)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",


### PR DESCRIPTION
## Problem

The **Active Workers** panel on the agent-tasks dashboard always showed 0 during active reviews/implements. The `agent_task_in_progress` Prometheus gauge was an in-memory counter in the API process that drifted whenever:

- The API container restarted (all gauges reset to 0)
- `_monitor_worker` hit an exception in `wait_container()` — the `finally` block decremented even though the worker was still alive
- The startup reconnect logic (`discover_running_workers`) ran before the worker was visible in `docker ps`

## Fix

Replace the in-memory gauge with a cAdvisor query that counts running worker containers directly from Docker state:

```promql
count(container_last_seen{job="docker", name=~"worker-.*"}) OR vector(0)
```

This is **ground truth** — it observes Docker infrastructure directly via the cAdvisor exporter that Alloy already scrapes every 15s. No application bookkeeping needed.

## Changes

- **Dashboard:** swap Active Workers query to cAdvisor-based container count
- **metrics.py:** remove `TASK_IN_PROGRESS` gauge entirely (unused `Gauge` import too)
- **main.py:** remove all `inc()`/`dec()` calls (dispatch, monitor finally, startup reconnect)
- **tests:** remove gauge assertions

The `_monitor_worker` function is **kept** — it still handles completion metrics recording, container cleanup, and failure logging.