### PR TITLE
Harden deploy secret handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -59,7 +59,8 @@ jobs:
           KNOWLEDGE_DB_PASSWORD: ${{ secrets.KNOWLEDGE_DB_PASSWORD }}
         run: |
           cd /home/colin/code/homelab
-          scripts/prepare-deploy-checkout.sh
+          git fetch --no-tags origin "$DEPLOY_GIT_REF"
+          git reset --hard "$DEPLOY_REF"
           scripts/generate-env.sh
           SKIP_DEPLOY_CHECKOUT_SYNC=1 scripts/deploy.sh
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,6 +48,7 @@ jobs:
         env:
           STACKS: ${{ steps.detect.outputs.stacks }}
           DEPLOY_REF: ${{ github.sha }}
+          DEPLOY_GIT_REF: ${{ github.ref }}
           AGENT_API_KEY: ${{ secrets.AGENT_API_KEY }}
           BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
           BOT_APP_INSTALLATION_ID: ${{ secrets.BOT_APP_INSTALLATION_ID }}
@@ -58,8 +59,9 @@ jobs:
           KNOWLEDGE_DB_PASSWORD: ${{ secrets.KNOWLEDGE_DB_PASSWORD }}
         run: |
           cd /home/colin/code/homelab
+          scripts/prepare-deploy-checkout.sh
           scripts/generate-env.sh
-          scripts/deploy.sh
+          SKIP_DEPLOY_CHECKOUT_SYNC=1 scripts/deploy.sh
 
       - name: Get commit message
         if: always() && steps.detect.outputs.stacks != ''

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,9 @@ concurrency:
   group: deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: beelink
@@ -44,11 +47,17 @@ jobs:
         if: steps.detect.outputs.stacks != ''
         env:
           STACKS: ${{ steps.detect.outputs.stacks }}
