### PR TITLE
docs: document knowledge save deploy key lifecycle

### DIFF
--- a/docs/decisions/017-deploy-key-for-knowledge-save.md
+++ b/docs/decisions/017-deploy-key-for-knowledge-save.md
@@ -15,8 +15,8 @@ The initial approach mounted the entire host `~/.ssh/` directory into the contai
 
 A dedicated ed25519 key added as a GitHub deploy key with write access on the notes repo. Only the single private key file is mounted into the container.
 
-- **Pros:** Minimal blast radius (one key = one repo), no expiry, no runtime dependencies, SSH remote URL works unchanged
-- **Cons:** Manual one-time setup (key generation + adding to GitHub)
+- **Pros:** Minimal blast radius (one key = one repo), no runtime dependencies, SSH remote URL works unchanged
+- **Cons:** No built-in expiry, manual setup and rotation, write deploy keys can push destructive ref updates unless the target repo blocks them
 - **Verdict:** Chosen — right level of scoping for a single-repo push from a homelab container.
 
 ### GitHub App token (HTTPS)
@@ -45,9 +45,45 @@ Use a PAT as an HTTPS credential.
 
 ## Decision
 
-Use a dedicated deploy key (`~/.ssh/notes_deploy_key`) with write access scoped to `ColinCee/notes`. The compose service mounts only this key file and `known_hosts` (both read-only). `HOME=/home/user` is set so SSH finds the key without needing `/etc/passwd`.
+Use a dedicated deploy key (`~/.ssh/notes_deploy_key`) with write access scoped to `ColinCee/notes`. The compose service mounts only this key file read-only. `known_hosts` is baked into the image during build, and `/etc/passwd` is mounted read-only so the host uid resolves to a user for SSH.
 
 Pattern for future stacks needing git push access: generate a per-repo deploy key rather than sharing host credentials.
+
+## Accepted Residual Risks
+
+The deploy key is a long-lived static credential. If it is copied from the host
+or exposed through a container escape, GitHub will not time-bound the credential
+the way it does for GitHub App installation tokens.
+
+The risk is acceptable for this homelab because:
+
+1. The key is scoped to the notes repo instead of all host SSH identities.
+2. The key is mounted read-only and only into the `save` compose profile.
+3. The save command only performs a normal `git push origin main`.
+4. `ColinCee/notes` is the data target for this workflow; the homelab repo and
+   agent credentials are not exposed by this key.
+
+Branch protection or repository rules on `ColinCee/notes` would be a stronger
+server-side mitigation for force-push and branch deletion. If those controls are
+not available for the private notes repo, the fallback control is fast key
+revocation plus restoring from git history or backups.
+
+## Operational Mitigations
+
+The deploy key needs lifecycle management because GitHub deploy keys do not
+expire automatically:
+
+1. Rotate `~/.ssh/notes_deploy_key` after any suspected host/container
+   compromise, accidental key disclosure, or migration to a new host.
+2. Review GitHub deploy-key metadata during routine maintenance; `last_used_at`
+   is sufficient for a manual sanity check at this scale.
+3. Rebuild the knowledge image if GitHub rotates SSH host keys, because
+   `known_hosts` is generated at image build time.
+4. Reconsider GitHub App tokens if this grows beyond a single repo/key or if
+   automated deploy-key monitoring becomes necessary.
+
+The copy-paste procedures live in
+[`docs/runbooks/knowledge-base.md`](../runbooks/knowledge-base.md).
 
 ## References
 

