### PR TITLE
refactor(knowledge): replace HTML extraction with trafilatura

### DIFF
--- a/stacks/knowledge/app/knowledge/save.py
+++ b/stacks/knowledge/app/knowledge/save.py
@@ -9,33 +9,19 @@ import shutil
 import subprocess
 import urllib.request
 from datetime import date
+from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
-from bs4 import BeautifulSoup, Tag
+import trafilatura
 
 logger = logging.getLogger(__name__)
 
 _USER_AGENT = "knowledge-save/1.0"
 _TIMEOUT = 30
 _MIN_IMAGE_BYTES = 2 * 1024
-_STRIP_ELEMENTS = ("nav", "footer", "script", "style", "aside", "noscript", "audio")
-_BOILERPLATE_MARKERS = (
-    "nav",
-    "menu",
-    "footer",
-    "sidebar",
-    "social",
-    "share",
-    "cookie",
-    "banner",
-    "toc",
-    "table-of-contents",
-    "related",
-    "recommend",
-)
-_RELATED_HEADINGS = ("related", "recommended", "more from", "you might also", "further reading")
 _DECORATIVE_IMAGE_MARKERS = ("icon", "logo", "avatar", "sprite")
+_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 
 
 def save_url(url: str, *, notes_dir: Path) -> Path:
@@ -43,38 +29,23 @@ def save_url(url: str, *, notes_dir: Path) -> Path:
 
     Returns the path to the saved markdown file.
     """
-    # Sync to latest remote state before writing anything
     _git_sync(notes_dir)
 
     html = _fetch(url)
-    soup = BeautifulSoup(html, "html.parser")
-
-    title = _extract_title(soup, url)
+    title, body = _extract_content(html, url)
     slug = _url_slug(url)
     article_dir = notes_dir / "resources" / "articles" / slug
     md_path = article_dir / f"{slug}.md"
 
     if article_dir.exists():
         logger.info("Article already saved: %s (re-saving with updated content)", article_dir)
-
-    # Find the main content area
-    content_element = _find_content(soup)
-    _strip_boilerplate(content_element)
-
-    if article_dir.exists():
         shutil.rmtree(article_dir)
     article_dir.mkdir(parents=True, exist_ok=True)
 
-    # Download images and rewrite src to local paths
-    _download_images(content_element, url, article_dir)
-
-    # Convert to markdown-ish text
-    markdown = _to_markdown(content_element, title, url, saved_on=date.today())
-
-    # Write the note
+    body = _download_images(body, url, article_dir)
+    markdown = _frontmatter(title, url, saved_on=date.today()) + body + "\n"
     md_path.write_text(markdown, encoding="utf-8")
 
-    # Git commit and push
     _git_commit_and_push(notes_dir, article_dir, title)
 
     logger.info("Saved: %s → %s", url, md_path)
@@ -89,174 +60,92 @@ def _fetch(url: str) -> str:
         return response.read().decode(charset)
 
 
-def _extract_title(soup: BeautifulSoup, fallback_url: str) -> str:
-    """Extract page title from <title> or <h1>."""
-    if soup.title and soup.title.string:
-        return soup.title.string.strip()
-    h1 = soup.find("h1")
-    if h1:
-        return h1.get_text(strip=True)
-    return urlparse(fallback_url).netloc
+def _extract_content(html: str, url: str) -> tuple[str, str]:
+    """Extract article title and markdown body from HTML.
 
-
-def _find_content(soup: BeautifulSoup) -> Tag | BeautifulSoup:
-    """Find the main content element, falling back to body."""
-    for selector in ("article", "main", '[role="main"]'):
-        element = soup.select_one(selector)
-        if element:
-            return element
-    return soup.body or soup
-
-
-def _strip_boilerplate(content: Tag | BeautifulSoup) -> None:
-    """Remove obvious navigation, footer, and sharing boilerplate."""
-    for tag_name in _STRIP_ELEMENTS:
-        for tag in content.find_all(tag_name):
-            tag.decompose()
-
-    for tag in list(content.find_all(True)):
-        if _has_boilerplate_marker(tag):
-            tag.decompose()
-
-    _strip_related_sections(content)
-
-
-def _has_boilerplate_marker(tag: Tag) -> bool:
-    """Return True when class or role metadata marks the element as boilerplate."""
-    attrs = tag.attrs if isinstance(tag.attrs, dict) else {}
-    return _attribute_contains_marker(attrs.get("class")) or _attribute_contains_marker(
-        attrs.get("role")
-    )
-
-
-def _attribute_contains_marker(value: object) -> bool:
-    """Return True when an attribute value matches known boilerplate markers."""
-    if isinstance(value, str):
-        values = [value]
-    elif isinstance(value, list):
-        values = [item for item in value if isinstance(item, str)]
-    else:
-        return False
-
-    return any(
-        marker in raw_value.lower() for raw_value in values for marker in _BOILERPLATE_MARKERS
-    )
-
-
-def _strip_related_sections(content: Tag | BeautifulSoup) -> None:
-    """Remove 'Related content' sections identified by heading text.
-
-    Only removes sections when a containing <section> or <aside> is found,
-    avoiding accidental truncation of legitimate article content.
+    Uses trafilatura for content extraction and boilerplate removal.
+    Falls back to a simple <title> parse when trafilatura metadata is empty.
     """
-    for heading in content.find_all(["h2", "h3", "h4"]):
-        heading_text = heading.get_text(strip=True).lower()
-        if not any(marker in heading_text for marker in _RELATED_HEADINGS):
-            continue
+    meta = trafilatura.bare_extraction(html, url=url, with_metadata=True, include_images=True)
+    body = trafilatura.extract(
+        html, url=url, output_format="markdown", include_images=True, include_links=True
+    )
+    extracted_title: str | None = None
+    if meta:
+        raw = getattr(meta, "title", None)
+        if isinstance(raw, str):
+            extracted_title = raw
+    title = extracted_title or _title_from_html(html) or urlparse(url).netloc
+    return str(title), body or ""
 