-          ALL_SECRETS: ${{ toJson(secrets) }}
+          DEPLOY_REF: ${{ github.sha }}
+          AGENT_API_KEY: ${{ secrets.AGENT_API_KEY }}
+          BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+          BOT_APP_INSTALLATION_ID: ${{ secrets.BOT_APP_INSTALLATION_ID }}
+          CF_TUNNEL_TOKEN: ${{ secrets.CF_TUNNEL_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          DISCORD_PRIVATE_WEBHOOK_URL: ${{ secrets.DISCORD_PRIVATE_WEBHOOK_URL }}
+          GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+          KNOWLEDGE_DB_PASSWORD: ${{ secrets.KNOWLEDGE_DB_PASSWORD }}
         run: |
           cd /home/colin/code/homelab
-          git fetch origin main
-          git reset --hard origin/main
           scripts/generate-env.sh
           scripts/deploy.sh
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Internet
 ```
 Push to main
   → Self-hosted runner on beelink detects changed stacks
-  → Generates .env from GitHub secrets + .env.example templates
-  → docker compose up
+  → Syncs server checkout to the triggering commit
+  → Generates .env from allowlisted GitHub secrets + .env.example templates
+  → docker compose --env-file up
 ```
 
 ## Tooling

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,12 +50,13 @@ Two practical rules matter when you are tracing traffic:
 Push to `main` triggers the deploy workflow:
 
 ```text
-push to main → detect changed stacks → generate .env from GitHub secrets → docker compose up
+push to main → detect changed stacks → sync checkout → generate .env → docker compose --env-file up
 ```
 
 The workflow runs on a self-hosted runner on beelink — no SSH, no tailnet
-join from CI. Secrets live in GitHub and are written to `.env` files via
-`.env.example` templates at deploy time
+join from CI. Secrets live in GitHub, are exposed to deploy as an explicit
+allowlist, and are written to stack `.env` files via `.env.example` templates
+at deploy time
 ([ADR-012](decisions/012-deploy-pipeline.md)).
 
 ### External services (GHCR image polling)

--- a/docs/decisions/012-deploy-pipeline.md
+++ b/docs/decisions/012-deploy-pipeline.md
@@ -10,9 +10,11 @@ up`. Replacing it with a GitHub Actions pipeline gives us:
 
 1. **True IaC** — compose files, scripts, and workflow are all in the repo
 2. **GitHub as single source of truth for secrets** — `.env.example` templates
-   in the repo, real values in GitHub secrets, no manual syncing to the server
-3. **Zero-delay deploys on push** — auto-detect changed stacks, generate `.env`,
-   `docker compose up` — no Dokploy clicks
+   in the repo, real values in GitHub secrets, no manual syncing to the server;
+   the deploy workflow passes only the named secrets required by stack templates
+3. **Zero-delay deploys on push** — auto-detect changed stacks, sync the server
+   checkout to the triggering commit, generate `.env`, `docker compose up` — no
+   Dokploy clicks
 4. **Agent compatibility** — the agent can edit workflows and compose files
    directly; Dokploy's DB-stored config was opaque to it
 
@@ -141,7 +143,7 @@ Setup:
 2. Run as a systemd service under a dedicated user
 3. Change `deploy.yaml`: `runs-on: beelink` (deploy job only)
 4. Remove from workflow: Tailscale connect, deploy key setup, SSH steps
-5. Deploy step becomes: `generate-env.sh` → `deploy.sh` (both local)
+5. Deploy step becomes: sync checkout → `generate-env.sh` → `deploy.sh` (all local)
 6. Remove secrets: DEPLOY_SSH_KEY, TS_OAUTH_CLIENT_ID, TS_OAUTH_SECRET,
    DOKPLOY_API_KEY
 7. Remove from repo: `deploy-gate.sh`
@@ -152,11 +154,21 @@ Setup:
 What stays unchanged:
 
 - `detect-stacks.sh` — stack change detection
-- `generate-env.sh` — `.env` generation from templates
-- `deploy.sh` — git pull + docker compose up
+- `generate-env.sh` — `.env` generation from templates using only allowlisted
+  workflow secrets
+- `deploy.sh` — Docker Compose deploy using generated `.env` files as data
 - `.env.example` templates — secret variable mapping
 - GitHub secrets for app credentials (BOT_APP_ID, etc.)
 - `workflow_dispatch` manual deploy UI
+
+### Secret handling hardening
+
+Generated stack `.env` files are inputs to Docker Compose, not shell scripts.
+The deploy workflow must pass an explicit allowlist of GitHub secrets, render the
+stack templates after the server checkout is on the deployed commit, and run
+Compose with `--env-file`. This keeps the push/manual deploy UX while avoiding a
+single `toJson(secrets)` environment blob and avoiding `eval`/`source` execution
+of generated dotenv files.
 
 ### Tailscale security improvement
 

--- a/docs/runbooks/deploying-services.md
+++ b/docs/runbooks/deploying-services.md
@@ -7,11 +7,13 @@ How to add and deploy services on the homelab.
 Push to `main` triggers the deploy workflow (`.github/workflows/deploy.yaml`):
 
 ```
-push to main → detect changed stacks → generate .env → docker compose up
+push to main → detect changed stacks → sync checkout → generate .env → docker compose --env-file up
 ```
 
 The workflow runs on a self-hosted runner on beelink ([ADR-012](../decisions/012-deploy-pipeline.md)).
 Manual deploys are available via `workflow_dispatch` in the GitHub Actions UI.
+Before rendering `.env` files, the server checkout is reset to the workflow
+commit, so deploy scripts and templates come from the commit being deployed.
 
 For local/manual deploys on the server:
 
@@ -61,6 +63,8 @@ MY_SECRET=${MY_SECRET}
 ```
 
 Then add `MY_SECRET` to the deploy workflow's env block and as a GitHub secret.
+The deploy workflow intentionally passes only named secrets to the deploy step;
+do not use `toJson(secrets)` or source generated `.env` files as shell.
 
 ## Conventions
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,8 +13,9 @@ else
 fi
 
 cd "$(dirname "$0")/.."
-git fetch origin main
-git reset --hard "${DEPLOY_REF:-origin/main}"
+if [[ "${SKIP_DEPLOY_CHECKOUT_SYNC:-}" != "1" ]]; then
+  scripts/prepare-deploy-checkout.sh
+fi
 
 compose() {
   local file="$1"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,7 +14,54 @@ fi
 
 cd "$(dirname "$0")/.."
 git fetch origin main
-git reset --hard origin/main
+git reset --hard "${DEPLOY_REF:-origin/main}"
+
+compose() {
+  local file="$1"
+  local env_file="$2"
+  shift 2
+
+  if [[ -f "$env_file" ]]; then
+    docker compose --env-file "$env_file" -f "$file" "$@"
+  else
+    docker compose -f "$file" "$@"
+  fi
+}
+
+read_generated_env_value() {
+  local env_file="$1"
+  local key="$2"
+  local line
+  local value
+
+  [[ -f "$env_file" ]] || return 1
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" == "${key}="* ]] || continue
+    value="${line#*=}"
+    if [[ "$value" == \'*\' && "$value" == *\' ]]; then
+      value="${value:1:${#value}-2}"
+      value="${value//\\\'/$'\''}"
+      value="${value//\\\\/\\}"
+    fi
+    printf '%s' "$value"
+    return 0
+  done < "$env_file"
+  return 1
+}
+
+ensure_grafana_password() {
+  local env_file="$1"
+
+  if [[ -n "${GRAFANA_ADMIN_PASSWORD:-}" ]]; then
+    return
+  fi
+  if GRAFANA_ADMIN_PASSWORD="$(read_generated_env_value "$env_file" GRAFANA_ADMIN_PASSWORD)"; then
+    export GRAFANA_ADMIN_PASSWORD
+    return
+  fi
+  echo "❌ GRAFANA_ADMIN_PASSWORD is required for observability deploy" >&2
+  exit 1
+}
 
 install_timer() {
   local unit_base="$1"
@@ -35,22 +82,20 @@ for stack in "${stacks[@]}"; do
   file="stacks/${stack}/compose.yaml"
   [[ -f "$file" ]] || { echo "❌ No compose.yaml: ${stack}" >&2; exit 1; }
 
-  # Export .env vars (generate-env.sh writes files but its exports don't propagate)
   env_file="stacks/${stack}/.env"
-  # shellcheck source=/dev/null
-  if [[ -f "$env_file" ]]; then set -a; source "$env_file"; set +a; fi
 
   case "$stack" in
-    agents)         docker compose -f "$file" up -d --build --remove-orphans ;;
-    knowledge)      docker compose -f "$file" build ingest
-                    docker compose -f "$file" up -d --remove-orphans
+    agents)         compose "$file" "$env_file" up -d --build --remove-orphans ;;
+    knowledge)      compose "$file" "$env_file" build ingest
+                    compose "$file" "$env_file" up -d --remove-orphans
                     install_timer "stacks/knowledge/knowledge-backup" ;;
-    observability)  docker compose -f "$file" up -d --remove-orphans
+    observability)  compose "$file" "$env_file" up -d --remove-orphans
+                    ensure_grafana_password "$env_file"
                     scripts/sync-dashboards.sh ;;
