### PR TITLE
refactor(agent): simplify Docker runtime layout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,7 @@
 # Dockerfile and app source
 !stacks/agents/app/**
 
-# Keep host-local Python artifacts out of the image. The Dockerfile creates
-# /app/.venv during the build; copying a host venv can leave broken symlinks.
+# Keep host-local Python artifacts out of the build context.
 stacks/agents/app/.venv/
 stacks/agents/app/**/__pycache__/
 stacks/agents/app/**/*.pyc

--- a/stacks/agents/app/Dockerfile
+++ b/stacks/agents/app/Dockerfile
@@ -83,7 +83,7 @@ RUN python3 --version && uv --version && envsubst --version && \
 
 WORKDIR /app
 COPY stacks/agents/app/pyproject.toml stacks/agents/app/uv.lock ./
-RUN uv sync --frozen
+RUN UV_PROJECT_ENVIRONMENT=/opt/agent-venv uv sync --frozen
 
 # Pre-warm uv cache with root dev deps (yamllint, ruff, ty, pytest) so
 # runtime `uv sync` in worktrees hits cache instead of downloading.
@@ -101,7 +101,8 @@ COPY stacks/agents/app/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENV HOME=/home/agent
-ENV PATH="/app/.venv/bin:/mise/shims:$PATH"
+ENV UV_PROJECT_ENVIRONMENT="/opt/agent-venv"
+ENV PATH="/opt/agent-venv/bin:/mise/shims:$PATH"
 # Trust mise configs in worktrees (agent clones repos into /reviews/).
 ENV MISE_TRUSTED_CONFIG_PATHS="/reviews"
 
@@ -110,4 +111,4 @@ ENV MISE_TRUSTED_CONFIG_PATHS="/reviews"
 EXPOSE 8585
 ENTRYPOINT ["/entrypoint.sh"]
 # API mode (default) — override with 'python -m worker' for ephemeral workers
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8585"]
+CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8585"]

--- a/stacks/agents/app/entrypoint.sh
+++ b/stacks/agents/app/entrypoint.sh
@@ -16,6 +16,6 @@ if [ -S /var/run/docker.sock ]; then
     usermod -aG "$DOCKER_GROUP" agent
 fi
 
-# runuser resets PATH despite --preserve-environment on this host; re-apply
-# the image PATH so venv executables and mise shims remain available.
+# Re-apply the image PATH after dropping privileges so API and worker commands
+# use the image-managed Python runtime and mise shims.
 exec runuser --preserve-environment -u agent -- env PATH="$PATH" "$@"


### PR DESCRIPTION
## Summary
- move the agent app runtime virtualenv out of `/app` to `/opt/agent-venv` so source copies cannot overwrite runtime dependencies
- start the API with `python -m uvicorn` through the selected runtime interpreter
- keep `.dockerignore` strict as build hygiene and update comments to describe the durable invariant

Closes #255

## Refactor metrics
- Line count across `.dockerignore`, `stacks/agents/app/Dockerfile`, and `stacks/agents/app/entrypoint.sh`: 156 before, 156 after
- Dockerfile references to `/app/.venv`: 1 before, 0 after
- Runtime virtualenv location: source tree (`/app/.venv`) before, image-managed path (`/opt/agent-venv`) after
- New abstractions/scripts: 0

## Validation
- Commit hooks passed: ruff, yamllint, actionlint, shellcheck, pytest (237 passed)
- Beelink isolated build: `docker compose -p agents-issue255 build agent`
- Beelink runtime smoke through the real entrypoint confirmed `/opt/agent-venv` exists, `/app/.venv` is absent, and API/worker imports resolve as the `agent` user
- Beelink isolated API container returned `{"status":"ok"}` from `/health`

Note: an initial pre-change `mise run ci` baseline attempt in this WSL shell failed before any code changes because mise could not install local `python@3.14.4` (`Python installation is missing a lib directory`). The repository commit hooks and Beelink image validation completed successfully.
