### PR TITLE
fix(agent): restore review dispatch service startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,15 @@
 # Dockerfile and app source
 !stacks/agents/app/**
 
+# Keep host-local Python artifacts out of the image. The Dockerfile creates
+# /app/.venv during the build; copying a host venv can leave broken symlinks.
+stacks/agents/app/.venv/
+stacks/agents/app/**/__pycache__/
+stacks/agents/app/**/*.pyc
+stacks/agents/app/.pytest_cache/
+stacks/agents/app/.ruff_cache/
+stacks/agents/app/.env
+
 # Repo-level config needed by the build (mise install in Dockerfile)
 !mise.toml
 

--- a/stacks/agents/app/entrypoint.sh
+++ b/stacks/agents/app/entrypoint.sh
@@ -16,5 +16,6 @@ if [ -S /var/run/docker.sock ]; then
     usermod -aG "$DOCKER_GROUP" agent
 fi
 
-# Preserve PATH so /app/.venv/bin and mise shims remain available after dropping privileges.
-exec runuser --preserve-environment -u agent -- "$@"
+# runuser resets PATH despite --preserve-environment on this host; re-apply
+# the image PATH so venv executables and mise shims remain available.
+exec runuser --preserve-environment -u agent -- env PATH="$PATH" "$@"


### PR DESCRIPTION
## Summary
- exclude host-local Python artifacts from the agent Docker build context so `COPY stacks/agents/app/ .` cannot overwrite the image-created `.venv`
- explicitly re-apply the image PATH after `runuser` drops privileges so `uvicorn`, `python`, and mise shims resolve from the runtime image

Fixes #250

## Root cause
The Beelink `agents-agent-1` container was restart-looping with `runuser: failed to execute uvicorn: No such file or directory`. The built image also contained `/app/.venv/bin/python` symlinked to `/home/colin/.local/share/uv/...`, confirming the host `stacks/agents/app/.venv` was copied into the image by the root `.dockerignore` allowlist. Even with a valid image venv, `runuser` resets PATH on this host, so the entrypoint also needed to pass the intended runtime PATH explicitly.

## Validation
- `bash -n stacks/agents/app/entrypoint.sh`
- commit hooks: ruff, yamllint, actionlint, shellcheck, pytest (237 passed)
- hot-applied on Beelink and rebuilt `stacks/agents`: `curl http://100.100.146.119:8585/health` returns `{"status":"ok"}`
- re-commented `/review` on PR #243; Code Review run 25331704408 succeeded and logged `✅ Review dispatched to agent`; agent logged `POST /review` as 202 and spawned `worker-review-243`