-    flight-tracker) docker compose -f "$file" pull
-                    docker compose -f "$file" up -d --remove-orphans
+    flight-tracker) compose "$file" "$env_file" pull
+                    compose "$file" "$env_file" up -d --remove-orphans
                     install_timer "stacks/flight-tracker/flight-tracker-poll" ;;
-    *)              docker compose -f "$file" up -d --remove-orphans ;;
+    *)              compose "$file" "$env_file" up -d --remove-orphans ;;
   esac
   echo "✅ ${stack}"
 done

--- a/scripts/detect-stacks.sh
+++ b/scripts/detect-stacks.sh
@@ -14,11 +14,24 @@ for f in "$REPO_ROOT"/stacks/*/compose.yaml; do
   all+=("$(basename "$(dirname "$f")")")
 done
 
+is_known_stack() {
+  local candidate="$1"
+  local stack
+  for stack in "${all[@]}"; do
+    [[ "$stack" == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
 if [[ "${INPUT_STACK:-}" == "all" ]]; then
   echo "stacks=${all[*]}" >> "$OUTPUT"
   echo "Deploying: all (${all[*]})"
   exit 0
 elif [[ -n "${INPUT_STACK:-}" ]]; then
+  if ! is_known_stack "$INPUT_STACK"; then
+    echo "❌ Invalid stack: ${INPUT_STACK}" >&2
+    exit 1
+  fi
   echo "stacks=${INPUT_STACK}" >> "$OUTPUT"
   echo "Deploying: ${INPUT_STACK}"
   exit 0

--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -4,16 +4,69 @@ set -euo pipefail
 # Generate .env files from .env.example templates.
 # Variables like ${SECRET_NAME} are replaced from the environment;
 # constants (no ${}) pass through unchanged.
+# Generated .env files are data for Docker Compose; never source them as shell.
 #
 # Usage: generate-env.sh agents observability
 #    or: STACKS="agents observability" generate-env.sh
-#
-# If ALL_SECRETS is set (JSON from GitHub Actions toJson(secrets)),
-# each key is exported so envsubst can substitute them.
 
-if [[ -n "${ALL_SECRETS:-}" ]]; then
-  eval "$(echo "$ALL_SECRETS" | jq -r 'to_entries[] | select(.value != "") | "export \(.key)=\(.value | @sh)"')"
-fi
+quote_env_value() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\'/\\\'}"
+  printf "'%s'" "$value"
+}
+
+required_vars_for() {
+  local example="$1"
+  grep -ohE '\$\{[A-Z_][A-Z0-9_]*\}' "$example" 2>/dev/null \
+    | sed -E 's/^\$\{([^}]+)\}$/\1/' \
+    | sort -u || true
+}
+
+ensure_required_vars() {
+  local stack="$1"
+  shift
+  local missing=()
+  local var
+  for var in "$@"; do
+    if [[ -z "${!var:-}" ]]; then
+      missing+=("$var")
+    fi
+  done
+
+  if (( ${#missing[@]} )); then
+    echo "Missing required environment variable(s) for ${stack}: ${missing[*]}" >&2
+    exit 1
+  fi
+}
+
+render_env_file() {
+  local stack="$1"
+  local example="$2"
+  local output="$3"
+  shift 3
+  local vars=("$@")
+  local envsubst_vars=""
+  local var
+  local tmp
+
+  for var in "${vars[@]}"; do
+    envsubst_vars+="\${${var}} "
+  done
+
+  tmp="$(mktemp "${output}.XXXXXX")"
+  envsubst "$envsubst_vars" < "$example" | while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ -z "$line" || "$line" == \#* || "$line" != *=* ]]; then
+      printf '%s\n' "$line"
+      continue
+    fi
+
+    printf '%s=%s\n' "${line%%=*}" "$(quote_env_value "${line#*=}")"
+  done > "$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$output"
+  echo "Generated ${output} for ${stack}"
+}
 
 if (( $# )); then
   stacks=("$@")
@@ -24,7 +77,7 @@ fi
 for stack in "${stacks[@]}"; do
   example="stacks/${stack}/.env.example"
   [[ -f "$example" ]] || continue
-  vars=$(grep -oP '\$\{[A-Z_]+\}' "$example" | sort -u | tr '\n' ' ')
-  # Single-quote values so docker compose doesn't interpolate $ in passwords
-  envsubst "$vars" < "$example" | sed "s/=\(.*\)/='\1'/" > "stacks/${stack}/.env"
+  mapfile -t vars < <(required_vars_for "$example")
+  ensure_required_vars "$stack" "${vars[@]}"
+  render_env_file "$stack" "$example" "stacks/${stack}/.env" "${vars[@]}"
 done

--- a/scripts/prepare-deploy-checkout.sh
+++ b/scripts/prepare-deploy-checkout.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sync the server checkout to the commit being deployed.
+#
+# GitHub Actions passes DEPLOY_REF (github.sha) and DEPLOY_GIT_REF (github.ref)
+# so workflow_dispatch runs from non-main refs can fetch the commit before reset.
+# Local/server manual runs without DEPLOY_REF keep the historical origin/main behavior.
+
+cd "$(dirname "$0")/.."
+
+if [[ -n "${DEPLOY_REF:-}" ]]; then
+  git fetch --no-tags origin "${DEPLOY_GIT_REF:-refs/heads/main}"
+  git reset --hard "$DEPLOY_REF"
+else
+  git fetch origin main
+  git reset --hard origin/main
+fi

--- a/scripts/validate-compose.sh
+++ b/scripts/validate-compose.sh
@@ -7,7 +7,12 @@ set -euo pipefail
 
 # Export placeholders for all secret references in .env.example files.
 # grep -oE used instead of -P for portability (no PCRE dependency).
-for var in $(grep -ohE '\$\{[A-Z_]+' stacks/*/.env.example 2>/dev/null | sed 's/\${//' | sort -u); do
+mapfile -t env_vars < <(
+  grep -ohE '\$\{[A-Z_][A-Z0-9_]*\}' stacks/*/.env.example 2>/dev/null \
+    | sed -E 's/^\$\{([^}]+)\}$/\1/' \
+    | sort -u || true
+)
+for var in "${env_vars[@]}"; do
   export "${var}=placeholder"
 done
 
@@ -21,6 +26,11 @@ scripts/generate-env.sh "${stacks[@]}"
 # Validate each compose file
 for f in stacks/*/compose.yaml; do
   echo "Validating $f..."
-  docker compose -f "$f" config --quiet || exit 1
+  env_file="$(dirname "$f")/.env"
+  if [[ -f "$env_file" ]]; then
+    docker compose --env-file "$env_file" -f "$f" config --quiet || exit 1
+  else
+    docker compose -f "$f" config --quiet || exit 1
+  fi
 done
 echo "All compose files valid"

--- a/stacks/observability/compose.yaml
+++ b/stacks/observability/compose.yaml
@@ -5,7 +5,7 @@ services:
     ports:
       - "100.100.146.119:3001:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?}
       - GF_SERVER_ROOT_URL=http://beelink:3001
       - GF_USERS_DEFAULT_THEME=dark
       - GF_USERS_HOME_PAGE=/d/container-overview/container-overview


### PR DESCRIPTION
## Plan

This is the first pragmatic hardening PR from the supply-chain review. It keeps the existing push/manual deploy UX, but reduces deploy blast radius and removes shell-evaluated dotenv handling.

## Changes

- Add least-privilege `contents: read` permissions to CI and deploy workflows.
- Replace deploy-time `toJson(secrets)` with an explicit deployment secret allowlist.
- Deploy the exact triggering workflow commit instead of resetting to whatever `origin/main` is at runtime.
- Rework `generate-env.sh` to require referenced variables, quote generated values, write 0600 env files, and avoid `eval`.
- Rework `deploy.sh` to pass stack env files to Docker Compose with `--env-file` instead of `source`.
- Validate manual stack input and make Grafana admin password fail closed instead of falling back to `admin`.

## Validation

- Pre-commit hook: ruff lint/format, yamllint, actionlint, shellcheck, pytest (237 passed)
- Targeted shell/workflow/YAML checks
- Safe env rendering test for dollar signs, quotes, and backslashes

Note: local full `mise run ci` is blocked before project checks by a mise-managed Python install issue in this environment, and Docker Compose validation cannot run here because Docker is unavailable in WSL.