-        # Only remove when wrapped in a clear structural container
-        for ancestor in heading.parents:
-            if ancestor is content:
-                break
-            if ancestor.name in ("section", "aside"):
-                ancestor.decompose()
-                break
+
+def _title_from_html(html: str) -> str | None:
+    """Extract title from <title> tag without a full HTML parser dependency."""
+
+    class _TitleParser(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self._in_title = False
+            self.title: str | None = None
+
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            if tag == "title":
+                self._in_title = True
+
+        def handle_data(self, data: str) -> None:
+            if self._in_title:
+                self.title = data.strip()
+
+        def handle_endtag(self, tag: str) -> None:
+            if tag == "title":
+                self._in_title = False
+
+    parser = _TitleParser()
+    parser.feed(html)
+    return parser.title
 
 
-def _download_images(
-    content: Tag | BeautifulSoup,
-    base_url: str,
-    article_dir: Path,
-) -> None:
-    """Download images and rewrite src attributes to local relative paths."""
-    saved_image_count = 0
-    h1 = content.find("h1")
-    title_text = h1.get_text(strip=True).lower() if h1 else ""
+def _frontmatter(title: str, source_url: str, *, saved_on: date) -> str:
+    """Build YAML frontmatter block."""
+    return (
+        "---\n"
+        f"title: {json.dumps(title, ensure_ascii=False)}\n"
+        f"source: {source_url}\n"
+        f"saved: {saved_on.isoformat()}\n"
+        "---\n\n"
+    )
 
-    for img in list(content.find_all("img")):
-        source = _image_source(img)
-        if not source:
-            img.decompose()
-            continue
 
-        if _is_decorative_image(img, source):
-            img.decompose()
-            continue
+def _download_images(markdown: str, base_url: str, article_dir: Path) -> str:
+    """Download images referenced in markdown and rewrite URLs to local filenames."""
+    saved_count = 0
 
-        # Skip hero images that just repeat the title
-        alt = img.get("alt", "")
-        if (
-            isinstance(alt, str)
-            and saved_image_count == 0
-            and title_text
-            and alt.strip().lower() == title_text
-        ):
-            img.decompose()
-            continue
+    def _replace_image(match: re.Match[str]) -> str:
+        nonlocal saved_count
+        alt, src = match.group(1), match.group(2)
+        abs_url = urljoin(base_url, src)
 
-        abs_url = urljoin(base_url, source)
         if abs_url.startswith("data:"):
-            img.decompose()
-            continue
+            return ""
+        if any(marker in src.lower() for marker in _DECORATIVE_IMAGE_MARKERS):
+            return ""
 
         try:
             req = urllib.request.Request(abs_url, headers={"User-Agent": _USER_AGENT})
             with urllib.request.urlopen(req, timeout=_TIMEOUT) as response:
                 image_bytes = response.read()
                 if len(image_bytes) < _MIN_IMAGE_BYTES:
-                    img.decompose()
-                    continue
-
-                saved_image_count += 1
+                    return ""
+                saved_count += 1
                 ext = _image_extension(abs_url, _content_type(response))
-                filename = f"{saved_image_count:03d}{ext}"
-                local_path = article_dir / filename
-                local_path.write_bytes(image_bytes)
-            img["src"] = filename
+                filename = f"{saved_count:03d}{ext}"
+                (article_dir / filename).write_bytes(image_bytes)
+            return f"![{alt}]({filename})"
         except Exception:
             logger.warning("Failed to download image: %s", abs_url)
-            img["src"] = abs_url
+            return f"![{alt}]({abs_url})"
 
-
-def _image_source(img: Tag) -> str | None:
-    """Return the best available image URL from common attributes."""
-    for attr in ("src", "data-src", "data-lazy-src", "data-original"):
-        value = img.get(attr)
-        if isinstance(value, str) and value:
-            return value
-
-    for attr in ("srcset", "data-srcset"):
-        value = img.get(attr)
-        if isinstance(value, str) and value:
-            return value.split(",", 1)[0].strip().split(" ", 1)[0]
-
-    return None
-
-
-def _is_decorative_image(img: Tag, source: str) -> bool:
-    """Return True when an image is likely decorative boilerplate."""
-    lower_source = source.lower()
-    if any(marker in lower_source for marker in _DECORATIVE_IMAGE_MARKERS):
-        return True
-
-    alt = img.get("alt")
-    width = _parse_dimension(img.get("width"))
-    height = _parse_dimension(img.get("height"))
-    if isinstance(alt, str) and alt.strip():
-        return False
-    return width is not None and height is not None and width < 100 and height < 100
-
-
-def _parse_dimension(value: object) -> int | None:
-    """Parse an integer width or height attribute."""
-    if isinstance(value, int):
-        return value
-    if not isinstance(value, str):
-        return None
-    match = re.search(r"\d+", value)
-    if not match:
-        return None
-    return int(match.group())
+    return _IMAGE_RE.sub(_replace_image, markdown)
 
 
 def _content_type(response: object) -> str | None:
@@ -291,56 +180,6 @@ def _image_extension(url: str, content_type: str | None = None) -> str:
         if path.endswith(ext):
             return ext
     return ".png"
-
-
-def _to_markdown(
-    content: Tag | BeautifulSoup,
-    title: str,
-    source_url: str,
-    *,
-    saved_on: date,
-) -> str:
-    """Convert HTML content to a readable markdown note."""
-    lines: list[str] = [
-        "---",
-        f"title: {json.dumps(title, ensure_ascii=False)}",
-        f"source: {source_url}",
-        f"saved: {saved_on.isoformat()}",
-        "---",
-        "",
-    ]
-
-    heading_prefix = {"h1": "#", "h2": "##", "h3": "###", "h4": "####"}
-
-    for element in content.find_all(["h1", "h2", "h3", "h4", "p", "li", "img", "pre"]):
-        if element.name in heading_prefix:
-            text = element.get_text(" ", strip=True)
-            if not text:
-                continue
-            lines.append(f"{heading_prefix[element.name]} {text}")
-            lines.append("")
-        elif element.name == "p":
-            if element.find_parent("li") is not None:
-                continue
-            text = element.get_text(" ", strip=True)
-            if text:
-                lines.append(text)
-                lines.append("")
-        elif element.name == "li":
-            text = element.get_text(" ", strip=True)
-            if text:
-                lines.append(f"- {text}")
-        elif element.name == "img":
-            alt = element.get("alt", "")
-            src = element.get("src", "")
-            lines.append(f"![{alt}]({src})")
-            lines.append("")
-        elif element.name == "pre":
-            code = element.get_text()
-            lines.append(f"```\n{code}\n```")
-            lines.append("")
-
-    return "\n".join(lines) + "\n"
 
 
 def _slugify(text: str) -> str:

--- a/stacks/knowledge/app/pyproject.toml
+++ b/stacks/knowledge/app/pyproject.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 description = "Typed CLI package for the homelab knowledge base"
 requires-python = ">=3.14"
 dependencies = [
-    "beautifulsoup4>=4",
     "httpx>=0.28",
     "pgvector>=0.4",
     "pydantic>=2",
     "psycopg[binary]>=3.2",
     "pypdf>=5",
+    "trafilatura>=2.0.0",
 ]
 
 [dependency-groups]

--- a/stacks/knowledge/app/tests/fixtures/metr-uplift-update.html
+++ b/stacks/knowledge/app/tests/fixtures/metr-uplift-update.html
@@ -1,0 +1,925 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    
+    <meta charset="utf-8">
+    <meta content="ie=edge" http-equiv="x-ua-compatible">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+
+    
+
+<title>We are Changing our Developer Productivity Experiment Design - METR</title>
+
+  <script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "BlogPosting",
+      "headline": "We are Changing our Developer Productivity Experiment Design",
+      "author": "METR",
+      "datePublished": "2026-02-24T00:00:00-08:00",
+      "url": "https://metr.org/blog/2026-02-24-uplift-update/"
+    }
+    </script>
+    <meta name="citation_title" content="We are Changing our Developer Productivity Experiment Design">
+    <meta name="citation_date" content="2026/02/24">
+    <meta name="citation_journal_title" content="METR Blog">
+    <meta name="citation_public_url" content="https://metr.org/blog/2026-02-24-uplift-update/">
+
+
+  <meta property="description" content="Our second developer productivity study faces selection effects from wider AI adoption, prompting us to redesign our approach."/>
+
+
+
+  <meta property="og:title" content="We are Changing our Developer Productivity Experiment Design"/>
+  <meta property="twitter:title" content="We are Changing our Developer Productivity Experiment Design"/>
+
+
+
+  <meta property="og:type" content="website">
+
+
+
+
+
+  <meta property="og:image" content="https://metr.org/assets/images/logo/og-image-logo.png">
+  <meta property="twitter:image" content="https://metr.org/assets/images/logo/og-image-logo.png">
+
+
+
+  <meta property="twitter:card" name="twitter:card" content="summary_large_image">
+
+
+
+
+
+
+
+
+    
+      <link rel="icon" href="/assets/images/favicon/favicon.png">
+    
+    <link
+      rel="stylesheet"
+      href="/assets/css/littlefoot.css"
+    />
+    <link href="/assets/css/main.css?v=1776658094" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@300;400;500;600;700&family=Instrument+Sans:ital,wght@0,400..700;1,300..700&family=Inter:wght@100..900&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cabin+Sketch&display=swap" rel="stylesheet">
+    <script src="/assets/js/tocbot.js"></script>
+    <link rel="preload" href="/assets/js/substackapi_widget.js" as="script">
+
+    
+
+    
+  <script>
+    if (window.location.hostname === 'evals.alignment.org') {
+      window.location.href = 'https://metr.org' + window.location.pathname;
+    }
+  </script>
+</head>
+
+<body class="page  page-post page-post-1 blog-2026-02-24-uplift-update-page">
+
+<div id="wrapper" class="wrapper">
+  <div>
+    <style>
+  .menu-main-mobile {
+    visibility: hidden;
+  }
+</style>
+<div class="menu-main-mobile " id="menu-main-mobile">
+  
+  <div class="menu-main-mobile-top">
+    <div id="close-overlay" class="menu-main-close">
+      <div class="hamburger"></div>
+    </div>
+  </div>
+
+  <div class="menu-main-mobile-center">
+    
+      <ul class="menu">
+        
+          <li class="menu-item-research active">
+            <a href="/research">Research</a>
+          </li>
+        
+          <li class="menu-item-notes ">
+            <a href="/notes">Notes</a>
+          </li>
+        
+          <li class="menu-item-updates ">
+            <a href="/blog">Updates</a>
+          </li>
+        
+          <li class="menu-item-about ">
+            <a href="/about">About</a>
+          </li>
+        
+          <li class="menu-item-donate ">
+            <a href="/donate">Donate</a>
+          </li>
+        
+          <li class="menu-item-careers ">
+            <a href="/careers">Careers</a>
+          </li>
+        
+
+        
+        <li class=" menu-mobile-search">
+          <a href="/search">
+            Search
+            <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M15.7955 15.8111L21 21M18 10.5C18 14.6421 14.6421 18 10.5 18C6.35786 18 3 14.6421 3 10.5C3 6.35786 6.35786 3 10.5 3C14.6421 3 18 6.35786 18 10.5Z" stroke="#fdfcf9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </a>
+        </li>
+      </ul>
+    
+  </div>
+
+  <div class="menu-main-mobile-bottom">
+    
+      
+
+
+    
+    
+  </div>
+
+</div>
+
+
+    <div class="nav-container ">
+  <div class="container-xxl metr-gutter d-flex">
+    <style>
+  .logo-slideable-text {
+    opacity: 0;
+  }
+</style>
+<div class="logos">
+  <div class="logo logo-desktop">
+    <div class="logo-image">
+      <a href="/">
+        
+        
+        <img height="34" alt="METR Logo" src="/assets/images/logo/logo.svg" class="logo-slideable-image " />
+        <!--<div height="28px" alt="METR Logo text"
+          class="logo-slideable-text">
+          &nbsp;
+        </div> -->
+      </a>
+    </div>
+  </div>
+</div>
+
+    <div class="menu-main">
+  <ul>
+    
+      
+        
+        
+        <li class="active  ">
+          <a href="/research">Research</a>
+        </li>
+      
+    
+      
+        
+        
+        <li class="  ">
+          <a href="/notes">Notes</a>
+        </li>
+      
+    
+      
+        
+        
+        <li class="  ">
+          <a href="/blog">Updates</a>
+        </li>
+      
+    
+      
+        
+        
+        <li class="  ">
+          <a href="/about">About</a>
+        </li>
+      
+    
+      
+        
+        
+        <li class="  ">
+          <a href="/donate">Donate</a>
+        </li>
+      
+    
+      
+        
+        
+        <li class="  ">
+          <a href="/careers">Careers</a>
+        </li>
+      
+    
+
+    
+    <li class="menu-item-dropdown menu-item-search ">
+      <div class="searchbar-container">
+        <a href="#" class="search-trigger">
+          <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M15.7955 15.8111L21 21M18 10.5C18 14.6421 14.6421 18 10.5 18C6.35786 18 3 14.6421 3 10.5C3 6.35786 6.35786 3 10.5 3C14.6421 3 18 6.35786 18 10.5Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </a>
+        <form role="search" action="/search" class="search-form search-form-top-bar">
+          <div>
+            <input name="q" type="text" placeholder="Search..." maxlength="240" value="">
+          </div>
+        </form>
+      </div>
+    </li>
+  </ul>
+</div>
+
+    
+    <div class="hamburger-trigger" id="toggle-menu-main-mobile">
+  <button class="hamburger">Menu</button>
+</div>
+  </div>
+</div>
+
+
+
+
+  <div class="header">
+    <div class="header-title ">We are Changing our Developer Productivity Experiment Design</div>
+    <div class="header-subtitle"><span class="header-text "></span></div>
+    <div class="container-xxl">
+      
+        <div class="header-page-meta">
+          
+            
+              <div class="header-authors">
+                 
+                <h5>CONTRIBUTORS</h5>
+                  <div class="post-authors">
+                    
+                    
+                      
+                      
+                      
+                        
+                        <span class="post-author"><a href="/team/joel-becker/">Joel Becker</a></span>, 
+                      
+                    
+                      
+                      
+                      
+                        
+                        <span class="post-author"><a href="/team/nate-rush/">Nate Rush</a></span>, 
+                      
+                    
+                      
+                      
+                      
+                        
+                        <span class="post-author"><a href="/team/tom-cunningham/">Tom Cunningham</a></span>, 
+                      
+                    
+                      
+                      
+                      
+                        
+                        <span class="post-author"><a href="/team/david-rein/">David Rein</a></span>, 
+                      
+                    
+                      
+                        and
+                      
+                      
+                      
+                        
+                        <span class="post-author"><a href="/team/khalid-mahamud/">Khalid Mahamud</a></span>
+                      
+                    
+                  </div>
+                
+              </div>
+            
+          
+          <div class="header-date">
+            <h5>DATE</h5>
+            <span class="post-date">February 24, 2026</span>
+          </div>
+          
+          
+
+          
+            <div class="header-share">
+              <h5>SHARE</h5>
+              <div class="header-share-items">
+                <button class="copy-link-btn" type="button">
+                  <i class="fa fa-link"></i> Copy Link
+                </button>
+                
+                <button class="citation-popup-trigger" type="button" aria-haspopup="dialog" aria-expanded="false">
+                  <i class="fa-regular fa-copy"></i> Citation
+                </button>
+                <div class="citation-popup" role="dialog" aria-modal="true" aria-label="Citation">
+                  <div class="citation-popup-content">
+                    <div class="citation-popup-header">
+                      <span>BibTeX Citation</span>
+                      <button class="citation-popup-close" type="button" aria-label="Close">&times;</button>
+                    </div>
+                    <div class="citation-popup-body">
+                      <div class="highlight"><pre><code class="language-bibtex" data-lang="bibtex"><span class="nc">@misc</span><span class="p">{</span><span class="p">we-are-changing-our-developer-productivity-experiment-design</span><span class="p">,</span>
+    <span class="na">title</span> <span class="p">=</span> <span class="s">{We are Changing our Developer Productivity Experiment Design}</span><span class="p">,</span>
+    <span class="na">author</span> <span class="p">=</span> <span class="s">{Joel Becker, Nate Rush, Tom Cunningham, David Rein, Khalid Mahamud}</span><span class="p">,</span>
+    <span class="na">howpublished</span> <span class="p">=</span> <span class="s">{\url{https://metr.org/blog/2026-02-24-uplift-update/}}</span><span class="p">,</span>
+    <span class="na">year</span> <span class="p">=</span> <span class="s">{2026}</span><span class="p">,</span>
+    <span class="na">month</span> <span class="p">=</span> <span class="s">{02}</span><span class="p">,</span>
+<span class="p">}</span>
+</code></pre></div>
+                      <button class="citation-copy-btn" type="button"><i class="fa-solid fa-clipboard"></i> Copy</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="socials">
+                  
+                  
+                </div>
+              </div>
+            </div>
+          
+        </div>
+      
+    </div>
+  </div>
+
+
+
+
+    
+
+
+
+
+<div class="section pt-0">
+  <div class="container-xxl">
+    <div class="row">
+      <div class="col-12 col-lg-8 offset-lg-2">
+        <div class="content post-content">
+          <nav class="toc-sidebar">
+            <div class="toc-container"></div>
+            <div class="newsletter-signup">
+              <div id="custom-substack-embed"></div>
+              <script>
+                window.CustomSubstackWidget = {
+                  substackUrl: "metr.substack.com",
+                  placeholder: "Enter your email",
+                  buttonText: "Subscribe",
+                  theme: "custom",
+                  colors: {
+                    primary: "var(--color-bg-alt4)",
+                    input: "#FFFFFF",
+                    email: "#353535",
+                    text: "#000000",
+                  }
+                };
+              </script>
+              <script src="/assets/js/substackapi_widget.js"></script>
+            </div>
+          </nav>
+          <p>METR previously published a <a href="https://arxiv.org/pdf/2507.09089">paper</a> which found the use of AI tools caused a 20% slowdown in completing tasks among experienced open-source developers, using data from February to June 2025.</p>
+
+<p>To understand how AI is impacting developer productivity over time, we started a new experiment in August 2025 with a larger pool of developers using the latest AI tools.</p>
+
+<p>Unfortunately, given participant feedback and surveys, we believe that the data from our new experiment gives us an unreliable signal of the current productivity effect of AI tools. The primary reason is that we have observed a significant increase in developers choosing not to participate in the study because they do not wish to work without AI, which likely biases downwards our estimate of AI-assisted speedup. We additionally believe there have been selection effects due to a lower pay rate (we reduced the pay from $150/hr to $50/hr), and that our measurements of time-spent on each task are unreliable for the fraction of developers who use multiple AI agents concurrently.</p>
+
+<p>Based on conversations with study participants, we believe it is likely that developers are more sped up from AI tools now — in early 2026 — compared to our estimates from early 2025. However, because of the selection effects in our experiment, our data is only very weak evidence for the size of this increase.</p>
+
+<p>Our raw results show some evidence for speedup. Our early 2025 study found the use of AI causes tasks to take 19% longer, with a confidence interval between +2% and +39%. For the subset of the original developers who participated in the later study, we now estimate a speedup of -18% with a confidence interval between -38% and +9%. Among newly-recruited developers the estimated speedup is -4%, with a confidence interval between -15% and +9%.</p>
+
+<p><img src="/assets/images/uplift-2026-post/uplift_timeline.png" alt="Late-2025 AI likely accelerated open-source developers, but selection effects obscure the true speedup." /></p>
+
+<p>However the true speedup could be much higher among the developers and tasks which are selected out of the experiment. Some developers self-report very high speedups, though as we documented in our earlier study those estimates can be quite unreliable.</p>
+
+<p>Due to the severity of these selection effects, we are working on changes to the design of our study. Below, we provide further detail and describe our plans for other means of studying the impact of AI on developer productivity.</p>
+
+<h2 id="wider-adoption-of-ai-has-made-it-more-difficult-to-measure-task-level-productivity">Wider adoption of AI has made it more difficult to measure task-level productivity</h2>
+
+<p>Our second study, starting in August, consisted of 10 developers from the original study, plus a new set of 47 developers recruited from a more diverse set of open-source projects. The participants were paid $50/hour for their participation.</p>
+
+<p>As in the initial study, developers were asked to pre-specify each task that they intended to work on, and then submit the task-description for randomization. Each task was assigned to an “AI allowed” or “AI disallowed” condition. The developers would record the amount of time it took to complete the task, and we could thus compare the average time required to complete a typical task with and without AI.</p>
+
+<p>Throughout 2025 there was an increase in the use of agentic tools among open-source developers, such as Claude Code and Codex. This wider adoption of AI has had two important effects in our study:</p>
+
+<ol>
+  <li>
+    <p><strong>Recruitment and retention of developers has become more difficult.</strong> An increased share of developers say they would not want to do 50% of their work without AI, even though our study pays them $50/hour to work on tasks of their own choosing. Our study is thus systematically missing developers who have the most optimistic expectations about AI’s value.</p>
+  </li>
+  <li>
+    <p><strong>Developers have become more selective in which tasks they submit.</strong> When surveyed, 30% to 50% of developers told us that they were choosing not to submit some tasks because they did not want to do them without AI. This implies we are systematically missing tasks which have high expected uplift from AI.</p>
+  </li>
+</ol>
+
+<p>Together, these effects make it likely that our estimate reported above is a lower-bound on the true productivity effects of AI on these developers. The selection effects seem to affect a minority share of developers and of tasks, which limits the degree of bias. However we are likely missing data on the most active adopters of AI, who may be of most interest. As AI capabilities continue to increase and developers’ expectations grow as well, these effects will only get more dramatic, further limiting the validity of this study design.</p>
+
+<p>Based on our interviews and surveys we believe the increase in selection is primarily due to higher expectation of AI-driven uplift by our developers. However the second study also had a lower pay rate, $50/hour instead of $150/hour in the original study, and this also likely contributed to the higher selection.</p>
+
+<p>We also noticed some other problems, though we judged the magnitude of these to be less severe:</p>
+
+<ol start="3">
+  <li>
+    <p>Some developers told us the types of tasks they attempted were different with agentic AI, leaning on the strengths of AI. This has two effects (a) the task-selection will be different between those in our study and those outside it; (b) the time-differences within the study may not represent value-differences, due to the substitution in task-type.</p>
+  </li>
+  <li>
+    <p>Some developers told us the quality of the final work, for a given task, was different between AI-allowed and AI-disallowed conditions, e.g. differences in subjective code quality, or the amount of documentation or tests they chose to create.</p>
+  </li>
+  <li>
+    <p>Some developers were less likely to complete tasks that they submitted if they were assigned to the AI-disallowed condition. One developer did not complete any of the tasks that were assigned to the AI-disallowed condition.</p>
+  </li>
+  <li>
+    <p>Some developers reported it was challenging to report time-spent in completing tasks when they used agentic tools, because they would often work an unrelated task while waiting for the agent to complete its work.</p>
+  </li>
+</ol>
+
+<p>Altogether, these issues make it challenging to interpret our central estimate, and we believe it is likely a bad proxy for the real productivity impact of AI tools on these developers.</p>
+
+<h2 id="selected-developer-quotes">Selected developer quotes</h2>
+
+<p><em>“I’m torn. I’d like to help provide updated data on this question but also I really like using AI!”</em> — a developer from the original study early-2025 when asked to participate in the late-2025 study.</p>
+
+<p><em>“I found I am actually heavily biased sampling the issues … I avoid issues like AI can finish things in just 2 hours, but I have to spend 20 hours. I will feel so painful if the task is decided as AI-disallowed.”</em> — a developer from the new study noting selection effects when choosing what tasks to include in the study.</p>
+
+<p><em>“my head’s going to explode if I try to do too much the old fashioned way because it’s like trying to get across the city walking when all of a sudden I was more used to taking an Uber.”</em> — a developer from the new study noting selection effects when choosing what tasks to include in the study.</p>
+
+<h2 id="other-means-of-measuring-productivity">Other means of measuring productivity</h2>
+
+<p>The impact of AI tools on developer productivity is an important input to AI R&amp;D acceleration, and so we plan to continue exploring the following lines of research:</p>
+
+<ol>
+  <li>
+    <p><strong>More intensive experiments.</strong> The selection issues would be alleviated if we had higher compliance, which could be achieved if we run shorter intense experiments, and possibly pay higher rates.</p>
+  </li>
+  <li>
+    <p><strong>Observational data.</strong> There are many rich data sources on AI use in software development – from aggregate statistics (e.g. <a href="https://newsletter.semianalysis.com/p/claude-code-is-the-inflection-point">approximately 4% of GitHub commits are authored by Claude Code</a>) to fine-grained transcripts (e.g. <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5713646">Sarkar (2025)</a>). We intend to continue observation of our pool of open-source developers to understand how AI is used.</p>
+  </li>
+  <li>
+    <p><strong>Questionnaires.</strong> Despite the difficulty of interpreting self-reported productivity counterfactuals, and thus their potential biases, we are optimistic that careful choice of survey questions, along with time-use studies, could produce useful signals.</p>
+  </li>
+  <li>
+    <p><strong>Fixed-task experiments.</strong> Our original study was novel in letting developers choose their own tasks, before randomization was applied. We could revert to a simpler design in which developers are given a fixed task to complete, either with or without AI assistance.</p>
+  </li>
+  <li>
+    <p><strong>Evaluations.</strong> METR is continuing to build task evals, to measure the ability of agents to autonomously complete tasks, which has a clear relevance to productivity effects of agent adoption.</p>
+  </li>
+  <li>
+    <p><strong>Developer-level experiments.</strong> An alternative design is to randomize at the developer level instead of the task level, i.e. each participant either uses AI for all their tasks or for none. This alleviates some of the task-level selection problems, however it makes the developer-level selection problems worse, and has lower power in detecting productivity effects.</p>
+  </li>
+</ol>
+
+<p>As model capabilities continue to increase, we expect to continue to need to redesign some portions of our capability and measurement techniques.</p>
+
+<h2 id="details-of-the-productivity-study">Details of the productivity study</h2>
+
+<p>We paid developers $50/hour to work on their existing open-source projects, randomizing issues into working with AI-allowed or AI-disallowed. Developers were experienced open-source contributors with median 10 years experience. We have data from 57 developers, across 143 repos, and 800+ tasks.</p>
+
+<p>10 of these developers are from the original study, and the remaining developers are new and recruited from a more diverse set of repositories—including smaller, more greenfield, and less mature repositories.</p>
+
+<p>The full dataset from the early study is available <a href="https://github.com/METR/Measuring-Early-2025-AI-on-Exp-OSS-Devs">here</a>, and the most recent study <a href="https://github.com/METR/Measuring-Late-2025-AI-on-OSS-Devs">here</a>.</p>
+
+        </div>
+        <a class="btn btn-bibtex" role="button">Bib</a>
+<div class="bibtex">
+  <figure class="highlight">
+     <div class="code-display-wrapper">
+        <pre><code class="language-bibtex" data-lang="bibtex"><span class="nc">@misc</span><span class="p">{</span><span class="p">we-are-changing-our-developer-productivity-experiment-design</span><span class="p">,</span>
+    <span class="na">title</span> <span class="p">=</span> <span class="s">{We are Changing our Developer Productivity Experiment Design}</span><span class="p">,</span>
+    <span class="na">author</span> <span class="p">=</span> <span class="s">{Joel Becker, Nate Rush, Tom Cunningham, David Rein, Khalid Mahamud}</span><span class="p">,</span>
+    <span class="na">howpublished</span> <span class="p">=</span> <span class="s">{\url{https://metr.org/blog/2026-02-24-uplift-update/}}</span><span class="p">,</span>
+    <span class="na">year</span> <span class="p">=</span> <span class="s">{2026}</span><span class="p">,</span>
+    <span class="na">month</span> <span class="p">=</span> <span class="s">{02}</span><span class="p">,</span>
+<span class="p">}</span>
+</code></pre>
+        <button class="copy" type="button" aria-label="Copy code to clipboard"><i class="fa-solid fa-clipboard"></i></button>
+     </div>
+  </figure>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.btn-bibtex').forEach(function(button) {
+      button.addEventListener('click', function() {
+        button.nextElementSibling.classList.toggle('active');
+      });
+    });
+    document.querySelectorAll('.bibtex .copy').forEach(function(button) {
+      button.addEventListener('click', function() {
+        var code = button.closest('.bibtex').querySelector('code');
+        navigator.clipboard.writeText(code.innerText).then(function() {
+          button.querySelector('i').classList.replace('fa-clipboard', 'fa-clipboard-check');
+
+          setTimeout(function() {
+            button.querySelector('i').classList.replace('fa-clipboard-check', 'fa-clipboard');
+          }, 2000);
+        });
+      });
+    });
+  });
+</script>
+
+
+        <div class="subscribe-box mt-5 mb-5">
+          
+          
+          <img height="34" alt="METR Logo" src="/assets/images/gen/home/evals-logo-slideable.svg" class="logo-slideable-image mt-4 mb-4 " />
+          <p><strong>METR</strong> researches, develops, and evaluates frontier AI systems to measure how well they can perform complex tasks autonomously. Subscribe to our newsletter for updates.</p>
+
+          <div class="full-bleed divider-line pt-5 mb-3" style="z-index: 0; border-top-color: #EAECF0; top: 28px;"></div>
+
+          <div id="custom-substack-embed"></div>
+          <script>
+            window.CustomSubstackWidget = {
+              substackUrl: "metr.substack.com",
+              placeholder: "Join our newsletter",
+              buttonText: "Subscribe",
+              theme: "custom",
+              colors: {
+                primary: "var(--color-bg-alt4)",
+                input: "#FFFFFF",
+                email: "#353535",
+                text: "#000000",
+              }
+            };
+          </script>
+          <script src="/assets/js/substackapi_widget.js"></script>
+
+          <p class="mt-4 mb-4">Want to contribute to this work? METR is hiring: <a href="/careers">View open roles</a></p>
+
+        </div>
+
+        <div class="full-bleed divider-line pt-5"></div>
+
+        <div class="section featured-research-section">
+          <div class="featured-research-header">
+            <h2>Featured research</h2>
+          </div>
+
+          <p class="featured-research-description">METR researches, develops and runs cutting-edge tests of AI capabilities, including broad autonomous capabilities and the ability of AI systems to conduct AI R&D.</p>
+
+          <div class="research-tabs-container">
+            <div class="tab-content">
+              <div class="featured-research-tabs-content tab-pane fade show active" id="research-for-the-public" role="tabpanel" aria-labelledby="research-for-the-public-tab">
+                <div class="featured-research-card">
+  
+    <img src="/assets/images/gpt-5-1-research.jpg" alt="GPT-5.1 Evaluation Results" class="img-fluid mb-4" />
+  
+  <h3>GPT-5.1 Evaluation Results</h3>
+  <p class="featured-research-card-description">We evaluate whether GPT-5.1 poses significant catastrophic risks via AI self-improvement, rogue replication, or sabotage of AI labs.</p>
+  <span class="featured-research-card-link">
+    <a href="https://evaluations.metr.org/gpt-5-1-codex-max-report/" class="card-main-link">Read more <i class="fa-solid fa-arrow-down link-arrow"></i></a>
+  </span>
+  
+</div>
+                <div class="featured-research-card">
+  
+    <img src="/assets/images/measuring-ai-ability-to-complete-long-tasks/length-of-tasks-log.png" alt="Measuring AI Ability to Complete Long Tasks" class="img-fluid mb-4" />
+  
+  <h3>Measuring AI Ability to Complete Long Tasks</h3>
+  <p class="featured-research-card-description">We propose measuring AI performance in terms of the length of tasks AI agents can complete. We show that this metric has been consistently exponentially increasing.</p>
+  <span class="featured-research-card-link">
+    <a href="/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/" class="card-main-link">Read more <i class="fa-solid fa-arrow-down link-arrow"></i></a>
+  </span>
+  
+</div>
+                <div class="featured-research-card">
+  
+    <img src="/assets/images/downlift/forecasted-vs-observed.png" alt="Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity" class="img-fluid mb-4" />
+  
+  <h3>Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity</h3>
+  <p class="featured-research-card-description">We find that when developers use AI tools, they take 19% longer than without—AI makes them slower.</p>
+  <span class="featured-research-card-link">
+    <a href="/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/" class="card-main-link">Read more <i class="fa-solid fa-arrow-down link-arrow"></i></a>
+  </span>
+  
+</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+  </div>
+  <div class="footer-container">
+    <footer class="footer">
+  <div class="container-xxl metr-gutter">
+    <div class="row footer-bottom-section">
+      <div class="col-12 col-lg-5">
+        <div class="logo-image mb-2">
+          <a href="/">
+            <img height="34" alt="METR Logo" src="/assets/images/gen/home/evals-logo-slideable.svg" class="logo-slideable-image ">
+          </a>
+        </div>
+        <p>METR (pronounced 'meter') is a research nonprofit that scientifically measures whether and when AI systems might threaten catastrophic harm to society.</p>
+        <div id="custom-substack-embed"></div>
+        <script>
+          window.CustomSubstackWidget = {
+            substackUrl: "metr.substack.com",
+            placeholder: "Join our newsletter",
+            buttonText: "Subscribe",
+            theme: "custom",
+            colors: {
+              primary: "var(--color-bg-alt4)",
+              input: "#FFFFFF",
+              email: "#353535",
+              text: "#000000",
+            }
+          };
+        </script>
+        <script src="/assets/js/substackapi_widget.js"></script>
+      </div>
+      <div class="col-12 col-lg-6 offset-lg-1 mt-4">
+        <div class="row">
+          <div class="col-12 col-sm-4 mb-4">
+            <h4>Research</h4>
+            <ul>
+              <li><a href="/research">Research</a></li>
+              <li><a href="/notes">Notes</a></li>
+              <li><a href="/blog">Updates</a></li>
+            </ul>
+          </div>
+          <div class="col-12 col-sm-4 mb-4">
+            <h4>Follow METR</h4>
+            <ul>
+              <li><a href="https://metr.substack.com">
+              <svg class="social-icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" height="1em" width="1em">
+                <title>Substack</title>
+                <path d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z" fill="#666" stroke-width="1"></path>
+              </svg>
+              Substack</a></li>
+              <li><a href="https://x.com/METR_Evals">
+                <svg class="social-icon" width="1em" height="1em" viewBox="0 0 24 24" fill="none">
+                  <title>twitter</title><path d="M14.094 10.317 22.28 1H20.34l-7.11 8.088L7.557 1H1.01l8.583 12.231L1.01 23H2.95l7.503-8.543L16.446 23h6.546M3.649 2.432h2.978L20.34 21.639h-2.98" fill="currentColor"></path>
+                </svg> X (Twitter)</a></li>
+              <li><a href="https://www.linkedin.com/company/metr-evals/">
+                <svg class="social-icon" height="1em" width="1em" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+                  viewBox="0 0 382 382" xml:space="preserve">
+                <path style="fill:#0077B7;" d="M347.445,0H34.555C15.471,0,0,15.471,0,34.555v312.889C0,366.529,15.471,382,34.555,382h312.889
+                  C366.529,382,382,366.529,382,347.444V34.555C382,15.471,366.529,0,347.445,0z M118.207,329.844c0,5.554-4.502,10.056-10.056,10.056
+                  H65.345c-5.554,0-10.056-4.502-10.056-10.056V150.403c0-5.554,4.502-10.056,10.056-10.056h42.806
+                  c5.554,0,10.056,4.502,10.056,10.056V329.844z M86.748,123.432c-22.459,0-40.666-18.207-40.666-40.666S64.289,42.1,86.748,42.1
+                  s40.666,18.207,40.666,40.666S109.208,123.432,86.748,123.432z M341.91,330.654c0,5.106-4.14,9.246-9.246,9.246H286.73
+                  c-5.106,0-9.246-4.14-9.246-9.246v-84.168c0-12.556,3.683-55.021-32.813-55.021c-28.309,0-34.051,29.066-35.204,42.11v97.079
+                  c0,5.106-4.139,9.246-9.246,9.246h-44.426c-5.106,0-9.246-4.14-9.246-9.246V149.593c0-5.106,4.14-9.246,9.246-9.246h44.426
+                  c5.106,0,9.246,4.14,9.246,9.246v15.655c10.497-15.753,26.097-27.912,59.312-27.912c73.552,0,73.131,68.716,73.131,106.472
+                  L341.91,330.654L341.91,330.654z"/>
+                </svg>
+              LinkedIn</a></li>
+              <li><a href="https://github.com/METR/">
+                <svg class="social-icon" width="1em" height="1em" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#666"></path>
+                </svg>
+                GitHub</a></li>
+            </ul>
+          </div>
+          <div class="col-12 col-sm-4 mb-4">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="/about">About Us</a></li>
+              <li><a href="/careers">Careers</a></li>
+              <li><a href="/donate">Donate</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="footer-copyright">
+        © 2026 METR. All rights reserved.
+      </div>
+    </div>
+  </div>
+</footer>
+
+
+    
+  </div>
+</div>
+<script src="/assets/js/scripts.js"></script>
+
+
+
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-MMLYWX6QCN"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-MMLYWX6QCN');
+</script>
+
+
+
+
+
+<script>
+  document.addEventListener("DOMContentLoaded", function(event) {
+    addIdsToHeaders();
+
+    const postContent = document.querySelector(".content");
+    if (!postContent) return;
+    const headings = postContent.querySelectorAll('h1, h2, h3, h4, h5').length;
+    if (headings >= 4) {
+      const tocSidebar = document.querySelector('.toc-sidebar');
+      if (tocSidebar) {
+        tocSidebar.classList.add('display-toc');
+      }
+      tocbot.init({
+        // Where to render the table of contents.
+        tocSelector: '.toc-container',
+        // Where to grab the headings to build the table of contents.
+        contentSelector: '.content',
+        // Which headings to grab inside of the contentSelector element.
+        headingSelector: 'h1, h2, h3, h4, h5',
+        // Ensure correct positioning
+        hasInnerContainers: true,
+        ignoreSelector: '.hoverover *',
+        scrollSmoothOffset: -72,
+        collapseDepth: 6,
+        disableTocScrollSync: false,
+        positionFixedSelector: '.toc-sidebar',
+        positionFixedClass: 'is-position-fixed',
+        fixedSidebarOffset: 440,
+        onClick: function(e) {
+          const headerId = e.target.getAttribute('href').replace('#', '');
+          openContentByHeaderId(headerId);
+        }
+      });
+
+      // Make TOC sidebar stop before the featured research section
+      function handleTocSidebarPosition() {
+        const tocSidebar = document.querySelector('.toc-sidebar');
+        const featuredResearch = document.querySelector('.featured-research-section');
+        const content = document.querySelector('.content');
+
+        if (!tocSidebar || !featuredResearch || !content) return;
+
+        const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+        const sidebarHeight = tocSidebar.offsetHeight;
+        const featuredResearchTop = featuredResearch.getBoundingClientRect().top + scrollTop;
+        const contentTop = content.getBoundingClientRect().top + scrollTop;
+
+        // The point where the sidebar bottom would hit the featured research section
+        const stopPoint = featuredResearchTop - sidebarHeight - 160;
+
+        if (scrollTop > stopPoint && tocSidebar.classList.contains('is-position-fixed')) {
+          // Switch to absolute positioning, anchored at the stop point
+          tocSidebar.classList.add('is-stopped');
+          tocSidebar.style.top = (stopPoint - contentTop + 70) + 'px'; // 70px matches the original top offset
+        } else {
+          tocSidebar.classList.remove('is-stopped');
+          tocSidebar.style.top = '';
+        }
+      }
+
+      window.addEventListener('scroll', handleTocSidebarPosition);
+      window.addEventListener('resize', handleTocSidebarPosition);
+
+      // Make TOC fade when overlapping with tables, images, or figures
+      function handleTocOverlap() {
+        const tocSidebar = document.querySelector('.toc-sidebar');
+        if (!tocSidebar) return;
+        const isVisible = tocSidebar.offsetWidth > 0 || tocSidebar.offsetHeight > 0;
+        if (!isVisible) return;
+
+        const tocRect = tocSidebar.getBoundingClientRect();
+        const content = document.querySelector('.content');
+        if (!content) return;
+
+        const elements = content.querySelectorAll('table, img, figure');
+        let isOverlapping = false;
+
+        for (const el of elements) {
+          const elRect = el.getBoundingClientRect();
+          const horizontalOverlap = elRect.left < tocRect.right && elRect.right > tocRect.left;
+          const verticalOverlap = elRect.top < tocRect.bottom && elRect.bottom > tocRect.top;
+
+          if (horizontalOverlap && verticalOverlap) {
+            isOverlapping = true;
+            break;
+          }
+        }
+
+        if (isOverlapping) {
+          tocSidebar.classList.add('toc-faded');
+        } else {
+          tocSidebar.classList.remove('toc-faded');
+        }
+      }
+
+      window.addEventListener('scroll', handleTocOverlap);
+      window.addEventListener('resize', handleTocOverlap);
+
+      handleTocOverlap();
+
+      
+        function adjustMainMargin() {
+          // For browsers that don't support the :has selector:
+          if (window.innerWidth >= 992 && window.innerWidth <= 1469 && document.querySelector('.toc-list')) {
+            if (window.innerWidth > 1220) {
+              document.querySelector('.content').style.marginLeft = '10rem';
+              document.querySelector('.content').style.marginRight = '-8rem';
+            } else {
+              document.querySelector('.content').style.marginLeft = '8rem';
+              document.querySelector('.content').style.marginRight = '-8rem';
+            }
+          } else {
+            document.querySelector('.content').style.marginLeft = '';
+            document.querySelector('.content').style.marginRight = '';
+          }
+        }
+
+        window.addEventListener("resize", function(event) {
+          adjustMainMargin();
+        });
+
+        adjustMainMargin();
+      
+
+      window.setTimeout(() => {
+        /* Solves a bug where the TOC links don't land on the right place
+        https://github.com/tscanlin/tocbot/issues/254 */
+        tocbot.refresh();
+      }, 100);
+    }
+  });
+</script>
+
+
+<script type="application/javascript">
+  document.addEventListener('DOMContentLoaded', () => {
+    littlefoot.littlefoot({
+      activateOnHover: true,
+      dismissOnUnhover: true,
+      activateCallback: function(tooltip, button) {
+        const match = button.id.match(/lf-fnref:(\d+):?\d*/);
+        if (match) {
+          const downLink = tooltip.querySelector('.littlefoot__content .a-fn-ref-raw');
+          // move it inside the tag before it (i.e., the paragraph tag)
+          if (downLink) {
+            downLink.setAttribute('href', `#fn:${match[1]}`);
+            const content = tooltip.querySelector('.littlefoot__content');
+            const tags = content.children;
+            if (tags.length > 0) {
+              // find the last tag that isn't this link itself
+              let lastTag = tags[tags.length - 1];
+              if (lastTag === downLink) {
+                lastTag = tags[tags.length - 2];
+              }
+              lastTag.appendChild(downLink);
+            }
+          }
+        }
+      },
+      buttonTemplate: `<button
+        aria-label="Footnote <% number %>"
+        class="littlefoot__button"
+        id="<% reference %>"
+        />
+        <span class="fn-ref-raw">[<% reference %>]</span>
+      </button>`,
+      contentTemplate: `<aside
+          alt="Footnote <% number %>"
+          class="littlefoot__popover"
+          id="fncontent:<% id %>"
+        >
+          <div class="littlefoot__wrapper">
+            <div class="littlefoot__content">
+              <% content %>
+              <a data-footnote-ref="<% reference %>" class="a-fn-ref-raw"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" style="height: 1rem">
+                <path d="M297.4 566.6C309.9 579.1 330.2 579.1 342.7 566.6L502.7 406.6C515.2 394.1 515.2 373.8 502.7 361.3C490.2 348.8 469.9 348.8 457.4 361.3L352 466.7L352 96C352 78.3 337.7 64 320 64C302.3 64 288 78.3 288 96L288 466.7L182.6 361.3C170.1 348.8 149.8 348.8 137.3 361.3C124.8 373.8 124.8 394.1 137.3 406.6L297.3 566.6z"/>
+              </svg></a>
+            </div>
+          </div>
+          <div class="littlefoot__tooltip"></div>
+        </aside>`
+    });
+    // Down arrow from: Font Awesome Free v7.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc. */
+    transformFootnoteReferences();
+    markLastFootnotesInGroupsByParagraph();
+    wrapFootnotesPrecedingCommasInNoWrapSpans();
+    addSpacesBetweenFootnotes();
+    scrollDownToFootnotesOnClick();
+  });
+</script>
+
+
+
+</body>
+</html>

--- a/stacks/knowledge/app/tests/test_save.py
+++ b/stacks/knowledge/app/tests/test_save.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
-import urllib.request
-from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -15,54 +13,180 @@ import pytest
 from knowledge import __main__ as cli
 from knowledge import save
 
-SAMPLE_HTML = """<!DOCTYPE html>
-<html>
-<head><title>Test Article Title</title></head>
-<body>
-<nav><a href="/">Home</a></nav>
-<header><h1>Site Header</h1></header>
-<article>
-    <h1>Test Article Title</h1>
-    <p>This is the first paragraph with important content.</p>
-    <h2>Section Two</h2>
-    <p>More content here about the topic.</p>
-    <img src="/images/diagram.png" alt="Architecture diagram">
-    <p>Final paragraph.</p>
-</article>
-<footer>Copyright 2026</footer>
-</body>
-</html>"""
-
-SIMPLE_HTML = """<html>
-<head><title>Simple Page</title></head>
-<body><p>Hello world</p></body>
-</html>"""
-
 
 def _task_event(stderr: str) -> dict[str, object]:
     return json.loads(stderr.strip())
 
 
-class TestExtractTitle:
+class TestTitleFromHtml:
     def test_extracts_from_title_tag(self) -> None:
-        from bs4 import BeautifulSoup
+        html = "<html><head><title>My Article</title></head><body></body></html>"
+        assert save._title_from_html(html) == "My Article"
 
-        soup = BeautifulSoup(SAMPLE_HTML, "html.parser")
-        assert save._extract_title(soup, "https://example.com") == "Test Article Title"
-
-    def test_falls_back_to_h1(self) -> None:
-        from bs4 import BeautifulSoup
-
-        html = "<html><body><h1>Heading Title</h1></body></html>"
-        soup = BeautifulSoup(html, "html.parser")
-        assert save._extract_title(soup, "https://example.com") == "Heading Title"
-
-    def test_falls_back_to_domain(self) -> None:
-        from bs4 import BeautifulSoup
-
+    def test_returns_none_when_no_title(self) -> None:
         html = "<html><body><p>No title</p></body></html>"
-        soup = BeautifulSoup(html, "html.parser")
-        assert save._extract_title(soup, "https://example.com/page") == "example.com"
+        assert save._title_from_html(html) is None
+
+    def test_strips_whitespace(self) -> None:
+        html = "<html><head><title>  Padded Title  </title></head></html>"
+        assert save._title_from_html(html) == "Padded Title"
+
+
+class TestExtractContent:
+    @patch("trafilatura.extract", return_value="## Heading\n\nBody text")
+    @patch("trafilatura.bare_extraction")
+    def test_uses_trafilatura_title_and_body(
+        self, mock_bare: MagicMock, mock_extract: MagicMock
+    ) -> None:
+        meta = MagicMock()
+        meta.title = "Extracted Title"
+        mock_bare.return_value = meta
+
+        title, body = save._extract_content("<html>...</html>", "https://example.com")
+
+        assert title == "Extracted Title"
+        assert body == "## Heading\n\nBody text"
+
+    @patch("trafilatura.extract", return_value="Some body")
+    @patch("trafilatura.bare_extraction")
+    def test_falls_back_to_html_title_tag(
+        self, mock_bare: MagicMock, mock_extract: MagicMock
+    ) -> None:
+        meta = MagicMock()
+        meta.title = None
+        mock_bare.return_value = meta
+        html = "<html><head><title>Fallback Title</title></head><body>content</body></html>"
+
+        title, _ = save._extract_content(html, "https://example.com")
+
+        assert title == "Fallback Title"
+
+    @patch("trafilatura.extract", return_value="Some body")
+    @patch("trafilatura.bare_extraction")
+    def test_falls_back_to_domain_when_no_title(
+        self, mock_bare: MagicMock, mock_extract: MagicMock
+    ) -> None:
+        meta = MagicMock()
+        meta.title = None
+        mock_bare.return_value = meta
+
+        title, _ = save._extract_content("<html><body>x</body></html>", "https://example.com/page")
+
+        assert title == "example.com"
+
+    @patch("trafilatura.extract", return_value=None)
+    @patch("trafilatura.bare_extraction", return_value=None)
+    def test_returns_empty_body_when_extraction_fails(
+        self, mock_bare: MagicMock, mock_extract: MagicMock
+    ) -> None:
+        title, body = save._extract_content("<html></html>", "https://example.com")
+
+        assert title == "example.com"
+        assert body == ""
+
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+class TestExtractContentRegression:
+    """End-to-end tests with real article HTML snapshots.
+
+    Fixtures are saved snapshots of public articles so tests run offline.
+    Source: https://metr.org/blog/2026-02-24-uplift-update/
+    """
+
+    def test_metr_article_produces_structured_markdown(self) -> None:
+        html = (_FIXTURE_DIR / "metr-uplift-update.html").read_text(encoding="utf-8")
+
+        title, body = save._extract_content(html, "https://metr.org/blog/2026-02-24-uplift-update/")
+
+        assert title
+        assert "experiment" in title.lower() or "productivity" in title.lower()
+        assert "##" in body, "Expected markdown headings"
+        assert "![" in body, "Expected image references"
+        assert len(body.splitlines()) > 30, "Expected substantial article content"
+
+
+class TestDownloadImages:
+    def test_downloads_and_rewrites_image_urls(self, tmp_path: Path) -> None:
+        markdown = "Text\n\n![Diagram](https://example.com/img.png)\n\nMore text"
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            response = MagicMock()
+            response.read.return_value = b"\x89PNG" + (b"x" * 3000)
+            response.headers.get_content_type.return_value = "image/png"
+            response.__enter__ = lambda s: response
+            response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = response
+
+            result = save._download_images(markdown, "https://example.com", tmp_path)
+
+        assert "![Diagram](001.png)" in result
+        assert (tmp_path / "001.png").exists()
+        assert len((tmp_path / "001.png").read_bytes()) > 2048
+
+    def test_filters_decorative_images(self, tmp_path: Path) -> None:
+        markdown = "![Site logo](/images/logo.png)\n\n![Chart](/images/chart.png)"
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            response = MagicMock()
+            response.read.return_value = b"\x89PNG" + (b"x" * 3000)
+            response.headers.get_content_type.return_value = "image/png"
+            response.__enter__ = lambda s: response
+            response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = response
+
+            result = save._download_images(markdown, "https://example.com", tmp_path)
+
+        assert "logo" not in result
+        assert "![Chart](001.png)" in result
+
+    def test_strips_images_below_min_size(self, tmp_path: Path) -> None:
+        markdown = "![Tiny](/tiny.png)"
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            response = MagicMock()
+            response.read.return_value = b"\x89PNG" + (b"x" * 100)
+            response.headers.get_content_type.return_value = "image/png"
+            response.__enter__ = lambda s: response
+            response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = response
+
+            result = save._download_images(markdown, "https://example.com", tmp_path)
+
+        assert result == ""
+        assert not list(tmp_path.iterdir())
+
+    def test_keeps_url_on_download_failure(self, tmp_path: Path) -> None:
+        markdown = "![Chart](https://example.com/chart.png)"
+
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            result = save._download_images(markdown, "https://example.com", tmp_path)
+
+        assert "![Chart](https://example.com/chart.png)" in result
+
+    def test_resolves_relative_urls(self, tmp_path: Path) -> None:
+        markdown = "![Diagram](/assets/img.png)"
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            response = MagicMock()
+            response.read.return_value = b"\x89PNG" + (b"x" * 3000)
+            response.headers.get_content_type.return_value = "image/png"
+            response.__enter__ = lambda s: response
+            response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = response
+
+            save._download_images(markdown, "https://example.com/blog/post", tmp_path)
+
+        call_arg = mock_urlopen.call_args[0][0]
+        assert call_arg.full_url == "https://example.com/assets/img.png"
+
+    def test_strips_data_uri_images(self, tmp_path: Path) -> None:
+        markdown = "![](data:image/png;base64,abc123)"
+
+        result = save._download_images(markdown, "https://example.com", tmp_path)
+
+        assert result == ""
 
 
 class TestUrlSlug:
@@ -89,82 +213,21 @@ class TestUrlSlug:
         assert slug == "article"
 
 
-class TestFindContent:
-    def test_finds_article_element(self) -> None:
-        from bs4 import BeautifulSoup
-
-        soup = BeautifulSoup(SAMPLE_HTML, "html.parser")
-        content = save._find_content(soup)
-        assert content.name == "article"
-
-    def test_falls_back_to_main(self) -> None:
-        from bs4 import BeautifulSoup
-
-        html = "<html><body><main><p>Content</p></main></body></html>"
-        soup = BeautifulSoup(html, "html.parser")
-        content = save._find_content(soup)
-        assert content.name == "main"
-
-    def test_falls_back_to_body(self) -> None:
-        from bs4 import BeautifulSoup
-
-        html = "<html><body><p>Content</p></body></html>"
-        soup = BeautifulSoup(html, "html.parser")
-        content = save._find_content(soup)
-        assert content.name == "body"
-
-
-class TestToMarkdown:
-    def test_includes_frontmatter(self) -> None:
-        from bs4 import BeautifulSoup
-
-        soup = BeautifulSoup("<article><p>Hello</p></article>", "html.parser")
-        md = save._to_markdown(
-            soup,
-            "My Title",
-            "https://example.com",
-            saved_on=date(2026, 4, 20),
-        )
-        assert md.startswith(
-            '---\ntitle: "My Title"\nsource: https://example.com\nsaved: 2026-04-20\n---\n'
-        )
-
-    def test_includes_paragraphs(self) -> None:
-        from bs4 import BeautifulSoup
-
-        html = "<article><p>First para</p><p>Second para</p></article>"
-        soup = BeautifulSoup(html, "html.parser")
-        md = save._to_markdown(soup, "Title", "https://x.com", saved_on=date(2026, 4, 20))
-        assert "First para" in md
-        assert "Second para" in md
-
-    def test_includes_images(self) -> None:
-        from bs4 import BeautifulSoup
-
-        soup = BeautifulSoup('<article><img src="001.png" alt="Diagram"></article>', "html.parser")
-        md = save._to_markdown(soup, "Title", "https://x.com", saved_on=date(2026, 4, 20))
-        assert "![Diagram](001.png)" in md
-
-    def test_does_not_duplicate_paragraphs_inside_list_items(self) -> None:
-        from bs4 import BeautifulSoup
-
-        soup = BeautifulSoup("<article><ul><li><p>One item</p></li></ul></article>", "html.parser")
-        md = save._to_markdown(soup, "Title", "https://x.com", saved_on=date(2026, 4, 20))
-        assert md.count("One item") == 1
-
-
 class TestSaveUrl:
     @patch.object(save, "_git_commit_and_push")
     @patch.object(save, "_git_sync")
+    @patch.object(save, "_extract_content")
     @patch.object(save, "_fetch")
     def test_creates_note_with_correct_structure(
         self,
         mock_fetch: MagicMock,
+        mock_extract: MagicMock,
         mock_sync: MagicMock,
         mock_git: MagicMock,
         tmp_path: Path,
     ) -> None:
-        mock_fetch.return_value = SIMPLE_HTML
+        mock_fetch.return_value = "<html>...</html>"
+        mock_extract.return_value = ("Simple Page", "Hello world")
 
         result = save.save_url("https://example.com/article", notes_dir=tmp_path)
 
@@ -174,99 +237,55 @@ class TestSaveUrl:
         content = result.read_text()
         assert 'title: "Simple Page"' in content
         assert "source: https://example.com/article" in content
+        assert "Hello world" in content
 
     @patch.object(save, "_git_commit_and_push")
     @patch.object(save, "_git_sync")
+    @patch.object(save, "_extract_content")
     @patch.object(save, "_fetch")
-    def test_downloads_meaningful_images_next_to_markdown(
+    def test_downloads_images_from_extracted_markdown(
         self,
         mock_fetch: MagicMock,
+        mock_extract: MagicMock,
         mock_sync: MagicMock,
         mock_git: MagicMock,
         tmp_path: Path,
     ) -> None:
-        mock_fetch.return_value = SAMPLE_HTML
+        mock_fetch.return_value = "<html>...</html>"
+        mock_extract.return_value = (
+            "Post Title",
+            "Content\n\n![Architecture diagram](https://example.com/images/diagram.png)",
+        )
 
         with patch("urllib.request.urlopen") as mock_urlopen:
-            mock_response = MagicMock()
-            mock_response.read.return_value = b"\x89PNG" + (b"x" * 3000)
-            mock_response.headers.get_content_type.return_value = "image/png"
-            mock_response.__enter__ = lambda s: mock_response
-            mock_response.__exit__ = MagicMock(return_value=False)
-            mock_urlopen.return_value = mock_response
+            response = MagicMock()
+            response.read.return_value = b"\x89PNG" + (b"x" * 3000)
+            response.headers.get_content_type.return_value = "image/png"
+            response.__enter__ = lambda s: response
+            response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = response
 
             result = save.save_url("https://example.com/post", notes_dir=tmp_path)
 
         article_dir = result.parent
-        image_paths = sorted(path.name for path in article_dir.iterdir() if path.suffix == ".png")
+        image_paths = sorted(p.name for p in article_dir.iterdir() if p.suffix == ".png")
         assert image_paths == ["001.png"]
         assert "![Architecture diagram](001.png)" in result.read_text()
 
     @patch.object(save, "_git_commit_and_push")
     @patch.object(save, "_git_sync")
-    @patch.object(save, "_fetch")
-    def test_filters_boilerplate_and_junk_images(
-        self,
-        mock_fetch: MagicMock,
-        mock_sync: MagicMock,
-        mock_git: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        mock_fetch.return_value = """<html><body>
-        <main>
-            <div class="top-nav">Products</div>
-            <article>
-                <p>Real content.</p>
-                <div class="share-menu">Share this</div>
-                <img src="/images/logo.png" alt="Site logo">
-                <img src="/images/icon.png" width="32" height="32" alt="">
-                <img src="/images/real-image.png" alt="Real diagram">
-                <audio>Play me</audio>
-                <div role="navigation">The Latest</div>
-            </article>
-            <div class="footer-links">Meta © 2026</div>
-        </main>
-        </body></html>"""
-
-        def fake_urlopen(request: object, timeout: int) -> MagicMock:
-            url = request.full_url if isinstance(request, urllib.request.Request) else str(request)
-            response = MagicMock()
-            response.__enter__ = lambda s: response
-            response.__exit__ = MagicMock(return_value=False)
-            response.headers.get_content_type.return_value = "image/png"
-            if url.endswith("real-image.png"):
-                response.read.return_value = b"\x89PNG" + (b"x" * 3000)
-            else:
-                response.read.return_value = b"\x89PNG" + (b"x" * 100)
-            return response
-
-        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
-            result = save.save_url("https://example.com/post", notes_dir=tmp_path)
-
-        markdown = result.read_text()
-        article_dir = result.parent
-        assert "Real content." in markdown
-        assert "Products" not in markdown
-        assert "Share this" not in markdown
-        assert "The Latest" not in markdown
-        assert "Meta © 2026" not in markdown
-        assert "Play me" not in markdown
-        assert "logo.png" not in markdown
-        assert "icon.png" not in markdown
-        assert "![Real diagram](001.png)" in markdown
-        assert sorted(path.name for path in article_dir.iterdir()) == ["001.png", "post.md"]
-
-    @patch.object(save, "_git_commit_and_push")
-    @patch.object(save, "_git_sync")
+    @patch.object(save, "_extract_content")
     @patch.object(save, "_fetch")
     def test_resaves_existing_article_with_updated_content(
         self,
         mock_fetch: MagicMock,
+        mock_extract: MagicMock,
         mock_sync: MagicMock,
         mock_git: MagicMock,
         tmp_path: Path,
     ) -> None:
-        mock_fetch.return_value = SIMPLE_HTML
+        mock_fetch.return_value = "<html>...</html>"
+        mock_extract.return_value = ("Simple Page", "Hello world")
 
         slug = save._url_slug("https://example.com/article")
         article_dir = tmp_path / "resources" / "articles" / slug
@@ -285,15 +304,18 @@ class TestSaveUrl:
 
     @patch.object(save, "_git_commit_and_push")
     @patch.object(save, "_git_sync")
+    @patch.object(save, "_extract_content")
     @patch.object(save, "_fetch")
     def test_syncs_before_writing(
         self,
         mock_fetch: MagicMock,
+        mock_extract: MagicMock,
         mock_sync: MagicMock,
         mock_git: MagicMock,
         tmp_path: Path,
     ) -> None:
-        mock_fetch.return_value = SIMPLE_HTML
+        mock_fetch.return_value = "<html>...</html>"
+        mock_extract.return_value = ("Title", "Body")
 
         save.save_url("https://example.com/article", notes_dir=tmp_path)
 

--- a/stacks/knowledge/app/uv.lock
+++ b/stacks/knowledge/app/uv.lock
@@ -24,16 +24,12 @@ wheels = [
 ]
 
 [[package]]
-name = "beautifulsoup4"
-version = "4.14.3"
+name = "babel"
+version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "soupsieve" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
 ]
 
 [[package]]
@@ -46,12 +42,82 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "courlan"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "tld" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/54/6d6ceeff4bed42e7a10d6064d35ee43a810e7b3e8beb4abeae8cff4713ae/courlan-1.3.2.tar.gz", hash = "sha256:0b66f4db3a9c39a6e22dd247c72cfaa57d68ea660e94bb2c84ec7db8712af190", size = 206382, upload-time = "2024-10-29T16:40:20.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/ca/6a667ccbe649856dcd3458bab80b016681b274399d6211187c6ab969fc50/courlan-1.3.2-py3-none-any.whl", hash = "sha256:d0dab52cf5b5b1000ee2839fbc2837e93b2514d3cb5bb61ae158a55b7a04c6be", size = 33848, upload-time = "2024-10-29T16:40:18.325Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload-time = "2026-03-26T09:56:10.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378", size = 300379, upload-time = "2026-03-26T09:56:08.409Z" },
 ]
 
 [[package]]
