### PR TITLE
Switch embeddings to halfvec(3072) and add HNSW index

### DIFF
--- a/docs/decisions/016-knowledge-base.md
+++ b/docs/decisions/016-knowledge-base.md
@@ -48,13 +48,13 @@ avoid running a separate service.
 
 Postgres with the pgvector extension. One container handles both relational
 storage (documents, metadata, content hashes) and vector similarity search
-(HNSW index, cosine distance). Every knowledge management tool evaluated
+(HNSW index, cosine distance, halfvec for 3072-dim embeddings). Every knowledge management tool evaluated
 (Khoj, AnythingLLM, Open WebUI) supports Postgres as a backend — so if we
 ever add a UI, it can plug into the existing database.
 
 | Feature | pgvector | Qdrant | Chroma |
 |---------|----------|--------|--------|
-| Vector search | ✅ HNSW + cosine | ✅ native | ✅ native |
+| Vector search | ✅ HNSW + cosine (halfvec) | ✅ native | ✅ native |
 | Relational queries | ✅ full SQL | ❌ | ❌ |
 | Metadata filtering | ✅ SQL WHERE | ✅ payload filters | ✅ where filters |
 | RAM usage | ~100 MB | ~200 MB | ~150 MB |
@@ -76,6 +76,11 @@ with a fine-grained PAT (`models:read` permission required since March 2025).
 Rate-limited on the free tier (~10-50 RPM), which is fine for incremental
 updates but slow for bulk ingestion (~12 min for 195 files). Content hashing
 means re-runs skip unchanged files.
+
+**Dimension constraint:** pgvector HNSW indexes support up to 2000 dimensions
+for the `vector` type, but 3072 exceeds that limit. Using `halfvec(3072)`
+(half-precision float16) instead — HNSW supports up to 4000 dimensions on
+`halfvec`. The precision loss is negligible for cosine similarity ranking.
 
 ### MCP vs Copilot CLI skill for integration
 

--- a/stacks/knowledge/app/knowledge/database.py
+++ b/stacks/knowledge/app/knowledge/database.py
@@ -246,10 +246,10 @@ def _vector_search(
                 c.content AS chunk_content,
                 c.metadata AS chunk_metadata,
                 c.created_at AS chunk_created_at,
-                GREATEST(0.0, LEAST(1.0, 1 - (c.embedding <=> %s::vector))) AS score
+                GREATEST(0.0, LEAST(1.0, 1 - (c.embedding <=> %s::halfvec))) AS score
             FROM chunks c
             JOIN documents d ON d.id = c.document_id
-            ORDER BY c.embedding <=> %s::vector
+            ORDER BY c.embedding <=> %s::halfvec
             LIMIT %s
             """,
             (embedding, embedding, limit),
@@ -278,7 +278,7 @@ def _hybrid_search(
         cursor.execute(
             """
             WITH vector_ranked AS (
-                SELECT c.id, ROW_NUMBER() OVER (ORDER BY c.embedding <=> %(emb)s::vector) AS rank_v
+                SELECT c.id, ROW_NUMBER() OVER (ORDER BY c.embedding <=> %(emb)s::halfvec) AS rank_v
                 FROM chunks c
                 LIMIT %(candidates)s
             ),

--- a/stacks/knowledge/app/knowledge/models.py
+++ b/stacks/knowledge/app/knowledge/models.py
@@ -14,6 +14,8 @@ type NoteLinkType = Literal["wikilink", "similarity"]
 def normalize_embedding(value: Any) -> list[float]:
     if hasattr(value, "tolist"):
         value = value.tolist()
+    elif hasattr(value, "to_list"):
+        value = value.to_list()
 
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
         raise TypeError("embedding must be a sequence of floats")

--- a/stacks/knowledge/app/tests/integration/test_ingest_e2e.py
+++ b/stacks/knowledge/app/tests/integration/test_ingest_e2e.py
@@ -87,6 +87,30 @@ def test_migrations_create_all_expected_tables(fresh_db: None) -> None:
     assert tables == ["chunks", "documents", "note_links"]
 
 
+def test_hnsw_index_exists_on_embedding_column(fresh_db: None) -> None:
+    # The HNSW index is the whole point of the halfvec migration — verify it
+    # exists so a future schema change doesn't silently regress to seq scans.
+    from knowledge.database import _cursor, connect
+
+    conn = connect()
+    try:
+        with _cursor(conn) as cursor:
+            cursor.execute(
+                """
+                SELECT indexname, indexdef
+                FROM pg_indexes
+                WHERE tablename = 'chunks' AND indexname = 'chunks_embedding_idx'
+                """
+            )
+            row = cursor.fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None, "HNSW index chunks_embedding_idx not found on chunks table"
+    assert "hnsw" in row["indexdef"].lower()
+    assert "halfvec_cosine_ops" in row["indexdef"].lower()
+
+
 def test_ingest_then_search_roundtrip(fresh_db: None, tmp_path: Path) -> None:
     # Regression for the full bug class: with migrations applied and embeddings
     # stubbed, a freshly ingested note must be searchable.

--- a/stacks/knowledge/app/tests/test_models.py
+++ b/stacks/knowledge/app/tests/test_models.py
@@ -30,6 +30,35 @@ def test_chunk_requires_expected_embedding_dimension() -> None:
         )
 
 
