### PR TITLE
fix(knowledge): ingest silently failing, migrations never applied

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,51 +11,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-
-      - name: Install dependencies
-        run: uv sync
-
-      - name: Install agent dependencies
-        run: cd stacks/agents/app && uv sync
-
-      - name: Lint (ruff)
-        run: cd stacks/agents/app && uv run ruff check .
-
-      - name: Format check (ruff)
-        run: cd stacks/agents/app && uv run ruff format --check .
-
-      - name: Type check (ty)
-        run: cd stacks/agents/app && uv run ty check .
-
-      - name: Tests (pytest)
-        run: cd stacks/agents/app && uv run pytest tests/ -v
-
-      - name: Knowledge — install dependencies
-        run: cd stacks/knowledge/app && uv sync
-
-      - name: Knowledge — lint (ruff)
-        run: cd stacks/knowledge/app && uv run ruff check .
-
-      - name: Knowledge — type check (ty)
-        run: cd stacks/knowledge/app && uv run ty check .
-
-      - name: Knowledge — unit tests (pytest)
-        run: cd stacks/knowledge/app && uv run pytest tests/ -v --ignore=tests/integration
-
-      - name: Lint YAML
-        run: uv run yamllint -c .yamllint.yaml stacks/
-
-      - name: Lint GitHub Actions
-        run: |
-          find .github/workflows -name '*.yaml' -o -name '*.yml' | grep -v '.lock.yml' | xargs actionlint
-
-      - name: Validate compose files
-        run: mise run validate:compose
-
-      - name: Check version consistency
-        run: mise run check:versions
+      - name: Run CI (lint + typecheck + test + validate)
+        run: mise run ci
 
   knowledge-integration:
     runs-on: ubuntu-24.04
@@ -79,11 +37,8 @@ jobs:
       PGDATABASE: knowledge
       PGUSER: knowledge
       PGPASSWORD: knowledge
-      RUN_INTEGRATION_TESTS: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-      - name: Install dependencies
-        run: cd stacks/knowledge/app && uv sync
       - name: Run integration tests
-        run: cd stacks/knowledge/app && uv run pytest tests/integration/ -v
+        run: mise run test:integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,18 @@ jobs:
       - name: Tests (pytest)
         run: cd stacks/agents/app && uv run pytest tests/ -v
 
+      - name: Knowledge — install dependencies
+        run: cd stacks/knowledge/app && uv sync
+
+      - name: Knowledge — lint (ruff)
+        run: cd stacks/knowledge/app && uv run ruff check .
+
+      - name: Knowledge — type check (ty)
+        run: cd stacks/knowledge/app && uv run ty check .
+
+      - name: Knowledge — unit tests (pytest)
+        run: cd stacks/knowledge/app && uv run pytest tests/ -v --ignore=tests/integration
+
       - name: Lint YAML
         run: uv run yamllint -c .yamllint.yaml stacks/
 
@@ -44,3 +56,34 @@ jobs:
 
       - name: Check version consistency
         run: mise run check:versions
+
+  knowledge-integration:
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.2-pg17-trixie@sha256:65825bc6b0af32c347ac8c244a429b3dc88337c9e4390ed9f3f2778aeb675977
+        env:
+          POSTGRES_DB: knowledge
+          POSTGRES_USER: knowledge
+          POSTGRES_PASSWORD: knowledge
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U knowledge -d knowledge"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGDATABASE: knowledge
+      PGUSER: knowledge
+      PGPASSWORD: knowledge
+      RUN_INTEGRATION_TESTS: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      - name: Install dependencies
+        run: cd stacks/knowledge/app && uv sync
+      - name: Run integration tests
+        run: cd stacks/knowledge/app && uv run pytest tests/integration/ -v

