### PR TITLE
chore(deploy): clean up Discord notification

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,7 +63,9 @@ jobs:
         if: always() && steps.detect.outputs.stacks != ''
         with:
           webhook: ${{ secrets.DISCORD_PRIVATE_WEBHOOK_URL }}
+          nocontext: true
           title: Deploy
+          url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
           description: |
             **Stacks:** ${{ steps.detect.outputs.stacks }}
             **Commit:** ${{ steps.commit.outputs.msg }}

--- a/stacks/observability/compose.yaml
+++ b/stacks/observability/compose.yaml
@@ -8,6 +8,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_SERVER_ROOT_URL=http://beelink:3001
       - GF_USERS_DEFAULT_THEME=dark
+      - GF_USERS_HOME_PAGE=/d/container-overview/container-overview
       - GF_UNIFIED_ALERTING_ENABLED=true
       - DISCORD_PRIVATE_WEBHOOK_URL=${DISCORD_PRIVATE_WEBHOOK_URL}
     volumes:

--- a/stacks/observability/dashboards/agent-tasks.json
+++ b/stacks/observability/dashboards/agent-tasks.json
@@ -19,7 +19,18 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {

--- a/stacks/observability/dashboards/container-overview.json
+++ b/stacks/observability/dashboards/container-overview.json
@@ -19,7 +19,18 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {

--- a/stacks/observability/dashboards/security.json
+++ b/stacks/observability/dashboards/security.json
@@ -18,7 +18,18 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
   "panels": [
     {
       "datasource": {


### PR DESCRIPTION
Strip noisy GitHub context fields (Repository, Ref, Event, Triggered by, Workflow) from deploy Discord messages via `nocontext: true`. Add commit URL as the title link so the message stays compact but clickable.

**Before:** 12+ lines with redundant metadata
**After:** 4 lines — status, stacks, commit, actor — with a clickable link to the commit