--- a/docs/runbooks/knowledge-base.md
+++ b/docs/runbooks/knowledge-base.md
@@ -43,6 +43,15 @@ Or directly on beelink:
 ssh beelink "cd /home/colin/code/homelab && bash scripts/ingest-notes.sh"
 ```
 
+### Save a web page to notes
+
+The save profile fetches the page, writes it into the notes repo, commits, and
+pushes to `main` using the repo-scoped deploy key from ADR-017.
+
+```bash
+ssh beelink "cd /home/colin/code/homelab/stacks/knowledge && docker compose --profile save run --rm save save \"<URL>\""
+```
+
 ### Inspect recent task runs
 
 - **Grafana:** `Container Overview` → `Knowledge Task Runs`
@@ -78,6 +87,74 @@ ssh beelink "docker exec knowledge-postgres-1 psql -U knowledge -d knowledge -c 
 
 # Postgres container status
 ssh beelink "docker ps --filter name=knowledge-postgres"
+```
+
+## Credential Lifecycle
+
+The `save` profile uses a write deploy key at `~/.ssh/notes_deploy_key` on
+beelink. The key is scoped to `ColinCee/notes` and mounted read-only into the
+container; do not mount the whole host `~/.ssh` directory.
+
+### Check deploy key metadata
+
+Use this during routine maintenance or before deleting an old key. `last_used_at`
+is a sanity check, not a complete compromise detector.
+
+```bash
+gh api repos/ColinCee/notes/keys \
+  --jq '.[] | [.id, .title, .read_only, .created_at, (.last_used_at // "never")] | @tsv'
+```
+
+### Rotate the notes deploy key
+
+Generate the replacement key on beelink:
+
+```bash
+ssh beelink 'ssh-keygen -t ed25519 -N "" -C "knowledge-save-$(date +%Y-%m-%d)" -f ~/.ssh/notes_deploy_key.next && chmod 600 ~/.ssh/notes_deploy_key.next'
+ssh beelink 'cat ~/.ssh/notes_deploy_key.next.pub'
+```
+
+Add the printed public key to `ColinCee/notes` as a **write** deploy key in
+GitHub: **Settings -> Deploy keys -> Add deploy key -> Allow write access**.
+
+Replace the active key on beelink after the new key exists in GitHub:
+
+```bash
+ssh beelink 'mv ~/.ssh/notes_deploy_key ~/.ssh/notes_deploy_key.old.$(date +%Y%m%d) && mv ~/.ssh/notes_deploy_key.next ~/.ssh/notes_deploy_key && chmod 600 ~/.ssh/notes_deploy_key'
+```
+
+Verify the container can authenticate without writing to the notes repo:
+
+```bash
+ssh beelink "cd /home/colin/code/homelab/stacks/knowledge && docker compose --profile save run --rm --entrypoint git save ls-remote git@github.com:ColinCee/notes.git HEAD"
+```
+
+After verification, delete the old deploy key from GitHub. Use the metadata
+command above to find the old key id, then:
+
+```bash
+gh api -X DELETE repos/ColinCee/notes/keys/<old-key-id>
+ssh beelink 'rm -f ~/.ssh/notes_deploy_key.old.* ~/.ssh/notes_deploy_key.next.pub'
+```
+
+### Respond to a suspected deploy key leak
+
+1. Delete the deploy key from `ColinCee/notes` immediately.
+2. Move the old private key aside on beelink and generate a replacement using
+   the rotation procedure above.
+3. Review recent notes repo commits and deploy-key `last_used_at` metadata.
+4. Restore the notes repo from git history or backup if unexpected commits,
+   branch deletions, or force-pushes occurred.
+
+### Refresh GitHub SSH host keys
+
+The knowledge image writes `/home/user/.ssh/known_hosts` at build time with
+`ssh-keyscan github.com`. If GitHub rotates SSH host keys, first confirm the new
+fingerprints against GitHub's published documentation, then rebuild the save
+image and verify SSH authentication:
+
+```bash
+ssh beelink "cd /home/colin/code/homelab/stacks/knowledge && docker compose build --no-cache save && docker compose --profile save run --rm --entrypoint git save ls-remote git@github.com:ColinCee/notes.git HEAD"
 ```
 
 ## Troubleshooting

--- a/docs/runbooks/knowledge-base.md
+++ b/docs/runbooks/knowledge-base.md
@@ -93,21 +93,12 @@ ssh beelink "docker ps --filter name=knowledge-postgres"
 
 The `save` profile uses a write deploy key at `~/.ssh/notes_deploy_key` on
 beelink. The key is scoped to `ColinCee/notes` and mounted read-only into the