--- a/mise.toml
+++ b/mise.toml
@@ -10,9 +10,11 @@ trivy = "0.69.3"
 description = "Lint Python, bash, YAML, and GitHub Actions"
 run = [
   "cd stacks/agents/app && uv run ruff check .",
+  "cd stacks/agents/app && uv run ruff format --check .",
   "cd stacks/knowledge/app && uv run ruff check .",
+  "cd stacks/knowledge/app && uv run ruff format --check .",
   "if ls .githooks/* &>/dev/null; then shellcheck .githooks/*; else echo 'No githooks to lint'; fi",
-  "uv run yamllint -c .yamllint.yaml stacks/",
+  "uv run yamllint -c .yamllint.yaml stacks/ .github/workflows/",
   "if [ -d .github/workflows ]; then find .github/workflows -name '*.yaml' -o -name '*.yml' | grep -v '.lock.yml' | xargs actionlint; else echo 'No workflows to lint'; fi",
 ]
 
@@ -31,11 +33,15 @@ run = [
 ]
 
 [tasks.test]
-description = "Run Python tests"
+description = "Run Python tests (unit tests only; excludes integration tests that need live services)"
 run = [
   "cd stacks/agents/app && uv run pytest tests/ -v",
-  "cd stacks/knowledge/app && uv run pytest tests/ -v",
+  "cd stacks/knowledge/app && uv run pytest tests/ -v --ignore=tests/integration",
 ]
+
+[tasks."test:integration"]
+description = "Run integration tests (requires live Postgres; see stacks/knowledge/app/tests/integration/ for env vars)"
+run = "cd stacks/knowledge/app && RUN_INTEGRATION_TESTS=1 uv run pytest tests/integration/ -v"
 
 [tasks."knowledge:lint"]
 description = "Lint the knowledge CLI package"

--- a/stacks/knowledge/app/knowledge/__main__.py
+++ b/stacks/knowledge/app/knowledge/__main__.py
@@ -160,7 +160,20 @@ def _handle_ingest(args: argparse.Namespace) -> dict[str, EventValue]:
 
     payload = result.model_dump(mode="json")
     print(json.dumps(payload, indent=2))
+    if args.dir:
+        _check_directory_ingest_health(result)
     return _normalize_event_fields(payload)
+
+
+def _check_directory_ingest_health(result: object) -> None:
+    files_failed = getattr(result, "files_failed", 0)
+    documents_processed = getattr(result, "documents_processed", 0)
+    if files_failed > 0 and documents_processed == 0:
+        raise CLIError(
+            f"directory ingest failed: {files_failed} files failed and 0 were processed "
+            "— likely a systemic issue (see logs above)",
+            exit_code=2,
+        )
 
 
 def _handle_search(args: argparse.Namespace) -> dict[str, EventValue]:

--- a/stacks/knowledge/app/knowledge/database.py
+++ b/stacks/knowledge/app/knowledge/database.py
@@ -16,7 +16,22 @@ from psycopg.types.json import Jsonb
 from .models import Chunk, Document, NoteLink, RelatedDocument, SearchResult, normalize_embedding
 
 DATABASE_URL_ENV = "KNOWLEDGE_DB_URL"
-MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "migrations"
+
+
+def _resolve_migrations_dir() -> Path:
+    # Repo layout:      stacks/knowledge/app/knowledge/database.py + stacks/knowledge/migrations/
+    # Container layout: /app/knowledge/database.py            + /app/migrations/
+    here = Path(__file__).resolve()
+    candidates = [here.parents[2] / "migrations", here.parents[1] / "migrations"]
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    raise FileNotFoundError(
+        f"Could not locate migrations directory. Tried: {[str(c) for c in candidates]}"
+    )
+
+
+MIGRATIONS_DIR = _resolve_migrations_dir()
 
 type DBRow = dict[str, Any]
 type DatabaseConnection = Connection[Any]

