### PR TITLE
docs: clarify ADR currency guidance

### DIFF
--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -13,7 +13,7 @@ docs-specific editing guidance.
 ## Structure
 
 - `docs/roadmap.md` — active work, planned items, and known limitations (solved items archived in ADRs)
-- `docs/decisions/` — append-only ADRs numbered sequentially (e.g., `001-dokploy.md`)
+- `docs/decisions/` — ADRs numbered sequentially (e.g., `001-dokploy.md`)
 - `docs/runbooks/` — operational how-tos with commands you can copy-paste
 - `docs/private/` — encrypted sensitive docs (security audits, network topology)
 
@@ -47,6 +47,14 @@ ADRs follow this structure — keep it consistent:
 
 - Include a feature comparison table when evaluating multiple options
 - Verdicts should be one sentence explaining why it was chosen or rejected
+
+## ADR Currency
+
+ADRs preserve decision history, but they are not immutable typo museums. Update a
+current ADR in place when the decision still stands and the change only corrects
+stale implementation references, clarifies accepted residual risks, or documents
+the mitigations that make the decision safe. Use a new superseding ADR when the
+decision, tradeoff, or architecture has materially changed.
 
 ## Writing Style
 

--- a/.github/skills/audit-docs/SKILL.md
+++ b/.github/skills/audit-docs/SKILL.md
@@ -76,9 +76,10 @@ For each runbook in `docs/runbooks/`:
 
 ### 7. ADR currency
 
-ADRs are append-only and don't go stale in the traditional sense, but check:
+ADRs preserve decision history, but accepted/current ADRs can still need low-churn corrections:
 
-- Is any ADR's decision contradicted by current implementation? If so, it should be marked "Superseded" with a pointer to the new reality.
+- If the decision still stands but the ADR has stale implementation references, incomplete residual-risk framing, or unclear mitigations, update the ADR in place.
+- If the decision, tradeoff, or architecture has materially changed, mark the ADR "Superseded" with a pointer to the new reality.
 - Are there architecture/security decisions that lack an ADR? (Check for patterns that were decided but never written up.)
 
 ## Identifying high-value gaps
@@ -116,11 +117,11 @@ After presenting findings, fix all stale docs in a single commit:
 3. Commit with `docs:` conventional prefix
 4. Create a PR for review
 
-Do NOT write ADRs without human input — they require tradeoff reasoning that only the author knows. Flag them as gaps and ask.
+Do NOT write new ADRs without human input — they require tradeoff reasoning that only the author knows. Flag them as gaps and ask. In-place corrections to current ADRs are fine when they preserve the existing decision and only clarify facts, risks, or mitigations.
 
 ## What NOT to do
 
 - Don't rewrite docs for style — only fix factual inaccuracies
 - Don't add detail that belongs in source code (exact schemas, constants, timeouts)
 - Don't create new docs without confirming the gap is real and high-value
-- Don't update ADRs — they're append-only. If one is wrong, suggest a superseding ADR.
+- Don't rewrite ADR history to pretend a different decision was made. Use in-place edits only for factual corrections or clearer risk/mitigation framing; use a superseding ADR when the decision changed.


### PR DESCRIPTION
## Summary

- Clarifies that current ADRs can be edited in place for factual corrections and residual-risk/mitigation framing
- Keeps superseding ADRs for material decision, tradeoff, or architecture changes
- Aligns the audit-docs skill with the docs instruction guidance

## Validation

- Commit hook ran repo checks