-container; do not mount the whole host `~/.ssh` directory.
-
-### Check deploy key metadata
-
-Use this during routine maintenance or before deleting an old key. `last_used_at`
-is a sanity check, not a complete compromise detector.
-
-```bash
-gh api repos/ColinCee/notes/keys \
-  --jq '.[] | [.id, .title, .read_only, .created_at, (.last_used_at // "never")] | @tsv'
-```
+container; do not mount the whole host `~/.ssh` directory. Rotate it after host
+compromise, accidental disclosure, or moving the save workflow to a new machine.
 
 ### Rotate the notes deploy key
 
-Generate the replacement key on beelink:
+Generate a replacement key on beelink and print the public key:
 
 ```bash
 ssh beelink 'ssh-keygen -t ed25519 -N "" -C "knowledge-save-$(date +%Y-%m-%d)" -f ~/.ssh/notes_deploy_key.next && chmod 600 ~/.ssh/notes_deploy_key.next'
@@ -116,42 +107,28 @@ ssh beelink 'cat ~/.ssh/notes_deploy_key.next.pub'
 
 Add the printed public key to `ColinCee/notes` as a **write** deploy key in
 GitHub: **Settings -> Deploy keys -> Add deploy key -> Allow write access**.
-
-Replace the active key on beelink after the new key exists in GitHub:
+Then swap the host key and verify that the container can authenticate without
+writing to the notes repo:
 
 ```bash
 ssh beelink 'mv ~/.ssh/notes_deploy_key ~/.ssh/notes_deploy_key.old.$(date +%Y%m%d) && mv ~/.ssh/notes_deploy_key.next ~/.ssh/notes_deploy_key && chmod 600 ~/.ssh/notes_deploy_key'
-```
-
-Verify the container can authenticate without writing to the notes repo:
-
-```bash
 ssh beelink "cd /home/colin/code/homelab/stacks/knowledge && docker compose --profile save run --rm --entrypoint git save ls-remote git@github.com:ColinCee/notes.git HEAD"
 ```
 
-After verification, delete the old deploy key from GitHub. Use the metadata
-command above to find the old key id, then:
+After verification, delete the old deploy key from GitHub and clean up the
+temporary files:
 
 ```bash
+gh api repos/ColinCee/notes/keys --jq '.[] | [.id, .title, .read_only, (.last_used_at // "never")] | @tsv'
 gh api -X DELETE repos/ColinCee/notes/keys/<old-key-id>
 ssh beelink 'rm -f ~/.ssh/notes_deploy_key.old.* ~/.ssh/notes_deploy_key.next.pub'
 ```
 
-### Respond to a suspected deploy key leak
-
-1. Delete the deploy key from `ColinCee/notes` immediately.
-2. Move the old private key aside on beelink and generate a replacement using
-   the rotation procedure above.
-3. Review recent notes repo commits and deploy-key `last_used_at` metadata.
-4. Restore the notes repo from git history or backup if unexpected commits,
-   branch deletions, or force-pushes occurred.
-
 ### Refresh GitHub SSH host keys
 
 The knowledge image writes `/home/user/.ssh/known_hosts` at build time with
-`ssh-keyscan github.com`. If GitHub rotates SSH host keys, first confirm the new
-fingerprints against GitHub's published documentation, then rebuild the save
-image and verify SSH authentication:
+`ssh-keyscan github.com`. If GitHub rotates SSH host keys, confirm the new
+fingerprints against GitHub's published documentation, then rebuild and verify:
 
 ```bash
 ssh beelink "cd /home/colin/code/homelab/stacks/knowledge && docker compose build --no-cache save && docker compose --profile save run --rm --entrypoint git save ls-remote git@github.com:ColinCee/notes.git HEAD"


### PR DESCRIPTION
## Summary

- Reframes ADR-017 so deploy-key non-expiry is an accepted lifecycle risk instead of an unqualified benefit
- Documents the concrete mitigations for the notes deploy key: scoped mount, manual metadata review, rotation, compromise response, and known_hosts refresh
- Adds copy-pasteable knowledge-base runbook steps for deploy-key rotation and SSH host-key rebuilds

Closes #240

## Validation

- Commit hook ran repo checks: ruff lint, ruff format, yamllint, actionlint, shellcheck, pytest