@@ -68,12 +134,12 @@ name = "homelab-knowledge"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "beautifulsoup4" },
     { name = "httpx" },
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pypdf" },
+    { name = "trafilatura" },
 ]
 
 [package.dev-dependencies]
@@ -85,12 +151,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "beautifulsoup4", specifier = ">=4" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "pgvector", specifier = ">=0.4" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pypdf", specifier = ">=5" },
+    { name = "trafilatura", specifier = ">=2.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -98,6 +164,22 @@ dev = [
     { name = "pytest", specifier = ">=8" },
     { name = "ruff", specifier = ">=0.11" },
     { name = "ty", specifier = ">=0.0.1" },
+]
+
+[[package]]
+name = "htmldate"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "dateparser" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/10/ead9dabc999f353c3aa5d0dc0835b1e355215a5ecb489a7f4ef2ddad5e33/htmldate-1.9.4.tar.gz", hash = "sha256:1129063e02dd0354b74264de71e950c0c3fcee191178321418ccad2074cc8ed0", size = 44690, upload-time = "2025-11-04T17:46:44.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/bd/adfcdaaad5805c0c5156aeefd64c1e868c05e9c1cd6fd21751f168cd88c7/htmldate-1.9.4-py3-none-any.whl", hash = "sha256:1b94bcc4e08232a5b692159903acf95548b6a7492dddca5bb123d89d6325921c", size = 31558, upload-time = "2025-11-04T17:46:43.258Z" },
 ]
 
 [[package]]
