### PR TITLE
refactor: fix broken alert rules and normalize observability config

### DIFF
--- a/stacks/observability/config.alloy
+++ b/stacks/observability/config.alloy
@@ -13,7 +13,6 @@ prometheus.scrape "host" {
   forward_to = [prometheus.remote_write.default.receiver]
 
   scrape_interval = "15s"
-  job_name        = "node"
 }
 
 // ================================

--- a/stacks/observability/dashboards/agent-tasks.json
+++ b/stacks/observability/dashboards/agent-tasks.json
@@ -934,5 +934,5 @@
   "timezone": "",
   "title": "Agent Tasks",
   "uid": "agent-tasks",
-  "version": 1
+  "version": 0
 }

--- a/stacks/observability/dashboards/security.json
+++ b/stacks/observability/dashboards/security.json
@@ -18,6 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": null,
   "links": [
     {
       "asDropdown": true,
@@ -974,6 +975,6 @@
   "timezone": "browser",
   "title": "Security",
   "uid": "security",
-  "version": 7,
+  "version": 0,
   "weekStart": ""
 }

--- a/stacks/observability/provisioning/alerting/rules.yaml
+++ b/stacks/observability/provisioning/alerting/rules.yaml
@@ -13,9 +13,9 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: "PBFA97CFB590B2093"
+            datasourceUid: prometheus
             model:
-              expr: 1 - avg(rate(node_cpu_seconds_total{mode="idle",job="node"}[5m]))
+              expr: 1 - avg(rate(node_cpu_seconds_total{mode="idle",job="integrations/unix"}[5m]))
               instant: true
               refId: A
           - refId: C
@@ -45,9 +45,9 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: "PBFA97CFB590B2093"
+            datasourceUid: prometheus
             model:
-              expr: 1 - (node_memory_AvailableBytes{job="node"} / node_memory_MemTotal_bytes{job="node"})
+              expr: 1 - (node_memory_AvailableBytes{job="integrations/unix"} / node_memory_MemTotal_bytes{job="integrations/unix"})
               instant: true
               refId: A
           - refId: C
@@ -77,11 +77,11 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: "PBFA97CFB590B2093"
+            datasourceUid: prometheus
             model:
               expr: >-
-                1 - (node_filesystem_avail_bytes{mountpoint="/",job="node"}
-                / node_filesystem_size_bytes{mountpoint="/",job="node"})
+                1 - (node_filesystem_avail_bytes{mountpoint="/",job="integrations/unix"}
+                / node_filesystem_size_bytes{mountpoint="/",job="integrations/unix"})
               instant: true
               refId: A
           - refId: C


### PR DESCRIPTION
## What

Fix broken Grafana alert rules and normalize observability stack config to match conventions.

## Changes

| File | Change |
|------|--------|
| `provisioning/alerting/rules.yaml` | Fixed datasource UID (`PBFA97CFB590B2093` → `prometheus`) and job label (`node` → `integrations/unix`) |
| `config.alloy` | Removed dead `job_name = "node"` (overridden by unix exporter) |
| `dashboards/security.json` | Added `"id": null`, reset version to 0 |
| `dashboards/agent-tasks.json` | Reset version to 0 |

## Why

- **3 alert rules were silently broken** — they queried `job="node"` but actual host metrics have `job="integrations/unix"` (Alloy's `prometheus.exporter.unix` overrides the configured `job_name`). The high-CPU, high-RAM, and high-disk alerts would never fire.
- The datasource UID `PBFA97CFB590B2093` is a stale auto-generated Grafana ID; the stable provisioned UID is `prometheus`.
- Dashboard JSON normalized to match conventions in `.github/instructions/dashboards.instructions.md`.

## Before/After

| Metric | Before | After |
|--------|--------|-------|
| Broken alert selectors | 3 | 0 |
| Stale datasource UIDs | 3 | 0 |
| Dead config lines | 1 | 0 |
| Missing `id: null` | 1 | 0 |
| Non-zero source versions | 2 | 0 |