+def test_chunk_accepts_halfvec_like_object() -> None:
+    """pgvector returns HalfVector objects (with to_list()) for halfvec columns."""
+
+    # Arrange — simulate pgvector's HalfVector which has to_list() but isn't a Sequence
+    class FakeHalfVector:
+        def __init__(self, values: list[float]) -> None:
+            self._values = values
+
+        def to_list(self) -> list[float]:
+            return list(self._values)
+
+    document_id = uuid4()
+    embedding = [0.0] * EMBEDDING_DIMENSION
+    embedding[0] = 1.0
+
+    # Act
+    chunk = Chunk(
+        document_id=document_id,
+        chunk_index=0,
+        content="Test content",
+        embedding=FakeHalfVector(embedding),  # ty: ignore[invalid-argument-type]
+    )
+
+    # Assert
+    assert chunk.embedding is not None
+    assert len(chunk.embedding) == EMBEDDING_DIMENSION
+    assert chunk.embedding[0] == 1.0
+
+
 def test_document_validates_string_inputs() -> None:
     # Arrange
     document_id = uuid4()

--- a/stacks/knowledge/init.sql
+++ b/stacks/knowledge/init.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS chunks (
     document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
     chunk_index INTEGER NOT NULL,
     content TEXT NOT NULL,
-    embedding vector(3072) NOT NULL,
+    embedding halfvec(3072) NOT NULL,
     metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
     tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -33,3 +33,4 @@ CREATE INDEX IF NOT EXISTS documents_content_hash_idx ON documents (content_hash
 CREATE UNIQUE INDEX IF NOT EXISTS chunks_document_chunk_idx ON chunks (document_id, chunk_index);
 CREATE INDEX IF NOT EXISTS chunks_document_id_idx ON chunks (document_id);
 CREATE INDEX IF NOT EXISTS chunks_tsv_idx ON chunks USING gin (tsv);
+CREATE INDEX IF NOT EXISTS chunks_embedding_idx ON chunks USING hnsw (embedding halfvec_cosine_ops);

--- a/stacks/knowledge/migrations/003_halfvec_hnsw.sql
+++ b/stacks/knowledge/migrations/003_halfvec_hnsw.sql
@@ -1,0 +1,11 @@
+-- Switch embeddings from vector(3072) to halfvec(3072) and add HNSW index.
+--
+-- pgvector HNSW supports up to 2000 dims for vector, but 4000 for halfvec.
+-- text-embedding-3-large produces 3072-dim embeddings, so halfvec is required.
+-- Half-precision (float16) has negligible impact on cosine similarity ranking.
+
+ALTER TABLE chunks
+    ALTER COLUMN embedding TYPE halfvec(3072) USING embedding::halfvec(3072);
+
+CREATE INDEX IF NOT EXISTS chunks_embedding_idx
+    ON chunks USING hnsw (embedding halfvec_cosine_ops);


### PR DESCRIPTION
## Problem

ADR-016 claims "HNSW index, cosine distance" but no HNSW index exists on the `chunks.embedding` column. All vector searches do sequential scans. Worse, the column is `vector(3072)` which exceeds pgvector's 2000-dimension HNSW limit for the `vector` type — you can't just add the index.

## Solution

Switch to `halfvec(3072)` (pgvector HNSW supports up to 4000 dims on halfvec) and create the HNSW index. Half-precision float16 has negligible impact on cosine similarity ranking.

### Changes

- **Migration 003**: ALTER column from `vector(3072)` to `halfvec(3072)`, CREATE HNSW index with `halfvec_cosine_ops`
- **init.sql**: Updated for fresh installs
- **database.py**: Changed `::vector` → `::halfvec` in 3 search query locations
- **ADR-016**: Documents the dimension constraint and halfvec choice
- **Integration test**: Asserts the HNSW index exists in `pg_indexes`

### What doesn't change

- `find_similar_documents` uses column-to-column `<=>` with no explicit cast — works unchanged
- Python code sends embeddings as `vector` wire format; Postgres implicitly casts to `halfvec` on INSERT
- No re-embedding needed — existing data is cast in-place by the migration

### Deployment note

The migration runs automatically via `run_migrations()` on next ingest. The ALTER + index creation will take a few seconds on the current ~195 document corpus.

Closes #237