### PR TITLE
Clean up knowledge CLI and review agent startup

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -27,12 +27,11 @@ jobs:
       PR_NUMBER: ${{ github.event.issue.number }}
     steps:
       - name: React to /review comment
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh api "/repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" \
-            --method POST -f content='eyes' --silent
+            --method POST -f content='eyes' --silent 2>/dev/null || true
 
       - name: Block fork PRs
         env:

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -30,8 +30,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api "/repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" \
-            --method POST -f content='eyes' --silent 2>/dev/null || true
+          if ! ERROR=$(gh api "/repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" \
+            --method POST -f content='eyes' --silent 2>&1); then
+            echo "::warning::Could not add eyes reaction to /review comment: $ERROR"
+          fi
 
       - name: Block fork PRs
         env:

--- a/stacks/agents/app/entrypoint.sh
+++ b/stacks/agents/app/entrypoint.sh
@@ -16,4 +16,5 @@ if [ -S /var/run/docker.sock ]; then
     usermod -aG "$DOCKER_GROUP" agent
 fi
 
-exec runuser -u agent -- "$@"
+# Preserve PATH so /app/.venv/bin and mise shims remain available after dropping privileges.
+exec runuser --preserve-environment -u agent -- "$@"

--- a/stacks/knowledge/app/knowledge/__main__.py
+++ b/stacks/knowledge/app/knowledge/__main__.py
@@ -26,7 +26,7 @@ class CLIError(Exception):
 
 
 def main() -> None:
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    _configure_logging()
 
     parser = argparse.ArgumentParser(prog="knowledge", description="Knowledge base CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -117,6 +117,12 @@ def _run_migrations() -> None:
         run_migrations(db)
     finally:
         db.close()
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("jieba").setLevel(logging.WARNING)
 
 
 def _run_command(args: argparse.Namespace) -> dict[str, EventValue]:

--- a/stacks/knowledge/app/knowledge/tokenize.py
+++ b/stacks/knowledge/app/knowledge/tokenize.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+import logging
 import re
+import warnings
 
-import jieba
+# jieba emits Python 3.14 SyntaxWarnings during import; install the filter first.
+warnings.filterwarnings(
+    "ignore",
+    category=SyntaxWarning,
+    module=r"jieba(\.|$)",
+)
+import jieba  # noqa: E402
+
+jieba.setLogLevel(logging.WARNING)
 
 _CJK_SPAN_RE = re.compile(r"[\u3400-\u9fff]+")
 _ENGLISH_TERM_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9+#._-]*")


### PR DESCRIPTION
## Summary

- Suppresses noisy `jieba` import warnings/dictionary debug output and `httpx` request logs in the knowledge CLI.
- Fixes the review agent container restart loop by preserving PATH when `entrypoint.sh` drops from root to the `agent` user, so `/app/.venv/bin/uvicorn` and worker commands resolve.
- Keeps optional `/review` reaction failures from polluting workflow logs; the real dispatch failure was the down agent endpoint.

## Investigation

The `/review` comment on PR #244 did trigger the Code Review workflow, but the dispatch step failed with curl exit 7 because `http://100.100.146.119:8585/review` was unreachable. On beelink, `agents-agent-1` was restart-looping with:

```text
runuser: failed to execute uvicorn: No such file or directory
```

`runuser` was dropping the Dockerfile PATH that includes `/app/.venv/bin`; preserving the environment fixes the API startup path and the worker `python -m worker` path.

## Validation

- `uv run ruff check stacks/knowledge/app`
- `uv run ruff format --check stacks/knowledge/app`
- `cd stacks/knowledge/app && uv run pytest tests/ -v --ignore=tests/integration`
- `cd stacks/knowledge/app && uv run ty check .`
- `uv run yamllint -c .yamllint.yaml .github/workflows/code-review.yaml stacks/agents/compose.yaml stacks/knowledge/compose.yaml`
- `actionlint .github/workflows/code-review.yaml`
- `shellcheck stacks/agents/app/entrypoint.sh`
- focused code-review agent: no significant issues found

Note: repo-level `mise run lint/test/typecheck` is blocked locally by the existing mise Python install error: `Python installation is missing a lib directory`.