--- a/stacks/knowledge/app/tests/fixtures/sample_note.md
+++ b/stacks/knowledge/app/tests/fixtures/sample_note.md
@@ -1,0 +1,8 @@
+# Personal Finances Test Fixture
+
+This is a test note used by the integration test to verify the full
+ingest → search round-trip works against a real Postgres + pgvector instance.
+
+The note mentions some distinctive keywords so the full-text search
+component of hybrid search can match reliably without depending on
+real embeddings: **quokka habitat budget allocation 2026**.

--- a/stacks/knowledge/app/tests/integration/test_ingest_e2e.py
+++ b/stacks/knowledge/app/tests/integration/test_ingest_e2e.py
@@ -1,0 +1,112 @@
+"""End-to-end integration test for the knowledge ingest pipeline.
+
+Runs against a real Postgres + pgvector instance. Skipped unless RUN_INTEGRATION_TESTS=1.
+In CI a `services:` container provides Postgres; locally run with:
+
+    docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=test \\
+        pgvector/pgvector:0.8.2-pg17-trixie
+    PGHOST=localhost PGUSER=postgres PGPASSWORD=test PGDATABASE=postgres \\
+        RUN_INTEGRATION_TESTS=1 uv run pytest tests/integration/
+
+Verifies the regression from issue #230: migrations are picked up from the
+correct directory AND ingest+search round-trip succeeds with all stack pieces
+wired together.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import LiteralString, cast
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_INTEGRATION_TESTS") != "1",
+    reason="set RUN_INTEGRATION_TESTS=1 to run integration tests against real Postgres",
+)
+
+FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
+INIT_SQL = Path(__file__).resolve().parents[3] / "init.sql"
+
+EMBEDDING_DIMENSION = 3072
+
+
+def _stub_embeddings(texts: list[str], *, token: str | None = None) -> list[list[float]]:
+    # Deterministic non-zero unit vector — bypasses GitHub Models API.
+    # Each call returns the same vector so the search query embedding matches
+    # the stored chunk embedding exactly (cosine similarity = 1).
+    vector = [0.0] * EMBEDDING_DIMENSION
+    vector[0] = 1.0
+    return [vector for _ in texts]
+
+
+@pytest.fixture
+def fresh_db() -> Iterator[None]:
+    import psycopg
+
+    from knowledge.database import connect, resolve_database_url, run_migrations
+
+    # Bootstrap: run init.sql with a raw connection (before pgvector extension exists,
+    # we can't use knowledge.database.connect which registers the vector type).
+    raw = psycopg.connect(resolve_database_url() or "")
+    try:
+        with raw.cursor() as cursor:
+            cursor.execute("DROP TABLE IF EXISTS chunks, note_links, documents CASCADE")
+            cursor.execute(cast(LiteralString, INIT_SQL.read_text(encoding="utf-8")))
+        raw.commit()
+    finally:
+        raw.close()
+
+    conn = connect()
+    try:
+        run_migrations(conn)
+        yield
+    finally:
+        conn.close()
+
+
+def test_migrations_create_all_expected_tables(fresh_db: None) -> None:
+    # Regression for bug 1: MIGRATIONS_DIR pointing at a missing directory
+    # caused note_links to never be created. This test fails loudly if any
+    # migration silently no-ops.
+    from knowledge.database import _cursor, connect
+
+    conn = connect()
+    try:
+        with _cursor(conn) as cursor:
+            cursor.execute(
+                "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename"
+            )
+            tables = [row["tablename"] for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+    assert tables == ["chunks", "documents", "note_links"]
+
+
+def test_ingest_then_search_roundtrip(fresh_db: None, tmp_path: Path) -> None:
+    # Regression for the full bug class: with migrations applied and embeddings
+    # stubbed, a freshly ingested note must be searchable.
+    from knowledge.ingest import ingest_directory
+    from knowledge.search import search
+
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    fixture = FIXTURES_DIR / "sample_note.md"
+    (notes_dir / "sample_note.md").write_text(fixture.read_text(encoding="utf-8"))
+
+    with patch("knowledge.ingest.get_embeddings", side_effect=_stub_embeddings):
+        result = ingest_directory(notes_dir, glob_pattern="**/*.md")
+
+    assert result.documents_processed == 1
+    assert result.files_failed == 0
+    assert result.chunks_created >= 1
+
+    with patch("knowledge.search.get_embeddings", side_effect=_stub_embeddings):
+        hits = search("quokka habitat budget allocation 2026", limit=5)
+
+    assert hits, "expected at least one search hit for the ingested fixture"
+    assert any("sample_note.md" in hit.document.source_path for hit in hits)

--- a/stacks/knowledge/app/tests/test_database.py
+++ b/stacks/knowledge/app/tests/test_database.py
@@ -6,6 +6,7 @@ import pytest
 
 from knowledge.database import (
     DATABASE_URL_ENV,
+    MIGRATIONS_DIR,
     _migration_files,
     delete_note_links,
     list_documents_by_source_prefix,
@@ -37,6 +38,16 @@ def test_resolve_database_url_falls_back_to_none(monkeypatch: pytest.MonkeyPatch
 
     # Assert — None signals psycopg to use PG* env vars
     assert result is None
+
+
+def test_migrations_dir_resolves_to_real_directory_with_sql_files() -> None:
+    # Regression: MIGRATIONS_DIR previously resolved to a path that didn't exist
+    # in the container, causing run_migrations() to silently no-op.
+    # Assert
+    assert MIGRATIONS_DIR.is_dir(), f"MIGRATIONS_DIR does not exist: {MIGRATIONS_DIR}"
+    sql_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+    assert sql_files, f"no .sql files found under {MIGRATIONS_DIR}"
+    assert _migration_files() == sql_files
 
 
 def test_migration_files_returns_sorted_sql_paths(

--- a/stacks/knowledge/app/tests/test_main.py
+++ b/stacks/knowledge/app/tests/test_main.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from knowledge.__main__ import main
+from knowledge.models import DirectoryIngestResult
+
+
+def _make_result(*, processed: int, failed: int) -> DirectoryIngestResult:
+    return DirectoryIngestResult(
+        files_found=processed + failed,
+        files_failed=failed,
+        documents_processed=processed,
+        chunks_created=processed,
+        documents_skipped=0,
+        documents_deleted=0,
+    )
+
+
+@patch("knowledge.__main__.run_migrations")
+@patch("knowledge.__main__.connect")
+@patch("knowledge.__main__.ingest_directory")
+def test_directory_ingest_exits_nonzero_when_all_files_fail(
+    mock_ingest: MagicMock,
+    _mock_connect: MagicMock,
+    _mock_migrations: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Arrange — every file failed (e.g. systemic DB error)
+    mock_ingest.return_value = _make_result(processed=0, failed=5)
+    monkeypatch.setattr("sys.argv", ["knowledge", "ingest", "--dir", str(tmp_path)])
+
+    # Act / Assert
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code != 0
+
+
+@patch("knowledge.__main__.run_migrations")
+@patch("knowledge.__main__.connect")
+@patch("knowledge.__main__.ingest_directory")
+def test_directory_ingest_exits_zero_on_partial_success(
+    mock_ingest: MagicMock,
+    _mock_connect: MagicMock,
+    _mock_migrations: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Arrange — some files failed but at least one succeeded
+    mock_ingest.return_value = _make_result(processed=3, failed=2)
+    monkeypatch.setattr("sys.argv", ["knowledge", "ingest", "--dir", str(tmp_path)])
+
+    # Act / Assert — partial success is not a failure
+    main()

--- a/stacks/knowledge/init.sql
+++ b/stacks/knowledge/init.sql
@@ -32,7 +32,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS documents_source_path_idx ON documents (source
 CREATE INDEX IF NOT EXISTS documents_content_hash_idx ON documents (content_hash);
 CREATE UNIQUE INDEX IF NOT EXISTS chunks_document_chunk_idx ON chunks (document_id, chunk_index);
 CREATE INDEX IF NOT EXISTS chunks_document_id_idx ON chunks (document_id);
-CREATE INDEX IF NOT EXISTS chunks_embedding_hnsw_idx
-    ON chunks
-    USING hnsw (embedding vector_cosine_ops);
 CREATE INDEX IF NOT EXISTS chunks_tsv_idx ON chunks USING gin (tsv);


### PR DESCRIPTION
Closes #230.

## What this fixes

Two independent bugs made every `ColinCee/notes` push since 2026-04-19 silently drop new documents (including the entire `areas/personal-finances/` folder) while GHA reported green.

### Bug 1 — `MIGRATIONS_DIR` off-by-one

`database.py:19` used `Path(__file__).resolve().parents[2] / "migrations"`. In the container that resolves to `/migrations` (doesn't exist) instead of `/app/migrations` (where the Dockerfile copies them). `_migration_files()` silently returned `[]` and `run_migrations()` no-opped. Migration `002_add_note_links.sql` therefore never created the `note_links` table in the production volume, and every `ingest_file` call crashed on `refresh_note_links()` with `UndefinedTable`.

Fix: multi-candidate resolver that works in both the repo layout (`stacks/knowledge/app/knowledge/database.py` → `stacks/knowledge/migrations/`) and the container layout (`/app/knowledge/database.py` → `/app/migrations/`), and raises `FileNotFoundError` if neither candidate exists. No more silent no-op.

### Bug 2 — `exit 0` on systemic failure

`_do_directory_ingest` aborts after 5 consecutive failures (good), but the CLI in `__main__.py` still reported `status: succeeded, exit_code: 0`. GHA saw a green tick. Fix: raise `CLIError` when a directory ingest ends with `files_failed > 0 and documents_processed == 0`, so the `Ingest notes` workflow will turn red on the next systemic failure.

### Bonus — broken HNSW index in `init.sql`

While building the integration test I discovered `CREATE INDEX ... USING hnsw (embedding vector_cosine_ops)` in `init.sql` has never succeeded: HNSW maxes at 2000 dimensions but the column is `vector(3072)`. Docker's `docker-entrypoint-initdb.d` silently continued past the error, so prod has no vector index — searches fall back to sequential scan, which is fine at the current corpus size. Dropped the doomed index from `init.sql`; a proper ivfflat/halfvec index can be added in a follow-up.

## Regression coverage

- `test_migrations_dir_resolves_to_real_directory_with_sql_files` — asserts the resolver finds an existing directory with real migration files
- `test_directory_ingest_exits_nonzero_when_all_files_fail` — pins the CLI contract
- `test_directory_ingest_exits_zero_on_partial_success` — guards against over-zealous failure detection
- `tests/integration/test_ingest_e2e.py` — end-to-end: spins up real Postgres + pgvector via GHA `services:`, runs `init.sql` + migrations, ingests a fixture, searches, asserts a hit. Gated on `RUN_INTEGRATION_TESTS=1` so local dev isn't forced into it.

## CI

- New `Knowledge — lint / type check / unit tests` steps in the existing `check` job (previously the knowledge package was entirely uncovered in CI).
- New `knowledge-integration` job with a pgvector `services:` container.

## Deployment note

The `note_links` table was manually created on the live beelink DB during diagnosis (before this PR was written) so ingestion could resume. Once this PR merges and deploys, the next push to `ColinCee/notes` will trigger a successful ingest and the missing notes (`areas/personal-finances/`, etc.) will be picked up automatically. No manual intervention needed post-merge.

## Verification

- `mise run lint`, `mise run typecheck`, agent + knowledge pytest all green locally
- Integration test verified end-to-end on beelink against a fresh pgvector container (both tests pass)

🤖 Implemented together with Copilot CLI.