### PR TITLE
feat(grafana): set home dashboard and add cross-navigation links

### DIFF
--- a/stacks/observability/compose.yaml
+++ b/stacks/observability/compose.yaml
@@ -8,6 +8,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_SERVER_ROOT_URL=http://beelink:3001
       - GF_USERS_DEFAULT_THEME=dark
+      - GF_USERS_HOME_PAGE=/d/container-overview/container-overview
       - GF_UNIFIED_ALERTING_ENABLED=true
       - DISCORD_PRIVATE_WEBHOOK_URL=${DISCORD_PRIVATE_WEBHOOK_URL}
     volumes:

--- a/stacks/observability/dashboards/agent-tasks.json
+++ b/stacks/observability/dashboards/agent-tasks.json
@@ -19,7 +19,18 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {

--- a/stacks/observability/dashboards/container-overview.json
+++ b/stacks/observability/dashboards/container-overview.json
@@ -19,7 +19,18 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {

--- a/stacks/observability/dashboards/security.json
+++ b/stacks/observability/dashboards/security.json
@@ -18,7 +18,18 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
   "panels": [
     {
       "datasource": {


### PR DESCRIPTION
## Problem

Opening Grafana at `beelink:3001` lands on the default welcome page. Getting to any dashboard requires: hamburger menu → Dashboards → Homelab folder → pick a dashboard. Navigating between dashboards requires going back through the same flow.

## Changes

**Home page redirect:**
- Set `GF_USERS_HOME_PAGE=/d/container-overview/container-overview` so Grafana opens directly to the Container Overview dashboard

**Dashboard navigation links:**
- Added a "Dashboards" dropdown link to all three dashboards (container-overview, agent-tasks, security)
- Uses Grafana's built-in `type: dashboards` link which auto-discovers all dashboards — no manual URL list to maintain

After this, opening Grafana goes straight to Container Overview, and every dashboard has a dropdown in the top-left to jump to any other dashboard.