@@ -144,6 +226,79 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "justext"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml", extra = ["html-clean"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload-time = "2025-02-25T20:21:49.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ac/52f4e86d1924a7fc05af3aeb34488570eccc39b4af90530dd6acecdf16b5/justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7", size = 837940, upload-time = "2025-02-25T20:21:44.179Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+]
+
+[package.optional-dependencies]
+html-clean = [
+    { name = "lxml-html-clean" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/a4/5c62acfacd69ff4f5db395100f5cfb9b54e7ac8c69a235e4e939fd13f021/lxml_html_clean-0.4.4.tar.gz", hash = "sha256:58f39a9d632711202ed1d6d0b9b47a904e306c85de5761543b90e3e3f736acfb", size = 23899, upload-time = "2026-02-27T09:35:52.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/76/7ffc1d3005cf7749123bc47cb3ea343cd97b0ac2211bab40f57283577d0e/lxml_html_clean-0.4.4-py3-none-any.whl", hash = "sha256:ce2ef506614ecb85ee1c5fe0a2aa45b06a19514ec7949e9c8f34f06925cfabcb", size = 14565, upload-time = "2026-02-27T09:35:51.86Z" },
 ]
 
 [[package]]
@@ -331,6 +486,67 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f5/ed97c2dc47b5fbd4b73c0d7d75f9ebc8eca139f2bbef476bba35f28c0a77/regex-2026.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2da82d643fa698e5e5210e54af90181603d5853cf469f5eedf9bfc8f59b4b8c7", size = 490343, upload-time = "2026-04-03T20:55:15.241Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/de4828a7385ec166d673a5790ad06ac48cdaa98bc0960108dd4b9cc1aef7/regex-2026.4.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:54a1189ad9d9357760557c91103d5e421f0a2dabe68a5cdf9103d0dcf4e00752", size = 291909, upload-time = "2026-04-03T20:55:17.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/5cfbfc97f3201a4d24b596a77957e092030dcc4205894bc035cedcfce62f/regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951", size = 289692, upload-time = "2026-04-03T20:55:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/f2212d9fd56fe897e36d0110ba30ba2d247bd6410c5bd98499c7e5a1e1f2/regex-2026.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7cd3e4ee8d80447a83bbc9ab0c8459781fa77087f856c3e740d7763be0df27f", size = 796979, upload-time = "2026-04-03T20:55:22.56Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e3/a016c12675fbac988a60c7e1c16e67823ff0bc016beb27bd7a001dbdabc6/regex-2026.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e19e18c568d2866d8b6a6dfad823db86193503f90823a8f66689315ba28fbe8", size = 866744, upload-time = "2026-04-03T20:55:24.646Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a4/0b90ca4cf17adc3cb43de80ec71018c37c88ad64987e8d0d481a95ca60b5/regex-2026.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7698a6f38730fd1385d390d1ed07bb13dce39aa616aca6a6d89bea178464b9a4", size = 911613, upload-time = "2026-04-03T20:55:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3b/2b3dac0b82d41ab43aa87c6ecde63d71189d03fe8854b8ca455a315edac3/regex-2026.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:173a66f3651cdb761018078e2d9487f4cf971232c990035ec0eb1cdc6bf929a9", size = 800551, upload-time = "2026-04-03T20:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/25/fe/5365eb7aa0e753c4b5957815c321519ecab033c279c60e1b1ae2367fa810/regex-2026.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa7922bbb2cc84fa062d37723f199d4c0cd200245ce269c05db82d904db66b83", size = 776911, upload-time = "2026-04-03T20:55:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b3/7fb0072156bba065e3b778a7bc7b0a6328212be5dd6a86fd207e0c4f2dab/regex-2026.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:59f67cd0a0acaf0e564c20bbd7f767286f23e91e2572c5703bf3e56ea7557edb", size = 785751, upload-time = "2026-04-03T20:55:33.797Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1a/9f83677eb699273e56e858f7bd95acdbee376d42f59e8bfca2fd80d79df3/regex-2026.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:475e50f3f73f73614f7cba5524d6de49dee269df00272a1b85e3d19f6d498465", size = 860484, upload-time = "2026-04-03T20:55:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/7a/93937507b61cfcff8b4c5857f1b452852b09f741daa9acae15c971d8554e/regex-2026.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a1c0c7d67b64d85ac2e1879923bad2f08a08f3004055f2f406ef73c850114bd4", size = 765939, upload-time = "2026-04-03T20:55:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ea/81a7f968a351c6552b1670ead861e2a385be730ee28402233020c67f9e0f/regex-2026.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:1371c2ccbb744d66ee63631cc9ca12aa233d5749972626b68fe1a649dd98e566", size = 851417, upload-time = "2026-04-03T20:55:39.92Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7e/323c18ce4b5b8f44517a36342961a0306e931e499febbd876bb149d900f0/regex-2026.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59968142787042db793348a3f5b918cf24ced1f23247328530e063f89c128a95", size = 789056, upload-time = "2026-04-03T20:55:42.303Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/af/e7510f9b11b1913b0cd44eddb784b2d650b2af6515bfce4cffcc5bfd1d38/regex-2026.4.4-cp314-cp314-win32.whl", hash = "sha256:59efe72d37fd5a91e373e5146f187f921f365f4abc1249a5ab446a60f30dd5f8", size = 272130, upload-time = "2026-04-03T20:55:44.995Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/51/57dae534c915e2d3a21490e88836fa2ae79dde3b66255ecc0c0a155d2c10/regex-2026.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:e0aab3ff447845049d676827d2ff714aab4f73f340e155b7de7458cf53baa5a4", size = 280992, upload-time = "2026-04-03T20:55:47.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5e/abaf9f4c3792e34edb1434f06717fae2b07888d85cb5cec29f9204931bf8/regex-2026.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:a7a5bb6aa0cf62208bb4fa079b0c756734f8ad0e333b425732e8609bd51ee22f", size = 273563, upload-time = "2026-04-03T20:55:49.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/06/35da85f9f217b9538b99cbb170738993bcc3b23784322decb77619f11502/regex-2026.4.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:97850d0638391bdc7d35dc1c1039974dcb921eaafa8cc935ae4d7f272b1d60b3", size = 494191, upload-time = "2026-04-03T20:55:51.258Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5b/1bc35f479eef8285c4baf88d8c002023efdeebb7b44a8735b36195486ae7/regex-2026.4.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ee7337f88f2a580679f7bbfe69dc86c043954f9f9c541012f49abc554a962f2e", size = 293877, upload-time = "2026-04-03T20:55:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/f53b9ad17480b3ddd14c90da04bfb55ac6894b129e5dea87bcaf7d00e336/regex-2026.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7429f4e6192c11d659900c0648ba8776243bf396ab95558b8c51a345afeddde6", size = 292410, upload-time = "2026-04-03T20:55:55.736Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/56/52377f59f60a7c51aa4161eecf0b6032c20b461805aca051250da435ffc9/regex-2026.4.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4f10fbd5dd13dcf4265b4cc07d69ca70280742870c97ae10093e3d66000359", size = 811831, upload-time = "2026-04-03T20:55:57.802Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/63/8026310bf066f702a9c361f83a8c9658f3fe4edb349f9c1e5d5273b7c40c/regex-2026.4.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a152560af4f9742b96f3827090f866eeec5becd4765c8e0d3473d9d280e76a5a", size = 871199, upload-time = "2026-04-03T20:56:00.333Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9f/a514bbb00a466dbb506d43f187a04047f7be1505f10a9a15615ead5080ee/regex-2026.4.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54170b3e95339f415d54651f97df3bff7434a663912f9358237941bbf9143f55", size = 917649, upload-time = "2026-04-03T20:56:02.445Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6b/8399f68dd41a2030218839b9b18360d79b86d22b9fab5ef477c7f23ca67c/regex-2026.4.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07f190d65f5a72dcb9cf7106bfc3d21e7a49dd2879eda2207b683f32165e4d99", size = 816388, upload-time = "2026-04-03T20:56:04.595Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/9c/103963f47c24339a483b05edd568594c2be486188f688c0170fd504b2948/regex-2026.4.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9a2741ce5a29d3c84b0b94261ba630ab459a1b847a0d6beca7d62d188175c790", size = 785746, upload-time = "2026-04-03T20:56:07.13Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ee/7f6054c0dec0cee3463c304405e4ff42e27cff05bf36fcb34be549ab17bd/regex-2026.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b26c30df3a28fd9793113dac7385a4deb7294a06c0f760dd2b008bd49a9139bc", size = 801483, upload-time = "2026-04-03T20:56:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/51d3d941cf6070dc00c3338ecf138615fc3cce0421c3df6abe97a08af61a/regex-2026.4.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:421439d1bee44b19f4583ccf42670ca464ffb90e9fdc38d37f39d1ddd1e44f1f", size = 866331, upload-time = "2026-04-03T20:56:12.039Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e8/76d50dcc122ac33927d939f350eebcfe3dbcbda96913e03433fc36de5e63/regex-2026.4.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b40379b53ecbc747fd9bdf4a0ea14eb8188ca1bd0f54f78893a39024b28f4863", size = 772673, upload-time = "2026-04-03T20:56:14.558Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/5f6bf75e20ea6873d05ba4ec78378c375cbe08cdec571c83fbb01606e563/regex-2026.4.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:08c55c13d2eef54f73eeadc33146fb0baaa49e7335eb1aff6ae1324bf0ddbe4a", size = 857146, upload-time = "2026-04-03T20:56:16.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/33/3c76d9962949e487ebba353a18e89399f292287204ac8f2f4cfc3a51c233/regex-2026.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9776b85f510062f5a75ef112afe5f494ef1635607bf1cc220c1391e9ac2f5e81", size = 803463, upload-time = "2026-04-03T20:56:18.923Z" },
+    { url = "https://files.pythonhosted.org/packages/19/eb/ef32dcd2cb69b69bc0c3e55205bce94a7def48d495358946bc42186dcccc/regex-2026.4.4-cp314-cp314t-win32.whl", hash = "sha256:385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74", size = 275709, upload-time = "2026-04-03T20:56:20.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/86/c291bf740945acbf35ed7dbebf8e2eea2f3f78041f6bd7cdab80cb274dc0/regex-2026.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45", size = 285622, upload-time = "2026-04-03T20:56:23.641Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/ec846d560ae6a597115153c02ca6138a7877a1748b2072d9521c10a93e58/regex-2026.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d", size = 275773, upload-time = "2026-04-03T20:56:26.07Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
@@ -356,12 +572,39 @@ wheels = [
 ]
 
 [[package]]
-name = "soupsieve"
-version = "2.8.3"
+name = "six"
+version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tld"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5d/76b4383ac4e5b5e254e50c09807b3e13820bed6d6c11cd540264988d6802/tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345", size = 467175, upload-time = "2026-03-06T23:50:34.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/90/39a85a4b63c84213e78b3c17d22e1bf45328acf8ebb33ef93be30d0a3911/tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c", size = 296743, upload-time = "2026-03-06T23:50:32.465Z" },
+]
+
+[[package]]
+name = "trafilatura"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "courlan" },
+    { name = "htmldate" },
+    { name = "justext" },
+    { name = "lxml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/25/e3ebeefdebfdfae8c4a4396f5a6ea51fc6fa0831d63ce338e5090a8003dc/trafilatura-2.0.0.tar.gz", hash = "sha256:ceb7094a6ecc97e72fea73c7dba36714c5c5b577b6470e4520dca893706d6247", size = 253404, upload-time = "2024-12-03T15:23:24.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/b6/097367f180b6383a3581ca1b86fcae284e52075fa941d1232df35293363c/trafilatura-2.0.0-py3-none-any.whl", hash = "sha256:77eb5d1e993747f6f20938e1de2d840020719735690c840b9a1024803a4cd51d", size = 132557, upload-time = "2024-12-03T15:23:21.41Z" },
 ]
 
 [[package]]
