### PR TITLE
Add multilingual hybrid retrieval

### DIFF
--- a/docs/decisions/018-multilingual-hybrid-retrieval.md
+++ b/docs/decisions/018-multilingual-hybrid-retrieval.md
@@ -1,0 +1,88 @@
+# ADR-018: Multilingual hybrid retrieval
+
+**Date:** 2026-04-25
+**Status:** Accepted
+
+## Context
+
+ADR-016 requires Chinese language support for the personal knowledge base. The
+initial hybrid search implementation fused vector search with PostgreSQL English
+full-text search via reciprocal rank fusion (RRF). Live evaluation against the
+Mandarin notes showed good final results, but the lexical path was fragile:
+
+- no-space Chinese queries such as `内疚狼狈堕落胆怯` produced zero English FTS
+  candidates;
+- spaced Chinese compound queries worked only because PostgreSQL treated each
+  whitespace-separated compound as a token;
+- some longer English natural-language queries produced zero strict FTS
+  candidates because `websearch_to_tsquery` ANDs terms together;
+- naive OR relaxation recovered English candidates but introduced broad noisy
+  candidate sets.
+
+The implementation should improve Chinese and mixed-language retrieval without
+replacing the small Postgres-based stack or introducing a dedicated search
+engine.
+
+## Options Considered
+
+### Option A: Keep vector + English FTS only
+
+| Pros | Cons |
+|------|------|
+| No new moving parts | Chinese keyword retrieval silently degrades to vector-only |
+| Current rank-1 results are good on the small fixture | Fails the ADR-016 Chinese support requirement for realistic no-space queries |
+
+**Verdict:** Rejected. The current result quality is good, but the keyword
+ranker is not actually supporting Chinese retrieval.
+
+### Option B: App-level Jieba tokenization + Postgres simple FTS
+
+| Pros | Cons |
+|------|------|
+| Small dependency, no custom Postgres image | Tokenization is derived data that must be stored/backfilled |
+| Empirically segments the local no-space Chinese fixture correctly | Less sophisticated than a dedicated CJK search extension |
+| Keeps Postgres as the only backend | Requires a second tsvector and RRF candidate source |
+
+**Verdict:** Chosen. It is the simplest option that fixes the observed Chinese
+lexical gap while preserving the current architecture.
+
+### Option C: PGroonga, zhparser, or pg_jieba
+
+| Pros | Cons |
+|------|------|
+| Better DB-native CJK search | Custom Postgres image and extension maintenance |
+| Stronger language-specific indexing | More operational complexity than the evidence currently justifies |
+
+**Verdict:** Deferred. Reconsider only if the Jieba + simple FTS approach fails
+the retrieval fixture or real notes.
+
+### Option D: Replace RRF with weighted score fusion
+
+| Pros | Cons |
+|------|------|
+| Fine-grained weighting possible | Requires calibrating cosine, `ts_rank_cd`, and CJK lexical scores |
+| Can be tuned with enough labelled data | More brittle than rank fusion for heterogeneous retrievers |
+
+**Verdict:** Rejected for now. RRF is robust, simple, and matches pgvector,
+Azure AI Search, and Elasticsearch hybrid-search guidance.
+
+## Decision
+
+Keep RRF as the fusion layer and make candidate generation multilingual:
+
+1. vector search remains the recall backbone;
+2. English strict FTS remains the high-precision English keyword ranker;
+3. bounded English relaxed FTS contributes candidates for long English queries;
+4. Chinese lexical FTS uses app-level Jieba tokens stored in `chunks.cjk_tokens`
+   and indexed with a generated `tsv_zh` column using PostgreSQL `simple` FTS.
+
+The retrieval fixture in
+`stacks/knowledge/app/tests/fixtures/chinese_retrieval_eval_queries.json` is the
+regression set for Chinese, English, and mixed-language queries.
+
+## References
+
+- ADR-016: `docs/decisions/016-knowledge-base.md`
+- Issue: <https://github.com/ColinCee/homelab/issues/238>
+- Retrieval fixture:
+  `stacks/knowledge/app/tests/fixtures/chinese_retrieval_eval_queries.json`

--- a/stacks/knowledge/app/knowledge/database.py
+++ b/stacks/knowledge/app/knowledge/database.py
@@ -14,6 +14,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 
 from .models import Chunk, Document, NoteLink, RelatedDocument, SearchResult, normalize_embedding
+from .tokenize import cjk_search_text, english_relaxed_query_text
 
 DATABASE_URL_ENV = "KNOWLEDGE_DB_URL"
 
@@ -76,6 +77,7 @@ def run_migrations(conn: DatabaseConnection) -> None:
     with _cursor(conn) as cursor:
         for migration in _migration_files():
             cursor.execute(cast(LiteralString, migration.read_text(encoding="utf-8")))
+        _backfill_cjk_tokens(cursor)
     conn.commit()
 
 
