### PR TITLE
fix(knowledge): simplify boilerplate and related-section markers

### DIFF
--- a/stacks/knowledge/app/knowledge/save.py
+++ b/stacks/knowledge/app/knowledge/save.py
@@ -31,17 +31,10 @@ _BOILERPLATE_MARKERS = (
     "banner",
     "toc",
     "table-of-contents",
-    "related-posts",
-    "related-articles",
-    "recommended-posts",
+    "related",
+    "recommend",
 )
-_RELATED_HEADINGS = (
-    "related content",
-    "related posts",
-    "related articles",
-    "you might also like",
-    "recommended for you",
-)
+_RELATED_HEADINGS = ("related", "recommended", "more from", "you might also", "further reading")
 _DECORATIVE_IMAGE_MARKERS = ("icon", "logo", "avatar", "sprite")
 
 


### PR DESCRIPTION
## What

Simplify the boilerplate and related-section marker tuples in `save.py` to use shorter substring patterns that catch more variants with fewer entries.

## Why

The verbose markers (`related-posts`, `related-articles`, `recommended-posts`) were a subset of what the substring `related` and `recommend` already match via `_attribute_contains_marker()`. Similarly, `_RELATED_HEADINGS` used full phrases when shorter prefixes cover the same cases plus more (e.g., `"further reading"`, `"more from"`).

## Changes

- `_BOILERPLATE_MARKERS`: Replace 3 verbose entries with 2 substring markers (`related`, `recommend`)
- `_RELATED_HEADINGS`: Replace 5 verbose phrases with 5 shorter substring markers

No behavioural change to the conservative stripping logic — sections are still only removed when wrapped in a `<section>` or `<aside>` container.