@@ -416,4 +659,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]


### PR DESCRIPTION
## Summary

Replace ~200 lines of hand-rolled BeautifulSoup HTML parsing with [trafilatura](https://trafilatura.readthedocs.io/), an industry-standard content extraction library with best-in-class F1 scores on web content benchmarks.

## What changed

### Dependencies
- **Removed**: `beautifulsoup4` (and transitive `soupsieve`)
- **Added**: `trafilatura>=2.0.0` — handles content detection, boilerplate removal, related-section stripping, and markdown conversion in one call

### save.py (net -88 lines)
Replaced 15 BS4-based functions with 3:
- `_extract_content()` — wraps `trafilatura.extract()` + `bare_extraction()` with a `html.parser` fallback for title extraction
- `_frontmatter()` — builds YAML frontmatter block

**Kept unchanged**: `_fetch`, slug generation, git operations, image extension/content-type helpers.

### test_save.py
- **Deleted**: `TestExtractTitle`, `TestFindContent`, `TestToMarkdown` (tested removed BS4 internals)
- **Added**: `TestTitleFromHtml`, `TestExtractContent`, `TestDownloadImages` (test new boundaries)
- **Rewrote**: `TestSaveUrl` — mocks at `_extract_content` boundary instead of feeding HTML through the pipeline
- **Unchanged**: `TestUrlSlug`, `TestGitSync`, `TestGitCommitAndPush`, CLI test

## Why trafilatura
- Best F1 score in published benchmarks for web content extraction
- Built-in markdown output (`output_format="markdown"`) with headings, lists, code blocks, images
- Active maintenance, handles modern web patterns (JS-heavy sites, cookie banners, card grids)
- Replaces our fragile hardcoded boilerplate markers and CSS class matching

Closes #229