@@ -107,9 +109,11 @@ def insert_chunks(conn: DatabaseConnection, chunks: list[Chunk]) -> list[Chunk]:
         return []
 
     sql = """
-        INSERT INTO chunks (id, document_id, chunk_index, content, embedding, metadata, created_at)
-        VALUES (COALESCE(%s, gen_random_uuid()), %s, %s, %s, %s, %s, COALESCE(%s, now()))
-        RETURNING id, document_id, chunk_index, content, embedding, metadata, created_at
+        INSERT INTO chunks (
+            id, document_id, chunk_index, content, embedding, metadata, cjk_tokens, created_at
+        )
+        VALUES (COALESCE(%s, gen_random_uuid()), %s, %s, %s, %s, %s, %s, COALESCE(%s, now()))
+        RETURNING id, document_id, chunk_index, content, embedding, metadata, cjk_tokens, created_at
     """
     params_seq = [
         (
@@ -119,6 +123,7 @@ def insert_chunks(conn: DatabaseConnection, chunks: list[Chunk]) -> list[Chunk]:
             c.content,
             c.embedding,
             Jsonb(c.metadata),
+            c.cjk_tokens or cjk_search_text(c.content),
             c.created_at,
         )
         for c in chunks
@@ -268,11 +273,13 @@ def _hybrid_search(
     query_text: str,
     limit: int,
 ) -> list[SearchResult]:
-    """RRF hybrid: merge vector similarity and keyword (tsvector) rankings.
+    """RRF hybrid: merge vector similarity and English/Chinese keyword rankings.
 
     Uses websearch_to_tsquery for safe parsing of natural-language queries.
     """
-    candidate_limit = limit * 3
+    candidate_limit = max(limit * 10, 50)
+    cjk_query_text = cjk_search_text(query_text)
+    english_relaxed_text = english_relaxed_query_text(query_text)
 
     with _cursor(conn) as cursor:
         cursor.execute(
@@ -282,22 +289,70 @@ def _hybrid_search(
                 FROM chunks c
                 LIMIT %(candidates)s
             ),
-            keyword_ranked AS (
+            english_strict_query AS (
+                SELECT websearch_to_tsquery('english', %(tsq)s) AS query
+            ),
+            english_strict_ranked AS (
                 SELECT c.id,
                     ROW_NUMBER() OVER (
-                        ORDER BY ts_rank_cd(c.tsv, websearch_to_tsquery('english', %(tsq)s)) DESC
-                    ) AS rank_k
+                        ORDER BY ts_rank_cd(c.tsv, q.query) DESC
+                    ) AS rank_en_strict
                 FROM chunks c
-                WHERE c.tsv @@ websearch_to_tsquery('english', %(tsq)s)
+                CROSS JOIN english_strict_query q
+                WHERE c.tsv @@ q.query
                 LIMIT %(candidates)s
+            ),
+            english_relaxed_query AS (
+                SELECT CASE
+                    WHEN %(english_relaxed)s = '' THEN NULL::tsquery
+                    ELSE websearch_to_tsquery('english', %(english_relaxed)s)
+                END AS query
+            ),
+            english_relaxed_ranked AS (
+                SELECT c.id,
+                    ROW_NUMBER() OVER (
+                        ORDER BY ts_rank_cd(c.tsv, q.query) DESC
+                    ) AS rank_en_relaxed
+                FROM chunks c
+                CROSS JOIN english_relaxed_query q
+                WHERE q.query IS NOT NULL AND c.tsv @@ q.query
+                LIMIT %(candidates)s
+            ),
+            cjk_query AS (
+                SELECT CASE
+                    WHEN %(cjk_tsq)s = '' THEN NULL::tsquery
+                    ELSE websearch_to_tsquery('simple', %(cjk_tsq)s)
+                END AS query
+            ),
+            cjk_ranked AS (
+                SELECT c.id,
+                    ROW_NUMBER() OVER (
+                        ORDER BY ts_rank_cd(c.tsv_zh, q.query) DESC
+                    ) AS rank_cjk
+                FROM chunks c
+                CROSS JOIN cjk_query q
+                WHERE q.query IS NOT NULL AND c.tsv_zh @@ q.query
+                LIMIT %(candidates)s
+            ),
+            rrf_scores AS (
+                SELECT v.id AS chunk_id, 1.0 / (%(k)s + v.rank_v) AS score
+                FROM vector_ranked v
+                UNION ALL
+                SELECT s.id AS chunk_id, 1.0 / (%(k)s + s.rank_en_strict) AS score
+                FROM english_strict_ranked s
+                UNION ALL
+                SELECT r.id AS chunk_id, 1.0 / (%(k)s + r.rank_en_relaxed) AS score
+                FROM english_relaxed_ranked r
+                UNION ALL
+                SELECT z.id AS chunk_id, 1.0 / (%(k)s + z.rank_cjk) AS score
+                FROM cjk_ranked z
             ),
             rrf AS (
                 SELECT
-                    COALESCE(v.id, k.id) AS chunk_id,
-                    COALESCE(1.0 / (%(k)s + v.rank_v), 0.0)
-                      + COALESCE(1.0 / (%(k)s + k.rank_k), 0.0) AS rrf_score
-                FROM vector_ranked v
-                FULL OUTER JOIN keyword_ranked k ON v.id = k.id
+                    chunk_id,
+                    SUM(score) AS rrf_score
+                FROM rrf_scores
+                GROUP BY chunk_id
                 ORDER BY rrf_score DESC
                 LIMIT %(lim)s
             )
@@ -323,6 +378,8 @@ def _hybrid_search(
             {
                 "emb": embedding,
                 "tsq": query_text,
+                "english_relaxed": english_relaxed_text,
+                "cjk_tsq": cjk_query_text,
                 "k": _RRF_K,
                 "candidates": candidate_limit,
                 "lim": limit,
@@ -508,6 +565,24 @@ def _like_prefix_pattern(prefix: str) -> str:
     return f"{escaped_prefix}%"
 
 
+def _backfill_cjk_tokens(cursor: DatabaseCursor) -> None:
+    cursor.execute(
+        """
+        SELECT id, content
+        FROM chunks
+        WHERE cjk_tokens = '' AND content ~ '[一-龿]'
+        """
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        return
+
+    cursor.executemany(
+        "UPDATE chunks SET cjk_tokens = %s WHERE id = %s",
+        [(cjk_search_text(row["content"]), row["id"]) for row in rows],
+    )
+
+
 def _migration_files() -> list[Path]:
     return sorted(MIGRATIONS_DIR.glob("*.sql"))
 
@@ -556,6 +631,7 @@ def _search_result_from_row(row: DBRow) -> SearchResult:
                 "chunk_index": row["chunk_chunk_index"],
                 "content": row["chunk_content"],
                 "metadata": row["chunk_metadata"],
+                "cjk_tokens": row.get("chunk_cjk_tokens", ""),
                 "created_at": row["chunk_created_at"],
             }
         ),

--- a/stacks/knowledge/app/knowledge/ingest.py
+++ b/stacks/knowledge/app/knowledge/ingest.py
@@ -20,6 +20,7 @@ from .database import (
 from .embeddings import get_embeddings
 from .links import refresh_note_links
 from .models import Chunk, DirectoryIngestResult, Document, IngestResult
+from .tokenize import cjk_search_text
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +185,7 @@ def _do_ingest(
             chunk_index=i,
             content=text,
             embedding=embedding,
+            cjk_tokens=cjk_search_text(text),
         )
         for i, (text, embedding) in enumerate(zip(chunks_text, embeddings, strict=True))
     ]

--- a/stacks/knowledge/app/knowledge/models.py
+++ b/stacks/knowledge/app/knowledge/models.py
@@ -58,11 +58,14 @@ class Chunk(KnowledgeModel):
     content: str = Field(min_length=1)
     embedding: list[float] | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    cjk_tokens: str = ""
     created_at: datetime | None = None
 
-    @field_validator("content")
+    @field_validator("content", "cjk_tokens")
     @classmethod
     def validate_content(cls, value: str) -> str:
+        if value == "":
+            return value
         return _normalize_required_text(value)
 
     @field_validator("embedding", mode="before")

--- a/stacks/knowledge/app/knowledge/tokenize.py
+++ b/stacks/knowledge/app/knowledge/tokenize.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import re
+
+import jieba
+
+_CJK_SPAN_RE = re.compile(r"[\u3400-\u9fff]+")
+_ENGLISH_TERM_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9+#._-]*")
+
+_CJK_STOPWORDS = frozenset({"的", "了", "我", "是"})
+_ENGLISH_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "the",
+        "to",
+        "with",
+    }
+)
+
+
+def cjk_search_text(text: str) -> str:
+    """Return whitespace-separated Chinese search tokens for Postgres simple FTS."""
+
+    return " ".join(cjk_search_tokens(text))
+
+
+def cjk_search_tokens(text: str) -> list[str]:
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for span in _CJK_SPAN_RE.findall(text):
+        for token in jieba.cut_for_search(span):
+            normalized = token.strip()
+            if not normalized or normalized in _CJK_STOPWORDS or normalized in seen:
+                continue
+            seen.add(normalized)
+            tokens.append(normalized)
+
+    return tokens
+
+
+def english_relaxed_query_text(text: str) -> str:
+    """Return a safe websearch query that ORs useful English terms."""
+
+    terms: list[str] = []
+    seen: set[str] = set()
+    for match in _ENGLISH_TERM_RE.finditer(text):
+        term = _normalize_english_term(match.group(0))
+        if not term or term.lower() in _ENGLISH_STOPWORDS or term.lower() in seen:
+            continue
+        seen.add(term.lower())
+        terms.append(term)
+
+    return " OR ".join(terms)
+
+
+def _normalize_english_term(term: str) -> str:
+    return term.strip("._-+#")

--- a/stacks/knowledge/app/pyproject.toml
+++ b/stacks/knowledge/app/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "psycopg[binary]>=3.2",
     "pypdf>=5",
     "trafilatura>=2.0.0",
+    "jieba>=0.42.1",
 ]
 
 [dependency-groups]

--- a/stacks/knowledge/app/tests/fixtures/chinese_retrieval_eval_queries.json
+++ b/stacks/knowledge/app/tests/fixtures/chinese_retrieval_eval_queries.json
@@ -1,0 +1,133 @@
+[
+  {
+    "id": "zh-song-core-sequence",
+    "query": "学猫叫 月亮代表我的心 童话",
+    "language": "zh",
+    "expected_sources": [
+      "areas/mandarin/song-based-character-learning.md"
+    ],
+    "expected_terms": ["学猫叫", "月亮代表我的心", "童话"],
+    "notes": "Chinese exact-title query for the song learning sequence. Chinese lexical retrieval should contribute candidates, not rely on vector-only fallback."
+  },
+  {
+    "id": "zh-song-vocab-worth-learning",
+    "query": "内疚 狼狈 堕落 胆怯",
+    "language": "zh",
+    "expected_sources": [
+      "areas/mandarin/song-vocabulary-priorities.md"
+    ],
+    "expected_terms": ["内疚", "狼狈", "堕落", "胆怯"],
+    "notes": "Chinese compound lookup for non-RSH characters worth active study."
+  },
+  {
+    "id": "zh-literary-compounds",
+    "query": "憧憬 蹒跚 徜徉 褴褛 聆听",
+    "language": "zh",
+    "expected_sources": [
+      "areas/mandarin/song-vocabulary-priorities.md"
+    ],
+    "expected_terms": ["憧憬", "蹒跚", "徜徉", "褴褛", "聆听"],
+    "notes": "Chinese compound query where segmentation quality matters more than semantic similarity."
+  },
+  {
+    "id": "zh-no-space-song-sequence",
+    "query": "学猫叫月亮代表我的心童话",
+    "language": "zh",
+    "expected_sources": [
+      "areas/mandarin/song-based-character-learning.md"
+    ],
+    "expected_terms": ["学猫叫", "月亮代表我的心", "童话"],
+    "notes": "Realistic Chinese query with no spaces between song titles. Current English FTS returns zero keyword candidates."
+  },
+  {
+    "id": "zh-no-space-worth-learning",
+    "query": "内疚狼狈堕落胆怯",
+    "language": "zh",
+    "expected_sources": [
+      "areas/mandarin/song-vocabulary-priorities.md"
+    ],
+    "expected_terms": ["内疚", "狼狈", "堕落", "胆怯"],
+    "notes": "No-space Chinese compound query. A Chinese lexical retriever should segment this into searchable terms."
+  },
+  {
+    "id": "zh-no-space-literary",
+    "query": "憧憬蹒跚徜徉褴褛聆听",
+    "language": "zh",
+    "expected_sources": [
+      "areas/mandarin/song-vocabulary-priorities.md"
+    ],
+    "expected_terms": ["憧憬", "蹒跚", "徜徉", "褴褛", "聆听"],
+    "notes": "No-space literary compound query for testing Chinese segmentation rather than exact whitespace token matching."
+  },
+  {
+    "id": "zh-subterm-song",
+    "query": "月亮童话",
+    "language": "zh",
+    "expected_sources": [
+      "areas/mandarin/song-based-character-learning.md"
+    ],
+    "expected_terms": ["月亮", "童话"],
+    "notes": "Short no-space Chinese query that should match notes mentioning 月亮代表我的心 and 童话."
+  },
+  {
+    "id": "zh-single-character-sounds",
+    "query": "喵怦唔",
+    "language": "zh",
+    "expected_sources": [
+      "areas/mandarin/song-vocabulary-priorities.md"
+    ],
+    "expected_terms": ["喵", "怦", "唔"],
+    "notes": "No-space single-character query for onomatopoeia and interjections."
+  },
+  {
+    "id": "mixed-song-review-spike",
+    "query": "学猫叫 review spike retention",
+    "language": "mixed",
+    "expected_sources": [
+      "areas/mandarin/song-based-character-learning.md",
+      "areas/mandarin/anki-retention-and-pacing.md"
+    ],
+    "expected_terms": ["学猫叫", "review spike", "retention"],
+    "notes": "Mixed-language query that should benefit from vector, English FTS, and Chinese FTS together."
+  },
+  {
+    "id": "mixed-rsh-song-characters",
+    "query": "non RSH characters 喵 怦 唔",
+    "language": "mixed",
+    "expected_sources": [
+      "areas/mandarin/song-vocabulary-priorities.md"
+    ],
+    "expected_terms": ["non-RSH", "喵", "怦", "唔"],
+    "notes": "Mixed query with English descriptor plus Chinese single-character terms."
+  },
+  {
+    "id": "en-fsrs-pacing",
+    "query": "FSRS Hard Again tone errors retention 85 percent",
+    "language": "en",
+    "expected_sources": [
+      "areas/mandarin/anki-retention-and-pacing.md"
+    ],
+    "expected_terms": ["FSRS", "Hard", "Again", "tone errors", "85"],
+    "notes": "English FTS regression guard for the Anki pacing note."
+  },
+  {
+    "id": "en-cantonese-interference",
+    "query": "Cantonese Mandarin tone interference background",
+    "language": "en",
+    "expected_sources": [
+      "areas/mandarin/background.md"
+    ],
+    "expected_terms": ["Cantonese", "Mandarin", "interference"],
+    "notes": "English query for heritage/background context."
+  },
+  {
+    "id": "en-learning-milestones",
+    "query": "wuxia reading fluency HSK milestones Mandarin",
+    "language": "en",
+    "expected_sources": [
+      "areas/mandarin/learning-strategy.md"
+    ],
+    "expected_terms": ["wuxia", "HSK", "Milestones"],
+    "notes": "English semantic and keyword query for the overall Mandarin strategy note."
+  }
+]

--- a/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/anki-retention-and-pacing.md
+++ b/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/anki-retention-and-pacing.md
@@ -1,0 +1,4 @@
+# Anki Retention & Pacing Guide
+
+FSRS retention should stay near 85 percent. Use Hard for tone errors and Again for
+true failures. Unsuspending 学猫叫 can cause a review spike.

--- a/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/background.md
+++ b/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/background.md
@@ -1,0 +1,3 @@
+# Language Background
+
+Cantonese heritage helps Mandarin tone awareness, but interference remains a risk.

--- a/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/learning-strategy.md
+++ b/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/learning-strategy.md
@@ -1,0 +1,3 @@
+# Mandarin Learning Strategy
+
+Milestones include HSK progress, wuxia reading fluency, and Mandarin conversation.

--- a/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/song-based-character-learning.md
+++ b/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/song-based-character-learning.md
@@ -1,0 +1,4 @@
+# Song-Based Character Learning Plan
+
+The current song sequence includes 学猫叫, 月亮代表我的心, and 童话.
+After unsuspending 学猫叫 characters, expect a review spike and monitor retention.

--- a/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/song-vocabulary-priorities.md
+++ b/stacks/knowledge/app/tests/fixtures/mandarin_eval/areas/mandarin/song-vocabulary-priorities.md
@@ -1,0 +1,6 @@
+# Song Vocabulary Priorities
+
+Worth learning compounds include 内疚, 狼狈, 堕落, and 胆怯.
+Literary compounds include 憧憬, 蹒跚, 徜徉, 褴褛, and 聆听.
+Onomatopoeia and interjections include 喵, 怦, and 唔.
+These are non-RSH characters from songs.

--- a/stacks/knowledge/app/tests/integration/test_ingest_e2e.py
+++ b/stacks/knowledge/app/tests/integration/test_ingest_e2e.py
@@ -15,6 +15,7 @@ wired together.
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Iterator
 from pathlib import Path
@@ -41,6 +42,32 @@ def _stub_embeddings(texts: list[str], *, token: str | None = None) -> list[list
     vector = [0.0] * EMBEDDING_DIMENSION
     vector[0] = 1.0
     return [vector for _ in texts]
+
+
+def _eval_embeddings(texts: list[str], *, token: str | None = None) -> list[list[float]]:
+    # Make vector retrieval point at the background note by default. The eval
+    # then needs lexical RRF signals to lift non-background expected results.
+    return [_unit_vector(_eval_embedding_index(text)) for text in texts]
+
+
+def _eval_embedding_index(text: str) -> int:
+    if "Language Background" in text or "Cantonese Mandarin tone interference" in text:
+        return 0
+    if "Mandarin Learning Strategy" in text:
+        return 1
+    if "Anki Retention" in text:
+        return 2
+    if "Song-Based Character" in text:
+        return 3
+    if "Song Vocabulary" in text:
+        return 4
+    return 0
+
+
+def _unit_vector(index: int) -> list[float]:
+    vector = [0.0] * EMBEDDING_DIMENSION
+    vector[index] = 1.0
+    return vector
 
 
 @pytest.fixture
@@ -111,6 +138,27 @@ def test_hnsw_index_exists_on_embedding_column(fresh_db: None) -> None:
     assert "halfvec_cosine_ops" in row["indexdef"].lower()
 
 
+def test_chinese_fts_index_exists(fresh_db: None) -> None:
+    from knowledge.database import _cursor, connect
+
+    conn = connect()
+    try:
+        with _cursor(conn) as cursor:
+            cursor.execute(
+                """
+                SELECT indexdef
+                FROM pg_indexes
+                WHERE tablename = 'chunks' AND indexname = 'chunks_tsv_zh_idx'
+                """
+            )
+            row = cursor.fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None, "GIN index chunks_tsv_zh_idx not found on chunks table"
+    assert "gin" in row["indexdef"].lower()
+
+
 def test_ingest_then_search_roundtrip(fresh_db: None, tmp_path: Path) -> None:
     # Regression for the full bug class: with migrations applied and embeddings
     # stubbed, a freshly ingested note must be searchable.
@@ -134,3 +182,72 @@ def test_ingest_then_search_roundtrip(fresh_db: None, tmp_path: Path) -> None:
 
     assert hits, "expected at least one search hit for the ingested fixture"
     assert any("sample_note.md" in hit.document.source_path for hit in hits)
+
+
+def test_eval_queries_find_expected_mandarin_notes(fresh_db: None, tmp_path: Path) -> None:
+    from knowledge.ingest import ingest_directory
+    from knowledge.search import search
+
+    # This is a stable synthetic corpus, not the live private notes repo.
+    # The paths mirror real note locations so source_path behavior stays realistic.
+    notes_dir = tmp_path / "notes"
+    _write_mandarin_eval_notes(notes_dir)
+    eval_cases = json.loads(
+        (FIXTURES_DIR / "chinese_retrieval_eval_queries.json").read_text(encoding="utf-8")
+    )
+
+    with patch("knowledge.ingest.get_embeddings", side_effect=_eval_embeddings):
+        ingest_result = ingest_directory(notes_dir, glob_pattern="**/*.md")
+
+    assert ingest_result.files_failed == 0
+
+    with patch("knowledge.search.get_embeddings", side_effect=_eval_embeddings):
+        for case in eval_cases:
+            hits = search(case["query"], limit=1)
+            sources = [hit.document.source_path for hit in hits]
+
+            assert any(
+                source.endswith(expected)
+                for source in sources
+                for expected in case["expected_sources"]
+            ), f"{case['id']} did not return expected sources. got={sources}"
+
+
+def _write_mandarin_eval_notes(notes_dir: Path) -> None:
+    notes = {
+        "areas/mandarin/song-based-character-learning.md": """
+# Song-Based Character Learning Plan
+
+The current song sequence includes 学猫叫, 月亮代表我的心, and 童话.
+After unsuspending 学猫叫 characters, expect a review spike and monitor retention.
+""",
+        "areas/mandarin/song-vocabulary-priorities.md": """
+# Song Vocabulary Priorities
+
+Worth learning compounds include 内疚, 狼狈, 堕落, and 胆怯.
+Literary compounds include 憧憬, 蹒跚, 徜徉, 褴褛, and 聆听.
+Onomatopoeia and interjections include 喵, 怦, and 唔.
+These are non-RSH characters from songs.
+""",
+        "areas/mandarin/anki-retention-and-pacing.md": """
+# Anki Retention & Pacing Guide
+
+FSRS retention should stay near 85 percent. Use Hard for tone errors and Again for
+true failures. Unsuspending 学猫叫 can cause a review spike.
+""",
+        "areas/mandarin/background.md": """
+# Language Background
+
+Cantonese heritage helps Mandarin tone awareness, but interference remains a risk.
+""",
+        "areas/mandarin/learning-strategy.md": """
+# Mandarin Learning Strategy
+
+Milestones include HSK progress, wuxia reading fluency, and Mandarin conversation.
+""",
+    }
+
+    for relative_path, content in notes.items():
+        path = notes_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content.strip(), encoding="utf-8")

--- a/stacks/knowledge/app/tests/integration/test_ingest_e2e.py
+++ b/stacks/knowledge/app/tests/integration/test_ingest_e2e.py
@@ -30,6 +30,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
+MANDARIN_EVAL_DIR = FIXTURES_DIR / "mandarin_eval"
 INIT_SQL = Path(__file__).resolve().parents[3] / "init.sql"
 
 EMBEDDING_DIMENSION = 3072
@@ -184,20 +185,16 @@ def test_ingest_then_search_roundtrip(fresh_db: None, tmp_path: Path) -> None:
     assert any("sample_note.md" in hit.document.source_path for hit in hits)
 
 
-def test_eval_queries_find_expected_mandarin_notes(fresh_db: None, tmp_path: Path) -> None:
+def test_eval_queries_find_expected_mandarin_notes(fresh_db: None) -> None:
     from knowledge.ingest import ingest_directory
     from knowledge.search import search
 
-    # This is a stable synthetic corpus, not the live private notes repo.
-    # The paths mirror real note locations so source_path behavior stays realistic.
-    notes_dir = tmp_path / "notes"
-    _write_mandarin_eval_notes(notes_dir)
     eval_cases = json.loads(
         (FIXTURES_DIR / "chinese_retrieval_eval_queries.json").read_text(encoding="utf-8")
     )
 
     with patch("knowledge.ingest.get_embeddings", side_effect=_eval_embeddings):
-        ingest_result = ingest_directory(notes_dir, glob_pattern="**/*.md")
+        ingest_result = ingest_directory(MANDARIN_EVAL_DIR, glob_pattern="**/*.md")
 
     assert ingest_result.files_failed == 0
 
@@ -211,43 +208,3 @@ def test_eval_queries_find_expected_mandarin_notes(fresh_db: None, tmp_path: Pat
                 for source in sources
                 for expected in case["expected_sources"]
             ), f"{case['id']} did not return expected sources. got={sources}"
-
-
-def _write_mandarin_eval_notes(notes_dir: Path) -> None:
-    notes = {
-        "areas/mandarin/song-based-character-learning.md": """
-# Song-Based Character Learning Plan
-
-The current song sequence includes 学猫叫, 月亮代表我的心, and 童话.
-After unsuspending 学猫叫 characters, expect a review spike and monitor retention.
-""",
-        "areas/mandarin/song-vocabulary-priorities.md": """
-# Song Vocabulary Priorities
-
-Worth learning compounds include 内疚, 狼狈, 堕落, and 胆怯.
-Literary compounds include 憧憬, 蹒跚, 徜徉, 褴褛, and 聆听.
-Onomatopoeia and interjections include 喵, 怦, and 唔.
-These are non-RSH characters from songs.
-""",
-        "areas/mandarin/anki-retention-and-pacing.md": """
-# Anki Retention & Pacing Guide
-
-FSRS retention should stay near 85 percent. Use Hard for tone errors and Again for
-true failures. Unsuspending 学猫叫 can cause a review spike.
-""",
-        "areas/mandarin/background.md": """
-# Language Background
-
-Cantonese heritage helps Mandarin tone awareness, but interference remains a risk.
-""",
-        "areas/mandarin/learning-strategy.md": """
-# Mandarin Learning Strategy
-
-Milestones include HSK progress, wuxia reading fluency, and Mandarin conversation.
-""",
-    }
-
-    for relative_path, content in notes.items():
-        path = notes_dir / relative_path
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content.strip(), encoding="utf-8")

--- a/stacks/knowledge/app/tests/test_database.py
+++ b/stacks/knowledge/app/tests/test_database.py
@@ -7,14 +7,17 @@ import pytest
 from knowledge.database import (
     DATABASE_URL_ENV,
     MIGRATIONS_DIR,
+    _backfill_cjk_tokens,
     _migration_files,
     delete_note_links,
+    insert_chunks,
     list_documents_by_source_prefix,
     list_related_documents,
     resolve_database_url,
     run_migrations,
+    search_chunks,
 )
-from knowledge.models import Document
+from knowledge.models import EMBEDDING_DIMENSION, Chunk, Document
 
 
 def test_resolve_database_url_reads_environment(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -78,6 +81,7 @@ def test_run_migrations_executes_all_sql_files(
     # Arrange
     conn = MagicMock()
     cursor = MagicMock()
+    cursor.fetchall.return_value = []
     mock_cursor_factory.return_value.__enter__.return_value = cursor
     first = tmp_path / "001_first.sql"
     second = tmp_path / "002_second.sql"
@@ -91,7 +95,75 @@ def test_run_migrations_executes_all_sql_files(
     # Assert
     assert cursor.execute.call_args_list[0].args == ("SELECT 1;",)
     assert cursor.execute.call_args_list[1].args == ("SELECT 2;",)
+    assert "WHERE cjk_tokens = ''" in cursor.execute.call_args_list[2].args[0]
     conn.commit.assert_called_once_with()
+
+
+def test_backfill_cjk_tokens_updates_existing_chinese_chunks() -> None:
+    # Arrange
+    cursor = MagicMock()
+    chunk_id = UUID("00000000-0000-0000-0000-000000000001")
+    cursor.fetchall.return_value = [{"id": chunk_id, "content": "内疚狼狈堕落胆怯"}]
+
+    # Act
+    _backfill_cjk_tokens(cursor)
+
+    # Assert
+    cursor.executemany.assert_called_once_with(
+        "UPDATE chunks SET cjk_tokens = %s WHERE id = %s",
+        [("内疚 狼狈 堕落 胆怯", chunk_id)],
+    )
+
+
+@patch("knowledge.database._cursor")
+def test_insert_chunks_derives_cjk_tokens(
+    mock_cursor_factory: MagicMock,
+) -> None:
+    # Arrange
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = None
+    cursor.nextset.return_value = False
+    mock_cursor_factory.return_value.__enter__.return_value = cursor
+    chunk = Chunk(
+        document_id=UUID("00000000-0000-0000-0000-000000000001"),
+        chunk_index=0,
+        content="憧憬蹒跚徜徉褴褛聆听",
+        embedding=[0.1] * EMBEDDING_DIMENSION,
+    )
+
+    # Act
+    inserted = insert_chunks(conn, [chunk])
+
+    # Assert
+    assert inserted == []
+    params = cursor.executemany.call_args.args[1]
+    assert params[0][6] == "憧憬 蹒跚 徜徉 褴褛 聆听"
+
+
+@patch("knowledge.database._cursor")
+def test_search_chunks_fuses_vector_english_and_chinese_rankers(
+    mock_cursor_factory: MagicMock,
+) -> None:
+    # Arrange
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+    mock_cursor_factory.return_value.__enter__.return_value = cursor
+    embedding = [0.1] * EMBEDDING_DIMENSION
+
+    # Act
+    results = search_chunks(conn, embedding, limit=5, query_text="内疚狼狈堕落胆怯")
+
+    # Assert
+    assert results == []
+    sql, params = cursor.execute.call_args.args
+    assert "english_strict_ranked" in sql
+    assert "english_relaxed_ranked" in sql
+    assert "cjk_ranked" in sql
+    assert "UNION ALL" in sql
+    assert params["candidates"] == 50
+    assert params["cjk_tsq"] == "内疚 狼狈 堕落 胆怯"
 
 
 @patch("knowledge.database._cursor")

--- a/stacks/knowledge/app/tests/test_tokenize.py
+++ b/stacks/knowledge/app/tests/test_tokenize.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from knowledge.tokenize import cjk_search_tokens, english_relaxed_query_text
+
+
+def test_cjk_search_tokens_segment_no_space_chinese_compounds() -> None:
+    # Arrange / Act
+    tokens = cjk_search_tokens("内疚狼狈堕落胆怯")
+
+    # Assert
+    assert tokens == ["内疚", "狼狈", "堕落", "胆怯"]
+
+
+def test_cjk_search_tokens_keep_single_character_song_sounds() -> None:
+    # Arrange / Act
+    tokens = cjk_search_tokens("喵怦唔")
+
+    # Assert
+    assert tokens == ["喵", "怦", "唔"]
+
+
+def test_english_relaxed_query_text_ors_useful_terms() -> None:
+    # Arrange / Act
+    query = english_relaxed_query_text("FSRS Hard Again tone errors retention 85 percent")
+
+    # Assert
+    assert query == "FSRS OR Hard OR Again OR tone OR errors OR retention OR 85 OR percent"
+
+
+def test_retrieval_eval_fixture_covers_chinese_english_and_mixed_queries() -> None:
+    # Arrange
+    fixture = Path(__file__).parent / "fixtures" / "chinese_retrieval_eval_queries.json"
+
+    # Act
+    cases = json.loads(fixture.read_text(encoding="utf-8"))
+
+    # Assert
+    assert {case["language"] for case in cases} == {"zh", "en", "mixed"}
+    assert any(case["query"] == "内疚狼狈堕落胆怯" for case in cases)
+    assert all(case["expected_sources"] for case in cases)
+    assert all(case["expected_terms"] for case in cases)

--- a/stacks/knowledge/app/uv.lock
+++ b/stacks/knowledge/app/uv.lock
@@ -135,6 +135,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "jieba" },
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
@@ -152,6 +153,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
+    { name = "jieba", specifier = ">=0.42.1" },
     { name = "pgvector", specifier = ">=0.4" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2" },
@@ -227,6 +229,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
+
+[[package]]
+name = "jieba"
+version = "0.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/cb/18eeb235f833b726522d7ebed54f2278ce28ba9438e3135ab0278d9792a2/jieba-0.42.1.tar.gz", hash = "sha256:055ca12f62674fafed09427f176506079bc135638a14e23e25be909131928db2", size = 19214172, upload-time = "2020-01-20T14:27:23.5Z" }
 
 [[package]]
 name = "justext"

--- a/stacks/knowledge/init.sql
+++ b/stacks/knowledge/init.sql
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS chunks (
     embedding halfvec(3072) NOT NULL,
     metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
     tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
+    cjk_tokens TEXT NOT NULL DEFAULT '',
+    tsv_zh tsvector GENERATED ALWAYS AS (to_tsvector('simple', cjk_tokens)) STORED,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
@@ -33,4 +35,5 @@ CREATE INDEX IF NOT EXISTS documents_content_hash_idx ON documents (content_hash
 CREATE UNIQUE INDEX IF NOT EXISTS chunks_document_chunk_idx ON chunks (document_id, chunk_index);
 CREATE INDEX IF NOT EXISTS chunks_document_id_idx ON chunks (document_id);
 CREATE INDEX IF NOT EXISTS chunks_tsv_idx ON chunks USING gin (tsv);
+CREATE INDEX IF NOT EXISTS chunks_tsv_zh_idx ON chunks USING gin (tsv_zh);
 CREATE INDEX IF NOT EXISTS chunks_embedding_idx ON chunks USING hnsw (embedding halfvec_cosine_ops);

--- a/stacks/knowledge/migrations/004_add_cjk_fts.sql
+++ b/stacks/knowledge/migrations/004_add_cjk_fts.sql
@@ -1,0 +1,9 @@
+-- Add derived Chinese token search for multilingual hybrid retrieval.
+ALTER TABLE chunks
+    ADD COLUMN IF NOT EXISTS cjk_tokens TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE chunks
+    ADD COLUMN IF NOT EXISTS tsv_zh tsvector
+    GENERATED ALWAYS AS (to_tsvector('simple', cjk_tokens)) STORED;
+
+CREATE INDEX IF NOT EXISTS chunks_tsv_zh_idx ON chunks USING gin (tsv_zh);


### PR DESCRIPTION
Closes #238 

## Summary

- Adds app-level Jieba tokenization for CJK spans and stores derived `cjk_tokens` on knowledge chunks.
- Adds PostgreSQL `simple` FTS over `cjk_tokens` and fuses vector, English strict FTS, English relaxed FTS, and Chinese FTS with RRF.
- Documents the evidence, alternatives, and decision in ADR-018.
- Adds stable synthetic retrieval fixtures/tests so Chinese eval coverage does not depend on live personal notes.

## Evidence and design

Issue #238 is valid: the previous English-only PostgreSQL FTS path could match Chinese only when useful compounds were already whitespace-separated, and no-space Chinese queries fell back mostly to vector retrieval. Empirical probes showed Jieba `cut_for_search()` produced useful Chinese lexical candidates for realistic no-space Mandarin queries while preserving the existing RRF fusion approach.

The PR keeps RRF because raw scores from vector distance, `ts_rank_cd`, relaxed English FTS, and Chinese FTS are not directly comparable. RRF lets each retriever contribute bounded rank evidence without introducing score calibration complexity.

## Tests

- `cd stacks/knowledge/app && uv run pytest tests/ -v --ignore=tests/integration`
- `cd stacks/knowledge/app && uv run ruff check .`
- `cd stacks/knowledge/app && uv run ruff format --check .`
- `cd stacks/knowledge/app && uv run ty check .`
- pre-commit hook: `ruff`, `yamllint`, `actionlint`, `shellcheck`, `pytest` (`236 passed`)
